### PR TITLE
ci: token-based Codecov upload (mirror mononet)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # tokenless Codecov upload via OIDC
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -58,12 +59,12 @@ jobs:
         working-directory: honest-scholar
         run: uv run pytest
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.13'
+        if: ${{ matrix.python-version == '3.13' && env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ env.CODECOV_TOKEN }}
           files: honest-scholar/coverage.xml
-          use_oidc: true
-          fail_ci_if_error: false # a Codecov hiccup must not fail CI; the gate is the pytest --cov-fail-under
+          fail_ci_if_error: true
 
   plugin-validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes the `Repository not found` Codecov upload failure by switching to the **token-based** upload mononet already uses (tokenless OIDC isn't onboarded for this repo).

## Change
- Job-level `env: CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}`.
- Upload step now uses `token: ${{ env.CODECOV_TOKEN }}`, gated on `env.CODECOV_TOKEN != ''` so it is **skipped (not failed)** when the secret is absent, with `fail_ci_if_error: true` (matches mononet).
- Dropped the now-unneeded `id-token: write` permission.

A repo-scoped upload token self-identifies the repo to Codecov, so it won't hit "Repository not found".

## Requires (one-time, same as mononet)
Add a **`CODECOV_TOKEN`** repository secret to `davorrunje/honest-scholar` (Codecov → repo settings → upload token). Until it's set, the upload step simply no-ops and CI stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
