### PR TITLE
feat(dataset): manifest tooling — load/validate + Croissant interop (#2)

### DIFF
--- a/honest-scholar/honest_scholar/cli.py
+++ b/honest-scholar/honest_scholar/cli.py
@@ -7,14 +7,18 @@ issues (see ADR-0024 and ``docs/design/proposals/tooling-package.md``).
 
 from __future__ import annotations
 
+import dataclasses
+import json
 import platform
 import shutil
 import subprocess  # nosec B404 - used only to read `--version` of trusted tools
+from pathlib import Path
 from typing import Annotated
 
 import typer
 
 from honest_scholar import __version__
+from honest_scholar.dataset import manifest as manifest_mod
 
 app = typer.Typer(
     name="honest-scholar",
@@ -168,27 +172,84 @@ def validate(
 ) -> None:
     """Validate a ``datasets.yml`` manifest (the register/audit gate).
 
+    Prints a JSON report ``{ok, errors, warnings}`` and exits non-zero on any
+    hard error.
+
     :param manifest: Path to the manifest to validate.
+    :raises typer.Exit: Code 1 on a malformed manifest or any validation error.
     """
-    _not_implemented(2)
+    try:
+        parsed = manifest_mod.load(manifest)
+    except manifest_mod.ManifestError as exc:
+        typer.echo(json.dumps({"ok": False, "errors": [str(exc)], "warnings": []}))
+        raise typer.Exit(code=1) from exc
+    report = manifest_mod.validate(parsed)
+    typer.echo(
+        json.dumps(
+            {"ok": report.ok, "errors": report.errors, "warnings": report.warnings},
+            indent=2,
+        )
+    )
+    raise typer.Exit(code=0 if report.ok else 1)
 
 
 @dataset.command()
 def ingest(croissant: str) -> None:
-    """Ingest a published Croissant JSON-LD file to bootstrap a manifest entry.
+    """Ingest a published Croissant JSON-LD file to bootstrap a draft entry.
+
+    Prints the draft registry entry as JSON, with the human-owned fields it could
+    not fill listed under ``_needs_human`` (the caller confirms them on register).
 
     :param croissant: Path to the Croissant JSON-LD file.
+    :raises typer.Exit: Code 1 if the file is unreadable or has no ``name``.
     """
-    _not_implemented(2)
+    try:
+        doc = json.loads(Path(croissant).read_text(encoding="utf-8"))
+        entry = manifest_mod.entry_from_croissant(doc)
+    except (OSError, json.JSONDecodeError, manifest_mod.ManifestError) as exc:
+        typer.echo(f"ingest failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    draft = dataclasses.asdict(entry)
+    draft["_needs_human"] = [
+        name
+        for name in ("license", "tier", "access", "datasheet", "sensitivity")
+        if draft.get(name) is None
+    ]
+    typer.echo(json.dumps(draft, indent=2))
+    raise typer.Exit(code=0)
 
 
 @dataset.command()
-def emit(identifier: str) -> None:
-    """Emit a Croissant JSON-LD file for a manifest entry.
+def emit(
+    identifier: str,
+    manifest: Annotated[
+        str, typer.Option(help="Path to the manifest to read.")
+    ] = "datasets.yml",
+) -> None:
+    """Emit a Croissant JSON-LD document for a manifest entry.
 
-    :param identifier: The dataset id to emit (or ``--all`` in a later revision).
+    :param identifier: The dataset id to emit (``--all`` for the whole registry).
+    :param manifest: Path to the manifest to read.
+    :raises typer.Exit: Code 1 if the manifest is malformed or the id is unknown.
     """
-    _not_implemented(2)
+    try:
+        parsed = manifest_mod.load(manifest)
+    except manifest_mod.ManifestError as exc:
+        typer.echo(f"emit failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    if identifier == "--all":
+        typer.echo(
+            json.dumps(
+                [manifest_mod.croissant_for(e) for e in parsed.datasets], indent=2
+            )
+        )
+        raise typer.Exit(code=0)
+    for entry in parsed.datasets:
+        if entry.id == identifier:
+            typer.echo(json.dumps(manifest_mod.croissant_for(entry), indent=2))
+            raise typer.Exit(code=0)
+    typer.echo(f"emit failed: no entry with id {identifier!r}", err=True)
+    raise typer.Exit(code=1)
 
 
 @dataset.command()

--- a/honest-scholar/honest_scholar/dataset/manifest.py
+++ b/honest-scholar/honest_scholar/dataset/manifest.py
@@ -1,29 +1,534 @@
-"""Thin dataset-manifest tooling (honest-scholar#2)."""
+"""``datasets.yml`` manifest tooling — loader, validator and Croissant interop.
+
+Implements the metadata half of the ``dataset`` skill (honest-scholar#2): parse
+``datasets.yml`` into typed records, validate the base asset record plus
+tier-conditional required fields, and round-trip
+[Croissant](https://mlcommons.org/croissant/) / schema.org ``Dataset`` JSON-LD.
+
+This module is **metadata only** — it never opens data files, computes SHA-256,
+touches the network, or runs ``rclone``. Byte handling lives in
+:mod:`honest_scholar.dataset.retrieval` (honest-scholar#3). Design:
+``docs/design/proposals/dataset-manifest-tooling.md``.
+"""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
 
-if TYPE_CHECKING:
-    from pathlib import Path
+import yaml
+
+#: A file checksum value: 64 lowercase hex chars, optionally ``sha256:``-prefixed.
+SHA256_RE = re.compile(r"^(sha256:)?[0-9a-f]{64}$")
+
+TIERS = frozenset({"A", "B", "C"})
+ACCESS = frozenset({"open", "gated"})
+RETRIEVAL_KINDS = frozenset({"http", "doi", "openml", "git-lfs", "manual"})
+SENSITIVITY_VALUES = frozenset({"none", "pii", "confidential"})
 
 
-def register(name: str, source: str) -> dict[str, Any]:
-    """Register a dataset in the thin manifest.
+class ManifestError(ValueError):
+    """Raised when a ``datasets.yml`` file cannot be structurally decoded."""
 
-    :param name: Human-readable dataset name.
-    :param source: The dataset source (URL, DOI, or git/LFS locator).
-    :returns: The manifest entry created for the dataset.
-    :raises NotImplementedError: Always — pending implementation (honest-scholar#2).
+
+@dataclass
+class FileRef:
+    """One file belonging to a dataset entry.
+
+    :param path: Repo- or cache-relative path to the file.
+    :param sha256: Authoritative checksum (bare 64-hex or ``sha256:``-prefixed).
+    :param size: Optional byte size.
     """
-    raise NotImplementedError("dataset manifest tooling — see honest-scholar#2")
+
+    path: str
+    sha256: str
+    size: int | None = None
 
 
-def audit(manifest_path: str | Path) -> dict[str, Any]:
-    """Audit a dataset manifest's provenance and mirror state.
+@dataclass
+class Retrieval:
+    """A Tier-B retrieval recipe.
 
-    :param manifest_path: Path to the manifest file to audit.
-    :returns: An audit report mapping.
-    :raises NotImplementedError: Always — pending implementation (honest-scholar#2).
+    :param kind: One of :data:`RETRIEVAL_KINDS`.
+    :param url: The source locator (``http(s)``/``ftp``/``sftp``/``doi:`` …).
     """
-    raise NotImplementedError("dataset manifest tooling — see honest-scholar#2")
+
+    kind: str
+    url: str | None = None
+
+
+@dataclass
+class Citation:
+    """The DataCite six-mandatory tuple for a citable dataset.
+
+    All fields are optional at the record level; :func:`validate` warns (never
+    errors) when the tuple is incomplete, since a citable record may not yet exist.
+
+    :param identifier: DOI / persistent identifier.
+    :param creator: Dataset creator(s).
+    :param title: Dataset title.
+    :param publisher: Publishing entity.
+    :param publication_year: Year of publication.
+    :param resource_type: DataCite resource type (``Dataset``).
+    """
+
+    identifier: str | None = None
+    creator: str | None = None
+    title: str | None = None
+    publisher: str | None = None
+    publication_year: int | None = None
+    resource_type: str | None = None
+
+    def is_complete(self) -> bool:
+        """Return whether all six DataCite-mandatory fields are populated."""
+        return all(
+            value is not None
+            for value in (
+                self.identifier,
+                self.creator,
+                self.title,
+                self.publisher,
+                self.publication_year,
+                self.resource_type,
+            )
+        )
+
+
+@dataclass
+class DatasetEntry:
+    """A single dataset registry entry (the superset source of truth).
+
+    :param id: Stable slug, unique within the registry.
+    :param version: Dataset version string.
+    :param tier: Storage tier (``A`` / ``B`` / ``C``).
+    :param license: SPDX id or explicit terms + URL.
+    :param redistributable: Whether the license permits redistribution.
+    :param access: ``open`` or ``gated``.
+    :param files: The dataset's files.
+    :param datasheet: Path/URL to the Gebru datasheet, or ``"N/A + <reason>"``.
+    :param source: Tier-B canonical source URL.
+    :param retrieval: Tier-B retrieval recipe.
+    :param instructions: Tier-C acquisition instructions.
+    :param sensitivity: ``none`` / ``pii`` / ``confidential``.
+    :param pid: Persistent identifier (e.g. ``doi:10.xxxx/…``).
+    :param title: Human-readable title (defaults to `id` on emit).
+    :param description: Free-text description.
+    :param citation: DataCite citation tuple.
+    """
+
+    id: str
+    version: str | None = None
+    tier: str | None = None
+    license: str | None = None
+    redistributable: bool | None = None
+    access: str | None = None
+    files: list[FileRef] = field(default_factory=list)
+    datasheet: str | None = None
+    source: str | None = None
+    retrieval: Retrieval | None = None
+    instructions: str | None = None
+    sensitivity: str | None = None
+    pid: str | None = None
+    title: str | None = None
+    description: str | None = None
+    citation: Citation | None = None
+
+
+@dataclass
+class Mirror:
+    """The private-mirror binding block.
+
+    :param rclone_remote: Logical rclone remote name (credentials live elsewhere).
+    :param base_path: Base path under the remote.
+    :param hash: rclone transport hash (never authoritative).
+    """
+
+    rclone_remote: str | None = None
+    base_path: str | None = None
+    hash: str | None = None
+
+
+@dataclass
+class Manifest:
+    """A parsed ``datasets.yml`` registry.
+
+    :param mirror: Optional mirror binding.
+    :param datasets: The dataset entries.
+    """
+
+    mirror: Mirror | None = None
+    datasets: list[DatasetEntry] = field(default_factory=list)
+
+
+@dataclass
+class ValidationReport:
+    """The outcome of :func:`validate`.
+
+    :param errors: Hard violations, formatted ``entry '<id>': <field>: <reason>``.
+    :param warnings: Soft issues (incomplete citation, ``N/A`` datasheet).
+    """
+
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """Return whether the manifest has no hard errors."""
+        return not self.errors
+
+
+# --- loading ----------------------------------------------------------------
+
+
+def _opt_str(value: Any) -> str | None:
+    """Coerce a scalar to ``str``, preserving ``None``."""
+    return None if value is None else str(value)
+
+
+def _opt_bool(value: Any) -> bool | None:
+    """Return `value` if it is a real ``bool``, else ``None``.
+
+    A non-bool (e.g. the string ``"true"``) is left as ``None`` so
+    :func:`validate` can flag the type error rather than silently coercing.
+    """
+    return value if isinstance(value, bool) else None
+
+
+def _decode_file_ref(raw: Any, where: str) -> FileRef:
+    """Decode one ``files[]`` element, raising :class:`ManifestError` on shape."""
+    if not isinstance(raw, dict):
+        raise ManifestError(f"{where}: each file must be a mapping")
+    try:
+        size = raw.get("size")
+        return FileRef(
+            path=str(raw["path"]),
+            sha256=str(raw["sha256"]),
+            size=int(size) if size is not None else None,
+        )
+    except KeyError as exc:
+        raise ManifestError(f"{where}: file missing required key {exc}") from exc
+
+
+def _decode_retrieval(raw: Any, where: str) -> Retrieval:
+    """Decode a ``retrieval`` block."""
+    if not isinstance(raw, dict):
+        raise ManifestError(f"{where}: 'retrieval' must be a mapping")
+    return Retrieval(
+        kind=str(raw.get("kind", "")),
+        url=_opt_str(raw.get("url")),
+    )
+
+
+def _decode_citation(raw: Any, where: str) -> Citation:
+    """Decode a ``citation`` block (DataCite tuple)."""
+    if not isinstance(raw, dict):
+        raise ManifestError(f"{where}: 'citation' must be a mapping")
+    year = raw.get("publicationYear", raw.get("publication_year"))
+    return Citation(
+        identifier=_opt_str(raw.get("identifier")),
+        creator=_opt_str(raw.get("creator")),
+        title=_opt_str(raw.get("title")),
+        publisher=_opt_str(raw.get("publisher")),
+        publication_year=int(year) if year is not None else None,
+        resource_type=_opt_str(raw.get("resourceType", raw.get("resource_type"))),
+    )
+
+
+def _decode_entry(raw: Any, index: int) -> DatasetEntry:
+    """Decode one ``datasets[]`` element into a :class:`DatasetEntry`."""
+    where = f"datasets[{index}]"
+    if not isinstance(raw, dict):
+        raise ManifestError(f"{where}: entry must be a mapping")
+    if "id" not in raw:
+        raise ManifestError(f"{where}: entry missing required key 'id'")
+    entry_id = str(raw["id"])
+    where = f"entry '{entry_id}'"
+
+    retrieval = None
+    if raw.get("retrieval") is not None:
+        retrieval = _decode_retrieval(raw["retrieval"], where)
+    citation = None
+    if raw.get("citation") is not None:
+        citation = _decode_citation(raw["citation"], where)
+
+    return DatasetEntry(
+        id=entry_id,
+        version=_opt_str(raw.get("version")),
+        tier=_opt_str(raw.get("tier")),
+        license=_opt_str(raw.get("license")),
+        redistributable=_opt_bool(raw.get("redistributable")),
+        access=_opt_str(raw.get("access")),
+        files=[
+            _decode_file_ref(f, f"{where}: files[{i}]")
+            for i, f in enumerate(raw.get("files") or [])
+        ],
+        datasheet=_opt_str(raw.get("datasheet")),
+        source=_opt_str(raw.get("source")),
+        retrieval=retrieval,
+        instructions=_opt_str(raw.get("instructions")),
+        sensitivity=_opt_str(raw.get("sensitivity")),
+        pid=_opt_str(raw.get("pid")),
+        title=_opt_str(raw.get("title")),
+        description=_opt_str(raw.get("description")),
+        citation=citation,
+    )
+
+
+def load(path: str | Path = "datasets.yml") -> Manifest:
+    """Parse ``datasets.yml`` into a :class:`Manifest`.
+
+    :param path: Path to the manifest file.
+    :returns: The decoded manifest.
+    :raises ManifestError: If the file is missing, is not a YAML mapping, or an
+        entry is structurally malformed. The message names the offending entry.
+    """
+    manifest_path = Path(path)
+    if not manifest_path.is_file():
+        raise ManifestError(f"{manifest_path}: no such file")
+    try:
+        data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ManifestError(f"{manifest_path}: invalid YAML: {exc}") from exc
+    if data is None:
+        return Manifest()
+    if not isinstance(data, dict):
+        raise ManifestError(f"{manifest_path}: expected a mapping at the top level")
+
+    mirror = None
+    if (mraw := data.get("mirror")) is not None:
+        if not isinstance(mraw, dict):
+            raise ManifestError(f"{manifest_path}: 'mirror' must be a mapping")
+        mirror = Mirror(
+            rclone_remote=_opt_str(mraw.get("rclone_remote")),
+            base_path=_opt_str(mraw.get("base_path")),
+            hash=_opt_str(mraw.get("hash")),
+        )
+
+    datasets_raw = data.get("datasets") or []
+    if not isinstance(datasets_raw, list):
+        raise ManifestError(f"{manifest_path}: 'datasets' must be a list")
+    return Manifest(
+        mirror=mirror,
+        datasets=[_decode_entry(entry, i) for i, entry in enumerate(datasets_raw)],
+    )
+
+
+# --- validation -------------------------------------------------------------
+
+
+def _err(report: ValidationReport, entry_id: str, fieldname: str, reason: str) -> None:
+    """Append a hard error, formatted ``entry '<id>': <field>: <reason>``."""
+    report.errors.append(f"entry '{entry_id}': {fieldname}: {reason}")
+
+
+def _warn(report: ValidationReport, entry_id: str, fieldname: str, reason: str) -> None:
+    """Append a soft warning, formatted ``entry '<id>': <field>: <reason>``."""
+    report.warnings.append(f"entry '{entry_id}': {fieldname}: {reason}")
+
+
+def _validate_required(entry: DatasetEntry, report: ValidationReport) -> None:
+    """Validate the always-required core fields."""
+    eid = entry.id
+    if not entry.version:
+        _err(report, eid, "version", "required")
+    if entry.tier not in TIERS:
+        _err(report, eid, "tier", f"must be one of {sorted(TIERS)}, got {entry.tier!r}")
+    if not entry.license:
+        _err(report, eid, "license", "required (SPDX id or explicit terms + URL)")
+    if entry.redistributable is None:
+        _err(report, eid, "redistributable", "required boolean")
+    if entry.access not in ACCESS:
+        _err(
+            report,
+            eid,
+            "access",
+            f"must be one of {sorted(ACCESS)}, got {entry.access!r}",
+        )
+
+
+def _validate_files(entry: DatasetEntry, report: ValidationReport) -> None:
+    """Validate ``files[]`` presence, paths, and checksum shape."""
+    if not entry.files:
+        _err(report, entry.id, "files", "at least one file is required")
+    for i, ref in enumerate(entry.files):
+        if not ref.path:
+            _err(report, entry.id, f"files[{i}].path", "required")
+        if not SHA256_RE.match(ref.sha256):
+            _err(
+                report,
+                entry.id,
+                f"files[{i}].sha256",
+                "must be 64 hex (optional 'sha256:')",
+            )
+
+
+def _validate_datasheet(entry: DatasetEntry, report: ValidationReport) -> None:
+    """Require a datasheet; flag an ``N/A`` placeholder as a completeness gap."""
+    if not entry.datasheet:
+        _err(report, entry.id, "datasheet", "required (path/URL, or 'N/A + <reason>')")
+    elif entry.datasheet.strip().upper().startswith("N/A"):
+        _warn(report, entry.id, "datasheet", "placeholder 'N/A' — a completeness gap")
+
+
+def _validate_conditional(entry: DatasetEntry, report: ValidationReport) -> None:
+    """Validate tier-conditional required fields and enum values."""
+    eid = entry.id
+    if entry.tier == "B" and not (entry.source or entry.retrieval):
+        _err(report, eid, "source/retrieval", "required for Tier B")
+    if entry.retrieval is not None and entry.retrieval.kind not in RETRIEVAL_KINDS:
+        _err(report, eid, "retrieval.kind", f"must be one of {sorted(RETRIEVAL_KINDS)}")
+    if entry.tier == "C" and not entry.instructions:
+        _err(report, eid, "instructions", "required for Tier C (gated/manual)")
+    if entry.sensitivity is not None and entry.sensitivity not in SENSITIVITY_VALUES:
+        _err(report, eid, "sensitivity", f"must be one of {sorted(SENSITIVITY_VALUES)}")
+
+
+def _validate_consistency(entry: DatasetEntry, report: ValidationReport) -> None:
+    """Enforce tier↔(access, redistributable) consistency; warn on thin citations."""
+    eid = entry.id
+    if entry.tier == "A" and entry.redistributable is False:
+        _err(report, eid, "tier", "tier A requires redistributable: true")
+    if entry.tier == "A" and entry.access == "gated":
+        _err(report, eid, "tier", "tier A cannot be access: gated")
+    if entry.citation is not None and not entry.citation.is_complete():
+        _warn(report, eid, "citation", "incomplete DataCite tuple — not DOI-mintable")
+
+
+def _validate_entry(entry: DatasetEntry, report: ValidationReport) -> None:
+    """Append every rule violation for one entry to `report`."""
+    _validate_required(entry, report)
+    _validate_files(entry, report)
+    _validate_datasheet(entry, report)
+    _validate_conditional(entry, report)
+    _validate_consistency(entry, report)
+
+
+def validate(manifest: Manifest) -> ValidationReport:
+    """Validate a manifest against the schema and tier rules.
+
+    Accumulates *all* violations (never first-fail). Cross-entry checks (duplicate
+    ids) run once. Datasheet ``N/A`` placeholders and incomplete DataCite tuples
+    are warnings, not errors.
+
+    :param manifest: The manifest to validate.
+    :returns: A report; :attr:`ValidationReport.ok` is false if any hard error.
+    """
+    report = ValidationReport()
+    seen: dict[str, int] = {}
+    for entry in manifest.datasets:
+        seen[entry.id] = seen.get(entry.id, 0) + 1
+        _validate_entry(entry, report)
+    for entry_id, count in seen.items():
+        if count > 1:
+            report.errors.append(f"entry '{entry_id}': id: duplicated {count} times")
+    return report
+
+
+# --- Croissant interop ------------------------------------------------------
+
+_CROISSANT_CONTEXT = {
+    "@vocab": "https://schema.org/",
+    "sha256": "https://schema.org/sha256",
+    "cr": "http://mlcommons.org/croissant/",
+    "citeAs": "cr:citeAs",
+}
+
+
+def _citation_text(citation: Citation) -> str:
+    """Render a DataCite tuple as a one-line ``citeAs`` string."""
+    parts = [
+        part
+        for part in (
+            citation.creator,
+            f"({citation.publication_year})" if citation.publication_year else None,
+            citation.title,
+            citation.publisher,
+            citation.identifier,
+        )
+        if part
+    ]
+    return ". ".join(str(part) for part in parts)
+
+
+def croissant_for(entry: DatasetEntry) -> dict[str, Any]:
+    """Emit a schema.org ``Dataset`` Croissant JSON-LD document for one entry.
+
+    Fields with no registry value are omitted rather than emitted empty. The
+    registry stays the superset source of truth; this is an export view.
+
+    :param entry: The dataset entry to render.
+    :returns: A JSON-serializable Croissant document.
+    """
+    doc: dict[str, Any] = {
+        "@context": _CROISSANT_CONTEXT,
+        "@type": "Dataset",
+        "name": entry.title or entry.id,
+    }
+    if entry.description:
+        doc["description"] = entry.description
+    if entry.version:
+        doc["version"] = entry.version
+    if entry.license:
+        doc["license"] = entry.license
+    if entry.pid:
+        doc["identifier"] = entry.pid
+    if entry.citation is not None:
+        doc["citeAs"] = _citation_text(entry.citation)
+
+    distribution: list[dict[str, Any]] = []
+    for ref in entry.files:
+        obj: dict[str, Any] = {
+            "@type": "cr:FileObject",
+            "contentUrl": ref.path,
+            "sha256": ref.sha256,
+        }
+        if ref.size is not None:
+            obj["contentSize"] = ref.size
+        distribution.append(obj)
+    if distribution:
+        doc["distribution"] = distribution
+    return doc
+
+
+def entry_from_croissant(json_ld: dict[str, Any]) -> DatasetEntry:
+    """Ingest a published Croissant document into a *draft* registry entry.
+
+    Fills what the Croissant carries and leaves human-owned fields (``tier``,
+    ``retrieval``, ``datasheet``, ``sensitivity``) unset — the caller flags them
+    as TODO on register. Never guesses a tier or a license grant.
+
+    :param json_ld: A parsed Croissant / schema.org ``Dataset`` document.
+    :returns: A partial :class:`DatasetEntry` draft.
+    :raises ManifestError: If the document has no usable ``name``.
+    """
+    name = json_ld.get("name")
+    if not name:
+        raise ManifestError("croissant: document has no 'name' to derive an id from")
+
+    files: list[FileRef] = []
+    for obj in json_ld.get("distribution") or []:
+        if not isinstance(obj, dict):
+            continue
+        url = obj.get("contentUrl")
+        sha = obj.get("sha256")
+        if url and sha:
+            size = obj.get("contentSize")
+            files.append(
+                FileRef(
+                    path=str(url),
+                    sha256=str(sha),
+                    size=size if isinstance(size, int) else None,
+                )
+            )
+
+    return DatasetEntry(
+        id=str(name),
+        version=_opt_str(json_ld.get("version")),
+        license=_opt_str(json_ld.get("license")),
+        description=_opt_str(json_ld.get("description")),
+        pid=_opt_str(json_ld.get("identifier")),
+        files=files,
+        citation=Citation(title=str(name)) if json_ld.get("citeAs") else None,
+    )

--- a/honest-scholar/tests/test_cli.py
+++ b/honest-scholar/tests/test_cli.py
@@ -41,8 +41,6 @@ def test_stub_command_exits_2() -> None:
 def test_each_group_has_a_stub() -> None:
     cases = [
         (["literature", "resolve", "10.1000/xyz"], "honest-scholar#1"),
-        (["dataset", "validate", "datasets.yml"], "honest-scholar#2"),
-        (["dataset", "emit", "mnist"], "honest-scholar#2"),
         (["dataset", "fetch", "mnist"], "honest-scholar#3"),
         (["dataset", "audit"], "honest-scholar#3"),
         (["defend", "record", "claim"], "honest-scholar#4"),

--- a/honest-scholar/tests/test_manifest.py
+++ b/honest-scholar/tests/test_manifest.py
@@ -1,0 +1,233 @@
+"""Tests for the ``datasets.yml`` manifest tooling (honest-scholar#2)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from honest_scholar.cli import app
+from honest_scholar.dataset import manifest as m
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+_HEX = "a" * 64
+
+_VALID_YAML = f"""
+mirror:
+  rclone_remote: mystore
+  base_path: proj/datasets
+  hash: md5
+datasets:
+  - id: example-tabular
+    version: "1.0.0"
+    tier: B
+    license: CC-BY-4.0
+    redistributable: true
+    access: open
+    pid: doi:10.1234/abcd
+    files:
+      - path: data/example.parquet
+        sha256: {_HEX}
+        size: 12345
+    source: https://example.org/example.parquet
+    retrieval:
+      kind: http
+      url: https://example.org/example.parquet
+    datasheet: datasheets/example.md
+    citation:
+      creator: A. Author
+      title: Example
+      publisher: Example Org
+      publicationYear: 2024
+      resourceType: Dataset
+      identifier: doi:10.1234/abcd
+"""
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "datasets.yml"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_load_valid_manifest(tmp_path: Path) -> None:
+    manifest = m.load(_write(tmp_path, _VALID_YAML))
+    assert manifest.mirror is not None
+    assert manifest.mirror.rclone_remote == "mystore"
+    assert len(manifest.datasets) == 1
+    entry = manifest.datasets[0]
+    assert entry.id == "example-tabular"
+    assert entry.redistributable is True
+    assert entry.files[0].sha256 == _HEX
+    assert entry.retrieval is not None
+    assert entry.retrieval.kind == "http"
+
+
+def test_load_missing_file_raises() -> None:
+    with pytest.raises(m.ManifestError, match="no such file"):
+        m.load("does-not-exist.yml")
+
+
+def test_load_malformed_names_the_entry(tmp_path: Path) -> None:
+    bad = "datasets:\n  - version: '1'\n"  # entry has no id
+    with pytest.raises(m.ManifestError, match=r"datasets\[0\].*'id'"):
+        m.load(_write(tmp_path, bad))
+
+
+def test_validate_clean_manifest_ok(tmp_path: Path) -> None:
+    report = m.validate(m.load(_write(tmp_path, _VALID_YAML)))
+    assert report.ok
+    assert report.errors == []
+
+
+def test_validate_accumulates_all_errors() -> None:
+    entry = m.DatasetEntry(id="bad", files=[m.FileRef(path="x", sha256="nothex")])
+    report = m.validate(m.Manifest(datasets=[entry]))
+    assert not report.ok
+    joined = "\n".join(report.errors)
+    for fieldname in ("version", "tier", "license", "redistributable", "access"):
+        assert f"entry 'bad': {fieldname}" in joined
+    assert "files[0].sha256" in joined
+
+
+def test_validate_tier_b_requires_retrieval() -> None:
+    entry = m.DatasetEntry(
+        id="b",
+        version="1",
+        tier="B",
+        license="MIT",
+        redistributable=True,
+        access="open",
+        files=[m.FileRef(path="f", sha256=_HEX)],
+        datasheet="ds.md",
+    )
+    report = m.validate(m.Manifest(datasets=[entry]))
+    assert any("source/retrieval" in e for e in report.errors)
+
+
+def test_validate_tier_a_consistency() -> None:
+    common = {
+        "version": "1",
+        "tier": "A",
+        "license": "MIT",
+        "files": [m.FileRef(path="f", sha256=_HEX)],
+        "datasheet": "ds.md",
+    }
+    gated = m.DatasetEntry(id="g", access="gated", redistributable=True, **common)  # type: ignore[arg-type]
+    nonredist = m.DatasetEntry(id="n", access="open", redistributable=False, **common)  # type: ignore[arg-type]
+    report = m.validate(m.Manifest(datasets=[gated, nonredist]))
+    assert any("tier A cannot be access: gated" in e for e in report.errors)
+    assert any("tier A requires redistributable: true" in e for e in report.errors)
+
+
+def test_validate_duplicate_id_is_error() -> None:
+    entry = m.DatasetEntry(
+        id="dup",
+        version="1",
+        tier="B",
+        license="MIT",
+        redistributable=True,
+        access="open",
+        files=[m.FileRef(path="f", sha256=_HEX)],
+        datasheet="ds.md",
+        retrieval=m.Retrieval(kind="http", url="u"),
+    )
+    report = m.validate(m.Manifest(datasets=[entry, entry]))
+    assert any("duplicated" in e for e in report.errors)
+
+
+def test_validate_na_datasheet_is_warning_not_error() -> None:
+    entry = m.DatasetEntry(
+        id="c",
+        version="1",
+        tier="C",
+        license="proprietary",
+        redistributable=False,
+        access="gated",
+        files=[m.FileRef(path="f", sha256=_HEX)],
+        datasheet="N/A + not yet written",
+        instructions="email the authors",
+    )
+    report = m.validate(m.Manifest(datasets=[entry]))
+    assert report.ok  # N/A is a warning, not a hard error
+    assert any("datasheet" in w for w in report.warnings)
+
+
+def test_croissant_round_trip_preserves_core(tmp_path: Path) -> None:
+    entry = m.load(_write(tmp_path, _VALID_YAML)).datasets[0]
+    doc = m.croissant_for(entry)
+    assert doc["@type"] == "Dataset"
+    assert doc["distribution"][0]["contentUrl"] == "data/example.parquet"
+    assert doc["distribution"][0]["sha256"] == _HEX
+    back = m.entry_from_croissant(doc)
+    assert back.id == entry.id
+    assert back.version == entry.version
+    assert back.license == entry.license
+    assert back.files[0].sha256 == entry.files[0].sha256
+
+
+def test_entry_from_croissant_flags_human_todo() -> None:
+    draft = m.entry_from_croissant(
+        {"name": "x", "distribution": [{"contentUrl": "f", "sha256": _HEX}]}
+    )
+    assert draft.tier is None
+    assert draft.datasheet is None
+    assert draft.sensitivity is None
+
+
+def test_entry_from_croissant_without_name_raises() -> None:
+    with pytest.raises(m.ManifestError, match="no 'name'"):
+        m.entry_from_croissant({"description": "no name here"})
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def test_cli_validate_ok(tmp_path: Path) -> None:
+    path = _write(tmp_path, _VALID_YAML)
+    result = runner.invoke(app, ["dataset", "validate", str(path)])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["ok"] is True
+
+
+def test_cli_validate_reports_errors_and_exits_nonzero(tmp_path: Path) -> None:
+    path = _write(tmp_path, "datasets:\n  - id: bad\n")
+    result = runner.invoke(app, ["dataset", "validate", str(path)])
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["ok"] is False
+
+
+def test_cli_emit_by_id(tmp_path: Path) -> None:
+    path = _write(tmp_path, _VALID_YAML)
+    result = runner.invoke(
+        app, ["dataset", "emit", "example-tabular", "--manifest", str(path)]
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["@type"] == "Dataset"
+
+
+def test_cli_emit_unknown_id_exits_1(tmp_path: Path) -> None:
+    path = _write(tmp_path, _VALID_YAML)
+    result = runner.invoke(app, ["dataset", "emit", "nope", "--manifest", str(path)])
+    assert result.exit_code == 1
+
+
+def test_cli_ingest_emits_draft(tmp_path: Path) -> None:
+    croissant = tmp_path / "c.json"
+    croissant.write_text(
+        json.dumps(
+            {"name": "ingested", "distribution": [{"contentUrl": "f", "sha256": _HEX}]}
+        ),
+        encoding="utf-8",
+    )
+    result = runner.invoke(app, ["dataset", "ingest", str(croissant)])
+    assert result.exit_code == 0
+    draft = json.loads(result.stdout)
+    assert draft["id"] == "ingested"
+    assert "tier" in draft["_needs_human"]


### PR DESCRIPTION
Implements `honest_scholar/dataset/manifest.py` (honest-scholar#2) per `docs/design/proposals/dataset-manifest-tooling.md`. Metadata only — no bytes, no hashing, no network (that's #3, retrieval).

## What's implemented

- **Typed model** — `Manifest / DatasetEntry / FileRef / Retrieval / Citation / Mirror` dataclasses mirroring the `datasets.yml` schema. `pyyaml` + stdlib only.
- **`load()`** — structural decode; raises `ManifestError` naming the offending entry on malformed YAML/shape.
- **`validate()`** — accumulates **all** violations (never first-fail), formatted `entry '<id>': <field>: <reason>`:
  - core (version, tier∈{A,B,C}, license, redistributable, access∈{open,gated}, files with `sha256` shape `^(sha256:)?[0-9a-f]{64}$`, datasheet);
  - tier-conditional (B → source/retrieval + `retrieval.kind`; C → instructions; sensitivity enum);
  - **hard errors**: duplicate `id`; tier-consistency (`tier: A` with `redistributable: false` **or** `access: gated`) — matches the skill guardrail;
  - **warnings**: `N/A` datasheet placeholder; incomplete DataCite tuple.
- **Croissant interop** — `croissant_for()` emits schema.org `Dataset` JSON-LD (`distribution[]` with `contentUrl` + `sha256`, empty fields omitted); `entry_from_croissant()` ingests a draft and leaves human-owned fields (`tier`/`retrieval`/`datasheet`/`sensitivity`) unset.

## CLI

`dataset validate|ingest|emit` are now real (were stubs): JSON output; `validate` exits non-zero on any error; `emit` supports `--all` and `--manifest`; `ingest` prints a draft with a `_needs_human` list. `fetch|verify|mirror|audit` remain #3 stubs.

## Tests
17 new tests (`test_manifest.py`) covering load/validate rules, tier-consistency, duplicate-id, N/A-datasheet warning, Croissant round-trip, and the three CLI commands. `ruff`, `mypy --strict`, `pytest` (28 total) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
