### PR TITLE
docs(proposals): audit CLI-module specs before implementation

### DIFF
--- a/docs/design/proposals/dataset-manifest-tooling.md
+++ b/docs/design/proposals/dataset-manifest-tooling.md
@@ -63,12 +63,15 @@ keep the surface stdlib-only and JSON/YAML round-trippable.
 - **Core (all tiers):** `id` (unique slug), `version`, `tier ∈ {A,B,C}`, `license`
   (SPDX id *or* explicit terms + URL), `redistributable: bool`,
   `access ∈ {open,gated}`, `files[]` each with `path` + `sha256` matching
-  `^sha256:?[0-9a-f]{64}$`, `datasheet` (path/URL or `"N/A + <reason>"`).
+  `^sha256:?[0-9a-f]{64}$`, `datasheet` (path/URL required; a `"N/A + <reason>"`
+  placeholder is accepted structurally by `validate` but flagged by `audit` as a
+  datasheet-completeness deficiency, never a clean state).
 - **Tier-conditional:** `source`/`retrieval` required for **Tier B** (and
   `retrieval.kind ∈ {http,doi,openml,git-lfs,manual}`); acquisition `instructions`
   required for **Tier C**; `sensitivity` required if PII/confidential.
-- **Cross-entry:** duplicate `id` detection; `redistributable=false` with `tier: A`
-  is a hard error (tier follows license, not convenience).
+- **Cross-entry:** duplicate `id` detection; a `tier: A` entry with
+  `redistributable: false` **or** `access: gated` is a hard error (tier follows the
+  license/access, not convenience — matches the skill's tier-consistency guardrail).
 - Errors accumulate (report all, not first-fail) and are formatted as
   `entry '<id>': <field>: <reason>`; validation returns a structured result the
   `audit` verb renders as a gap report.
@@ -152,7 +155,8 @@ honest-scholar dataset emit <id> [-o <id>.croissant.json]   # or --all
   omission (B: source/retrieval; C: instructions; PII: sensitivity), accumulating
   all violations with `entry '<id>': <field>: <reason>` messages; exits non-zero
   from the CLI on any error.
-- Duplicate `id` and `tier: A` + `redistributable: false` are hard errors.
+- Duplicate `id`, and a `tier: A` entry with `redistributable: false` or
+  `access: gated`, are hard errors.
 - `emit` produces schema.org/Dataset Croissant JSON-LD whose `distribution[]`
   carries `contentUrl` + `sha256`, validated by a round-trip
   `entry → croissant → entry` that preserves core + citation fields.
@@ -160,12 +164,13 @@ honest-scholar dataset emit <id> [-o <id>.croissant.json]   # or --all
   tier/retrieval/datasheet/sensitivity as human-TODO.
 - No dependency beyond `pyyaml` + stdlib; no network or filesystem access to data
   files during validate/emit/ingest.
-- `register` and `audit` invoke `honest-scholar dataset …`; the SKILL TODO block (~line 105)
-  is updated to point at the CLI instead of the interim manual workaround.
+- `register` and `audit` invoke `honest-scholar dataset …`; the skill's § *Tooling*
+  note already documents this CLI (the interim manual workaround stays until the
+  module lands).
 
 ## Links
 
-- Skill: `../../../skills/dataset/SKILL.md` (Manifest, Tiers; TODO ~line 105)
+- Skill: `../../../skills/dataset/SKILL.md` (Manifest, Tiers; § *Tooling*)
 - Standards digest: `../../../resources/references/dataset-management-standards.md` (§2, §3)
 - Substrate base record: `../../../resources/substrate/asset-registry.md`
 - Design: `../03-dataset.md`, `../04-substrate-and-contract.md`

--- a/docs/design/proposals/dataset-retrieval-mirror-tooling.md
+++ b/docs/design/proposals/dataset-retrieval-mirror-tooling.md
@@ -7,8 +7,8 @@
 The `dataset` skill defines a resolution chain (local cache → private mirror →
 public source → gated instructions) with SHA-256 fixity at every hop, but the
 `fetch`/`verify`/`mirror`/`audit` verbs currently have no executable backing —
-`../../../skills/dataset/SKILL.md` (§Retrieval & mirror, ~line 156) lists the pooch
-fetcher and rclone wrappers as unwritten TODOs. **Interim (until the module is
+`../../../skills/dataset/SKILL.md` (§Retrieval & mirror, § *Tooling*) documents the
+pooch fetcher and rclone wrappers as not-yet-implemented. **Interim (until the module is
 implemented):** the skill orchestrates the resolution chain manually / via direct
 tool calls — fetch, `sha256sum` fixity checks, and hand-run `rclone` — which is
 error-prone; once `honest-scholar` is installed (via
@@ -95,7 +95,8 @@ Verb → core mapping:
 - `verify` → `verify` (steps-1 fixity only, offline)
 - `mirror` → `mirror_put` across an entry's files (populate/refresh)
 - `audit`  → `verify` + `mirror_check` across every manifest entry, plus
-  schema/license/datasheet completeness (owned by the loader/validator TODO)
+  schema/license/datasheet/tier-consistency completeness (owned by the manifest
+  loader/validator)
 
 CLI shape mirrors the verbs: `honest-scholar dataset fetch <id>`,
 `honest-scholar dataset verify [<id>|--all]`, `honest-scholar dataset mirror <id>`,
@@ -142,8 +143,8 @@ gitignored; CI uses env-var remotes sourced from secrets.
   `sha256/<hash>` key and a subsequent `fetch` (cache cleared) resolves from the
   mirror at step 2.
 - `verify` recomputes on-disk SHA-256 offline and never touches the network.
-- `audit` reports fixity + mirror presence + license/datasheet completeness across
-  the whole manifest.
+- `audit` reports fixity + mirror presence + license/datasheet/tier-consistency
+  completeness across the whole manifest.
 - rclone config resolves from either an untracked `rclone.conf` or env-var
   remotes; no test or fixture commits credentials; only `rclone.conf.example` is
   tracked.
@@ -152,7 +153,7 @@ gitignored; CI uses env-var remotes sourced from secrets.
 
 ## Links
 
-- `../../../skills/dataset/SKILL.md` — the skill and the TODO block this implements
+- `../../../skills/dataset/SKILL.md` — the skill (§ *Retrieval & mirror*, § *Tooling*) this implements
 - `../../../resources/substrate/asset-registry.md` — resolution chain + two-layer fixity
 - `../../../resources/references/dataset-tooling-mirror.md` — tooling review / stack decision
 - `../03-dataset.md`, `../04-substrate-and-contract.md`

--- a/docs/design/proposals/defend-record-helper.md
+++ b/docs/design/proposals/defend-record-helper.md
@@ -4,9 +4,9 @@
 
 ## Context
 
-The `defend` skill's record step (SKILL.md step 6) currently has no tooling. The
-`TODO (supporting module)` note (`../../../skills/defend/SKILL.md`, ~line 65) marks
-it unimplemented. **Interim (until the module is implemented):** the skill
+The `defend` skill's record step (SKILL.md step 6) currently has no tooling. Its
+§ *Tooling* note (`../../../skills/defend/SKILL.md`) marks it unimplemented.
+**Interim (until the module is implemented):** the skill
 orchestrates the write by hand — editing the target artifact's frontmatter to add an
 `understanding` block, and (if a transcript is kept) dropping it beside the artifact
 as `defend-<date>.md`; once `honest-scholar` is installed (via
@@ -133,7 +133,7 @@ entry per examination, and the full transcript beside the artifact as `defend-<d
 
 ## Links
 
-- `defend` skill (record step + TODO): `../../../skills/defend/SKILL.md`
+- `defend` skill (record step + § *Tooling*): `../../../skills/defend/SKILL.md`
 - Progress skill (frontmatter schema, `understanding`): `../../../skills/progress/SKILL.md`
 - Understanding & defense digest: `../../../resources/references/understanding-and-defense.md`
 - ADR-0021 thesis gate per-gap confirmation: `../../../decisions/0021-thesis-gate-per-gap-confirmation.md`

--- a/docs/design/proposals/exploration-backlog-helper.md
+++ b/docs/design/proposals/exploration-backlog-helper.md
@@ -9,11 +9,10 @@ table, and both currently leave the mechanics unimplemented. **Interim (until th
 module is implemented):** each skill orchestrates the row edits by hand / via direct
 tool calls; once `honest-scholar` is installed (via
 [`ensure-tooling`](../../../resources/ensure-tooling.md)) the skill calls
-`honest-scholar backlog …` instead. The two skills' `TODO`s:
+`honest-scholar backlog …` instead. The two skills:
 
 - `hypothesis-exploration` (`../../../skills/hypothesis-exploration/SKILL.md`, §Verbs,
-  and the `TODO (supporting script)` at ~L67) drives rows in a paper's
-  `docs/research/<paper>/backlog.md`.
+  § *Tooling*) drives rows in a paper's `docs/research/<paper>/backlog.md`.
 - `paper-exploration` (`../../../skills/paper-exploration/SKILL.md`, §Verbs) drives
   rows in `docs/research/portfolio-backlog.md`, and on `promote` also writes the
   paper registry `docs/research/papers.md`.
@@ -96,8 +95,9 @@ that touches files outside the backlog, and only on an explicit human pick:
 
 **Interaction with `papers.md`.** The helper only ever *appends* a registry row on
 paper-level `promote`; it never edits an existing registry row and never sets a
-`decision.md` verdict. `progress` (`../../../skills/progress/SKILL.md`) reads both
-the backlog and the registry read-only and is unchanged by this proposal.
+`decision.md` verdict. `progress` (`../../../skills/progress/SKILL.md`) reads the
+registry + artifact frontmatter read-only (**not** the backlog table) and is
+unchanged by this proposal.
 
 ## Dependencies & posture
 
@@ -119,7 +119,7 @@ the backlog and the registry read-only and is unchanged by this proposal.
 1. **Storage format.** Keep the human-readable markdown table and have the helper
    escape/round-trip provenance, or back the backlog with a YAML sidecar rendered
    to markdown for reading? The table is author-friendly and already parsed by
-   `rank`/`progress`; a sidecar is safer for verbatim snippets. Leaning: keep the
+   `rank`/`list`; a sidecar is safer for verbatim snippets. Leaning: keep the
    table, escape on write.
 2. **Slug ownership.** Does `promote` mint the `<YYYY-MM-DD-slug>` / `paper-id`, or
    does the human supply it? (`paper-id` must be stable and never reused.)
@@ -137,8 +137,8 @@ the backlog and the registry read-only and is unchanged by this proposal.
 - `promote` scaffolds the correct next-stage artifact, writes its status
   frontmatter, links it from the row, and — at paper level — appends the
   `papers.md` registry row; it runs only on an explicit id argument (human pick).
-- No verb writes a verdict or `decision.md`; `progress` continues to parse both
-  backlogs unchanged.
+- No verb writes a verdict or `decision.md`; `progress` continues to read the
+  registry + artifact frontmatter unchanged (it does not read the backlog table).
 - Deps limited to `pyyaml` + stdlib.
 
 ## Links

--- a/docs/design/proposals/literature-citation-graph-client.md
+++ b/docs/design/proposals/literature-citation-graph-client.md
@@ -8,8 +8,7 @@ The `literature` skill's `scout` and `position` modes both walk one citation-gra
 substrate: **OpenAlex** (keyless backbone, `mailto=` polite pool) plus **Semantic
 Scholar** (S2AG — citation contexts, SciCite intents, `isInfluential`,
 recommendations). Today there is no client: `../../../skills/literature/SKILL.md`
-(§ *Helper script*, the `TODO — literature graph module` at ~line 170) marks it
-unimplemented. **Interim (until the module is implemented):** the skill orchestrates
+(§ *Tooling*) marks it unimplemented. **Interim (until the module is implemented):** the skill orchestrates
 the graph step manually / via direct tool calls — persisting raw JSON as the
 provenance root and editing `references.json` / `triage.yml` — which is
 unreproducible and pushes pagination, degradation, and rate-limit handling onto the
@@ -89,7 +88,8 @@ Light-dep, per SKILL.md and `../../../resources/substrate/asset-registry.md`:
   `tooling-package.md`; already pulled by `pooch`, so zero net dep). No OpenAlex/S2
   SDKs, no graph libraries (`networkx` etc.); neighbor math is stdlib
   `set`/`collections.Counter`.
-- **stdlib** for JSON, argparse, on-disk cache.
+- **stdlib** for JSON and the on-disk cache; the CLI layer is **Typer** (the
+  package's house CLI framework, per `tooling-package.md`), not argparse.
 - `mailto=` on every OpenAlex call (polite pool); `x-api-key` header on S2 iff a key
   is configured (env / `.honest-scholar/config.yml`), else omit and degrade.
 - **Rate-limits / caching:** respect OpenAlex 10 req/s + 100k/day and S2's lower
@@ -129,7 +129,7 @@ Light-dep, per SKILL.md and `../../../resources/substrate/asset-registry.md`:
 
 ## Links
 
-- Skill + the TODO: `../../../skills/literature/SKILL.md` (§ *Helper script*, ~line 170)
+- Skill: `../../../skills/literature/SKILL.md` (§ *Tooling*)
 - Scout methodology: `../../../resources/references/citation-scouting.md`
 - Position methodology: `../../../resources/references/related-works-synthesis.md`
 - Substrate + light-dep posture: `../../../resources/substrate/asset-registry.md`

--- a/docs/design/proposals/tooling-package.md
+++ b/docs/design/proposals/tooling-package.md
@@ -21,7 +21,7 @@ environment.
 
 ```
 honest-scholar/                     # subdirectory of the plugin repo
-├── pyproject.toml                 # deps + [project.scripts] honest-scholar = honest_scholar.cli:app + [project.entry-points] mcp
+├── pyproject.toml                 # deps + [project.scripts] honest-scholar / hsch = honest_scholar.cli:app + [project.optional-dependencies] mcp
 ├── honest_scholar/
 │   ├── core/                      # shared: requests-based http client, on-disk cache, config read, provenance
 │   ├── literature/graph.py        # ← proposal: literature-citation-graph-client
@@ -40,11 +40,14 @@ A Typer command tree that mirrors the skill verbs; each command emits JSON:
 
 ```
 honest-scholar literature resolve | cites | refs | enrich | neighbors
-honest-scholar dataset    register | fetch | verify | mirror | audit
+honest-scholar dataset    validate | ingest | emit | fetch | verify | mirror | audit
 honest-scholar defend     record
-honest-scholar backlog    add | rank | promote | drop        # shared by both exploration skills
+honest-scholar backlog    park | add | list | rank | promote | drop   # shared by both exploration skills
 honest-scholar --version
 ```
+
+(`register` / `export` are *skill* verbs that call these CLI commands — `register`
+runs `ingest`+`validate`, `export` is `emit`; `add` realizes the `generate` verb.)
 
 The skills invoke these via Bash (after `ensure-tooling`). Typer is consistent
 with the experiment backend's CLI choice (ADR-0013).
@@ -89,12 +92,12 @@ uvx --from "git+https://github.com/davorrunje/honest-scholar.git#subdirectory=ho
   release candidates are validated from **TestPyPI** first. The git-subdirectory
   install (`uv tool install "git+…#subdirectory=honest-scholar"`) is the fallback
   for unreleased refs or when PyPI is unreachable.
+- **Names claimed:** distribution `honest-scholar`, CLI `honest-scholar` (+ short
+  alias `hsch`); the name is reserved on both PyPI and TestPyPI (pre-release
+  `0.0.0a0` published).
 
 ## Open questions
 
-- **Names:** distribution `honest-scholar`, CLI `honest-scholar` (+ short alias
-  `hsch`) — confirm the `honest-scholar` name is claimed on PyPI/TestPyPI ahead of
-  the first publish.
 - **MCP timing:** ship the wrapper in v0.1, or wait for a concrete need?
 - **Version pin source:** how the plugin communicates its pinned `honest-scholar`
   version to `ensure-tooling`. Since the package is co-versioned in the same repo,

--- a/skills/defend/SKILL.md
+++ b/skills/defend/SKILL.md
@@ -67,11 +67,11 @@ the author elects to stop and record the gap.
 > (`honest_scholar/defend/record.py`) — ensure via
 > [`ensure-tooling`](../../resources/ensure-tooling.md); it appends the
 > `understanding` frontmatter block and persists the transcript (issue #4).
-> **Interim, until it lands:** edit the artifact's frontmatter directly — set
-> `understanding: {status: ok|gaps, unresolved: [...]}` to match the schema
-> `progress` reads (`../progress/SKILL.md`), and bump the artifact's top-level
-> `last-updated` (do **not** nest a date inside `understanding`). If a transcript
-> is kept, write it beside the artifact as `defend-<date>.md`.
+> **Interim, until it lands:** edit the artifact's frontmatter directly — under the
+> `status:` block, set `understanding: {status: ok|gaps, unresolved: [...]}` to match
+> the schema `progress` reads (`../progress/SKILL.md`), and bump `status.last-updated`
+> (do **not** nest a date inside `understanding`). If a transcript is kept, write it
+> beside the artifact as `defend-<date>.md`.
 
 ## Example (a methodology probe)
 


### PR DESCRIPTION
Audit of the five CLI-module proposals + the umbrella (`tooling-package.md`) ahead of implementation, reconciling them against the decisions settled during the skill review. **No new design decisions** — every change aligns a spec to a choice already made.

## Cross-cutting

- **Umbrella CLI table was stale.** Now `dataset validate|ingest|emit|fetch|verify|mirror|audit` and `backlog park|add|list|rank|promote|drop` (with a note that `register`/`export`/`generate` are *skill* verbs that call these CLI commands). Fixed the `pyproject` comment (`hsch` alias + `[project.optional-dependencies] mcp`).
- **Stale SKILL references in every module spec.** Each pointed at a `TODO (supporting script/module)` / `§ Helper script` block at a hard-coded line number; the skill review converted all of those into `## Tooling` notes. Repointed and dropped the drift-prone line numbers.
- **`progress`-reads-backlog overclaim** (exploration-backlog): `progress` reads the registry + artifact frontmatter, not the backlog table.

## Per-spec

- **tooling-package:** the "confirm the name is claimed on PyPI/TestPyPI" open question is **resolved** (`0.0.0a0` published to both) → moved to Decided.
- **literature:** CLI layer is **Typer**, not `argparse`.
- **defend (SKILL):** interim note now nests `understanding` + `last-updated` under the `status:` block — matching the canonical template schema and the `defend-record` proposal.
- **dataset-manifest:** datasheet `"N/A + reason"` documented as an **audit-flagged** deficiency; the `tier: A` hard error now also covers `access: gated` (matches the skill's tier-consistency guardrail). retrieval spec's `audit` reports tier-consistency completeness too.

## Verification

- No residual stale refs / CLI mismatches (swept).
- `codespell` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
