### PR TITLE
ci: publish coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # tokenless Codecov upload via OIDC
     strategy:
       fail-fast: false
       matrix:
@@ -56,6 +57,13 @@ jobs:
       - name: Test
         working-directory: honest-scholar
         run: uv run pytest
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.13'
+        uses: codecov/codecov-action@v5
+        with:
+          files: honest-scholar/coverage.xml
+          use_oidc: true
+          fail_ci_if_error: false # a Codecov hiccup must not fail CI; the gate is the pytest --cov-fail-under
 
   plugin-validate:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 <p align="center">Keep your research honest — <strong>especially now that AI is in the loop</strong>.</p>
 
+<p align="center">
+  <a href="https://github.com/davorrunje/honest-scholar/actions/workflows/ci.yml"><img src="https://github.com/davorrunje/honest-scholar/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://codecov.io/gh/davorrunje/honest-scholar"><img src="https://codecov.io/gh/davorrunje/honest-scholar/branch/main/graph/badge.svg" alt="coverage"></a>
+</p>
+
 ---
 
 **`honest-scholar`** helps you keep research honest — *especially now that AI is in

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+# Codecov configuration.
+#
+# The *enforcing* coverage gate is pytest's `--cov-fail-under` (see
+# honest-scholar/pyproject.toml), enabled once the package reaches 100%. Until
+# then Codecov reports coverage informationally and never blocks a PR, so a
+# below-target percentage during the module build-out does not red the checks.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, files"
+  require_changes: false

--- a/honest-scholar/pyproject.toml
+++ b/honest-scholar/pyproject.toml
@@ -97,7 +97,7 @@ disallow_any_generics = true
 no_implicit_reexport = true
 
 [tool.pytest.ini_options]
-addopts = '--cov=honest_scholar --cov-branch --cov-report=term-missing'
+addopts = '--cov=honest_scholar --cov-branch --cov-report=term-missing --cov-report=xml'
 testpaths = ["tests"]
 
 [tool.coverage.report]


### PR DESCRIPTION
Publishes test coverage to Codecov. **The 100% hard gate is intentionally not in this PR** (see below).

## Changes
- **`pytest` emits `coverage.xml`** (`--cov-report=xml`) alongside the existing `term-missing` table.
- **CI uploads to Codecov** once — on the `3.13` matrix leg — via `codecov/codecov-action@v5` with **tokenless OIDC** (`id-token: write`). `fail_ci_if_error: false` so a Codecov outage can't red CI (enforcement is the pytest gate, not Codecov's status).
- **`codecov.yml`** keeps Codecov's project/patch statuses **informational**, so a below-target percentage doesn't block PRs while the modules are still landing.
- **README** gains CI + coverage badges.

## Why the 100% gate isn't here yet
`--cov-fail-under=100` on `main` today would fail every build: `main` is at **77%** (the five module files are still `NotImplementedError` stubs), and each module PR only covers its own module. The gate can only flip on once **#10–#14 merge** and a sweep drives the whole package to genuine 100% (covering the wired CLI paths, removing the now-dead `_not_implemented` helper, and `# pragma: no cover` on the truly-defensive lines). Tracked as a follow-up issue.

## Note
Tokenless upload works for public repos; if it proves flaky, add a `CODECOV_TOKEN` repo secret and Codecov v5 will use it automatically. The Codecov badge/dashboard needs the repo enabled at codecov.io (one-time, via GitHub login).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
