### PR TITLE
feat(cli): align command tree to the audited specs

### DIFF
--- a/honest-scholar/honest_scholar/cli.py
+++ b/honest-scholar/honest_scholar/cli.py
@@ -153,7 +153,7 @@ def neighbors(identifier: str) -> None:
     _not_implemented(1)
 
 
-# --- dataset (honest-scholar#2 / #3) ----------------------------------------------
+# --- dataset (honest-scholar#2 manifest / #3 retrieval) ---------------------------
 dataset = typer.Typer(
     help="Dataset manifest, retrieval and mirroring.", no_args_is_help=True
 )
@@ -161,48 +161,74 @@ app.add_typer(dataset, name="dataset")
 
 
 @dataset.command()
-def register(name: str) -> None:
-    """Register a dataset in the thin manifest.
+def validate(
+    manifest: Annotated[
+        str, typer.Argument(help="Path to the manifest to validate.")
+    ] = "datasets.yml",
+) -> None:
+    """Validate a ``datasets.yml`` manifest (the register/audit gate).
 
-    :param name: Dataset name to register.
+    :param manifest: Path to the manifest to validate.
     """
     _not_implemented(2)
 
 
 @dataset.command()
-def fetch(name: str) -> None:
-    """Fetch a registered dataset via pooch.
+def ingest(croissant: str) -> None:
+    """Ingest a published Croissant JSON-LD file to bootstrap a manifest entry.
 
-    :param name: Dataset name to fetch.
-    """
-    _not_implemented(3)
-
-
-@dataset.command()
-def verify(name: str) -> None:
-    """Verify a fetched dataset against its manifest checksums.
-
-    :param name: Dataset name to verify.
-    """
-    _not_implemented(3)
-
-
-@dataset.command()
-def mirror(name: str) -> None:
-    """Mirror a dataset to private storage via rclone.
-
-    :param name: Dataset name to mirror.
-    """
-    _not_implemented(3)
-
-
-@dataset.command()
-def audit(name: str) -> None:
-    """Audit a dataset's provenance and mirror state.
-
-    :param name: Dataset name to audit.
+    :param croissant: Path to the Croissant JSON-LD file.
     """
     _not_implemented(2)
+
+
+@dataset.command()
+def emit(identifier: str) -> None:
+    """Emit a Croissant JSON-LD file for a manifest entry.
+
+    :param identifier: The dataset id to emit (or ``--all`` in a later revision).
+    """
+    _not_implemented(2)
+
+
+@dataset.command()
+def fetch(identifier: str) -> None:
+    """Fetch a registered dataset through the resolution chain (pooch/rclone).
+
+    :param identifier: The dataset id to fetch.
+    """
+    _not_implemented(3)
+
+
+@dataset.command()
+def verify(identifier: str) -> None:
+    """Verify on-disk bytes against the manifest SHA-256 (offline).
+
+    :param identifier: The dataset id to verify.
+    """
+    _not_implemented(3)
+
+
+@dataset.command()
+def mirror(identifier: str) -> None:
+    """Populate/refresh the private rclone mirror for a dataset.
+
+    :param identifier: The dataset id to mirror.
+    """
+    _not_implemented(3)
+
+
+@dataset.command()
+def audit(
+    identifier: Annotated[
+        str, typer.Argument(help="Optional dataset id; whole manifest if omitted.")
+    ] = "",
+) -> None:
+    """Audit fixity, mirror presence and manifest completeness.
+
+    :param identifier: Optional dataset id; audits the whole manifest if omitted.
+    """
+    _not_implemented(3)
 
 
 # --- defend (honest-scholar#4) ----------------------------------------------------
@@ -222,6 +248,15 @@ def record(claim: str) -> None:
 # --- backlog (honest-scholar#5) ---------------------------------------------------
 backlog = typer.Typer(help="Exploration backlog management.", no_args_is_help=True)
 app.add_typer(backlog, name="backlog")
+
+
+@backlog.command()
+def park(item: str) -> None:
+    """Park a raw one-line idea as a backlog row before it is lost.
+
+    :param item: The one-line idea (its origin/provenance is required).
+    """
+    _not_implemented(5)
 
 
 @backlog.command()

--- a/honest-scholar/tests/test_cli.py
+++ b/honest-scholar/tests/test_cli.py
@@ -40,8 +40,13 @@ def test_stub_command_exits_2() -> None:
 
 def test_each_group_has_a_stub() -> None:
     cases = [
+        (["literature", "resolve", "10.1000/xyz"], "honest-scholar#1"),
+        (["dataset", "validate", "datasets.yml"], "honest-scholar#2"),
+        (["dataset", "emit", "mnist"], "honest-scholar#2"),
         (["dataset", "fetch", "mnist"], "honest-scholar#3"),
+        (["dataset", "audit"], "honest-scholar#3"),
         (["defend", "record", "claim"], "honest-scholar#4"),
+        (["backlog", "park", "idea"], "honest-scholar#5"),
         (["backlog", "add", "idea"], "honest-scholar#5"),
     ]
     for args, issue in cases:
@@ -49,3 +54,17 @@ def test_each_group_has_a_stub() -> None:
         assert result.exit_code == 2
         assert "not yet implemented" in result.stdout
         assert issue in result.stdout
+
+
+def test_dataset_command_tree_matches_audited_specs() -> None:
+    result = runner.invoke(app, ["dataset", "--help"])
+    assert result.exit_code == 0
+    for command in ("validate", "ingest", "emit", "fetch", "verify", "mirror", "audit"):
+        assert command in result.stdout
+
+
+def test_backlog_command_tree_matches_audited_specs() -> None:
+    result = runner.invoke(app, ["backlog", "--help"])
+    assert result.exit_code == 0
+    for command in ("park", "add", "list", "rank", "promote", "drop"):
+        assert command in result.stdout


### PR DESCRIPTION
Brings the Typer command tree in line with the authoritative CLI list from the spec audit (PR #8). The commands remain typed stubs (exit 2 + tracking-issue pointer) — this only corrects the **command surface** so `honest-scholar <group> --help` matches the specs before the modules are implemented.

## Changes

**`dataset` group**
- Remove `register` — it's a *skill* verb that calls the CLI, not a CLI command itself (spec audit).
- Add `validate | ingest | emit` (honest-scholar#2, manifest tooling).
- Keep `fetch | verify | mirror` (honest-scholar#3, retrieval); retag `audit` → #3 (retrieval orchestrates it, folding in the validator).
- `validate` / `audit` take **optional positional** args via `typer.Argument` (a bare `= default` becomes a Typer `--option`, not a positional).

**`backlog` group**
- Add the missing `park` command (honest-scholar#5).

Final surface: `dataset validate|ingest|emit|fetch|verify|mirror|audit`, `backlog park|add|list|rank|promote|drop`.

## Tests
- New assertions that the `dataset` and `backlog` command trees match the audited sets.
- Extended the stub-issue-number checks to cover the new commands.
- `ruff`, `mypy --strict`, and `pytest` (11) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
