### PR TITLE
feat(release): version-bump action (alpha/beta/rc/release)

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,78 @@
+name: Bump version
+
+# Bumps the honest-scholar PACKAGE version (PEP 440) and opens a release PR.
+# Compose a release-segment bump with a pre-release phase, e.g.
+#   release=minor pre=alpha -> 0.1.0a0 · pre=alpha -> …a{n+1} · pre=rc -> …rc0 ·
+#   pre=final -> drop prerelease · release=patch -> 0.0.1
+# The plugin (.claude-plugin/plugin.json) is versioned independently and is NOT
+# touched here. After merging the PR, push the tag v<version> to publish
+# (see publish.yml).
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "Release segment to bump (clears any prerelease)"
+        type: choice
+        options: [none, patch, minor, major]
+        default: none
+      pre:
+        description: "Pre-release phase"
+        type: choice
+        options: [keep, alpha, beta, rc, final]
+        default: keep
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Compute + write the new version
+        id: bump
+        run: |
+          version=$(python tools/bump_version.py \
+            --release "${{ inputs.release }}" --pre "${{ inputs.pre }}")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Bumped honest-scholar to $version"
+      - name: Open release PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          # A RELEASE_PAT (if set) lets the bump commit trigger CI on the PR;
+          # otherwise the default token is used and CI won't auto-run (see body).
+          token: ${{ secrets.RELEASE_PAT || github.token }}
+          branch: release/v${{ steps.bump.outputs.version }}
+          base: main
+          title: "release: honest-scholar v${{ steps.bump.outputs.version }}"
+          author: Davor Runje <davor@synthpop.ai>
+          committer: Davor Runje <davor@synthpop.ai>
+          commit-message: |
+            chore(release): honest-scholar v${{ steps.bump.outputs.version }}
+
+            Bump the package version (release=${{ inputs.release }}, pre=${{ inputs.pre }}).
+          labels: release
+          body: |
+            Bumps the **honest-scholar package** to `v${{ steps.bump.outputs.version }}`
+            (`--release ${{ inputs.release }} --pre ${{ inputs.pre }}`).
+
+            The plugin (`.claude-plugin/plugin.json`) is versioned independently and is
+            **not** touched here.
+
+            ### Publish after merging
+            ```bash
+            git switch main && git pull
+            git tag v${{ steps.bump.outputs.version }}
+            git push origin v${{ steps.bump.outputs.version }}   # → publish.yml → PyPI
+            ```
+            To validate on **TestPyPI** first, run the `Publish` workflow via
+            *workflow_dispatch* before tagging.
+
+            > If no CI checks appear on this PR, it was created with `GITHUB_TOKEN`
+            > (which can't trigger workflows). Add a `RELEASE_PAT` repo secret so the
+            > bump commit triggers CI, or re-run CI / admin-merge.

--- a/resources/ensure-tooling.md
+++ b/resources/ensure-tooling.md
@@ -21,7 +21,9 @@ environment changes** (installing `uv`/Python is the user's call), **honest stop
    - else `pipx`,
    - else `python3` (with `venv` + `pip`).
 3. **Install, isolated** — **PyPI-first**. The primary source is the published
-   package `honest-scholar` on PyPI, pinned to `honest-scholar==<version>`:
+   package `honest-scholar` on PyPI, pinned to a **compatible range**
+   (`honest-scholar>=<min>,<<next>`, where `<min>` is the minimum package version
+   this plugin release requires — see the *Version pinning* note):
    - `uv tool install honest-scholar` — installs Python + deps in an isolated tool
      env; or run ad hoc with `uvx honest-scholar …` (no persistent install).
    - else `pipx install honest-scholar`.
@@ -55,8 +57,12 @@ environment changes** (installing `uv`/Python is the user's call), **honest stop
   depend freely on `typer` / `requests` / `pyyaml` / `pooch` without touching
   anyone's torch/jax install.
 - **Idempotency:** step 1 must be cheap; only steps 2–3 touch the network.
-- **Version pinning:** the pinned version comes from the installed plugin; upgrades
-  are deliberate (bump the pin), not silent.
+- **Version pinning:** the plugin and the `honest-scholar` package are versioned
+  **independently**. The plugin pins a *compatible range* (`>=<min>,<<next>`), not an
+  exact string-lock — `<min>` is the minimum package version the plugin's skills
+  need (declared by the plugin; bump it deliberately when a skill starts using a new
+  CLI capability), `<next>` the next incompatible boundary. The package's own
+  releases (PEP 440, `v*` tags → PyPI) proceed on their own cadence.
 - **rclone** (the private-mirror engine) is a separate single static binary — **not
   a Python dependency**; `honest-scholar` shells out to it. It is **optional**: only
   private-mirror operations need it (Tier-A git/LFS and Tier-B `pooch` fetch do

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Bump the ``honest-scholar`` PyPI package version (PEP 440).
+
+Composes a release-segment bump (``major``/``minor``/``patch``) with a
+pre-release phase (``alpha``/``beta``/``rc``/``final``), so a single run can
+express "start the next minor's alpha" (``--release minor --pre alpha`` ->
+``0.1.0a0``), "advance the current prerelease" (``--pre alpha`` -> ``…a{n+1}``),
+"promote to the next phase" (``--pre rc`` on an alpha -> ``…rc0``), or "cut the
+final" (``--pre final`` -> drop the prerelease).
+
+Edits ``[project].version`` in ``honest-scholar/pyproject.toml`` in place (the
+package's source of truth; the runtime ``__version__`` derives from the installed
+metadata) and prints the new version to stdout.
+
+This bumps **only the package**. The Claude Code plugin (`.claude-plugin/plugin.json`)
+is versioned independently (per the versioning policy); it pins a *compatible*
+package version via `ensure-tooling`, it is not kept string-locked to it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_PYPROJECT = _ROOT / "honest-scholar" / "pyproject.toml"
+
+# Matches the [project] version line (line-anchored; no other `^version = "..."`).
+_VERSION_LINE = re.compile(r'(?m)^version\s*=\s*"([^"]+)"')
+_VERSION = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:(a|b|rc)(\d+))?$")
+_PHASES = ("a", "b", "rc")  # PEP 440 ascending order
+_PRE_TO_PHASE = {"alpha": "a", "beta": "b", "rc": "rc"}
+
+
+class BumpError(ValueError):
+    """Raised on a malformed version or an illegal (non-monotonic) bump."""
+
+
+def parse_version(raw: str) -> tuple[int, int, int, str | None, int]:
+    """Parse ``X.Y.Z[{a|b|rc}N]`` into ``(major, minor, patch, phase, num)``.
+
+    :param raw: The version string.
+    :returns: Release triple plus the pre-release phase (``None`` if final) and
+        its number.
+    :raises BumpError: If `raw` is not a supported version shape.
+    """
+    match = _VERSION.fullmatch(raw.strip())
+    if match is None:
+        raise BumpError(f"unsupported version {raw!r} (want X.Y.Z[{{a|b|rc}}N])")
+    major, minor, patch, phase, num = match.groups()
+    return int(major), int(minor), int(patch), phase, int(num or 0)
+
+
+def format_version(
+    major: int, minor: int, patch: int, phase: str | None, num: int
+) -> str:
+    """Render a parsed version back to a PEP 440 string."""
+    base = f"{major}.{minor}.{patch}"
+    return f"{base}{phase}{num}" if phase else base
+
+
+def bump(current: str, release: str, pre: str) -> str:
+    """Compute the next version from `current` given a release + pre-release bump.
+
+    :param release: ``none`` / ``patch`` / ``minor`` / ``major`` — a release-segment
+        bump clears any existing prerelease.
+    :param pre: ``keep`` / ``alpha`` / ``beta`` / ``rc`` / ``final``.
+    :returns: The new PEP 440 version string.
+    :raises BumpError: If nothing would change, or a pre-release bump would move
+        backwards (e.g. ``rc`` -> ``alpha``).
+    """
+    if release == "none" and pre == "keep":
+        raise BumpError("nothing to bump: pass --release and/or --pre")
+
+    major, minor, patch, phase, num = parse_version(current)
+
+    if release == "major":
+        major, minor, patch, phase, num = major + 1, 0, 0, None, 0
+    elif release == "minor":
+        minor, patch, phase, num = minor + 1, 0, None, 0
+    elif release == "patch":
+        patch, phase, num = patch + 1, None, 0
+    elif release != "none":
+        raise BumpError(f"unknown --release {release!r}")
+
+    if pre == "final":
+        phase, num = None, 0
+    elif pre in _PRE_TO_PHASE:
+        target = _PRE_TO_PHASE[pre]
+        if phase is None:
+            phase, num = target, 0
+        elif _PHASES.index(phase) < _PHASES.index(target):
+            phase, num = target, 0
+        elif phase == target:
+            num += 1
+        else:
+            raise BumpError(
+                f"cannot move backwards from prerelease {phase!r} to {target!r}"
+            )
+    elif pre != "keep":
+        raise BumpError(f"unknown --pre {pre!r}")
+
+    return format_version(major, minor, patch, phase, num)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: bump the manifest version in place and print it."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--release", choices=["none", "patch", "minor", "major"], default="none"
+    )
+    parser.add_argument(
+        "--pre", choices=["keep", "alpha", "beta", "rc", "final"], default="keep"
+    )
+    parser.add_argument("--pyproject", type=Path, default=_DEFAULT_PYPROJECT)
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print the new version, do not write."
+    )
+    args = parser.parse_args(argv)
+
+    text = args.pyproject.read_text(encoding="utf-8")
+    match = _VERSION_LINE.search(text)
+    if match is None:
+        print(f"no 'version = \"...\"' line in {args.pyproject}", file=sys.stderr)
+        return 2
+    try:
+        new = bump(match.group(1), args.release, args.pre)
+    except BumpError as exc:
+        print(f"bump failed: {exc}", file=sys.stderr)
+        return 2
+
+    if not args.dry_run:
+        updated = text[: match.start(1)] + new + text[match.end(1) :]
+        args.pyproject.write_text(updated, encoding="utf-8")
+    print(new)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a **Bump version** `workflow_dispatch` action + a small bump script for the `honest-scholar` **PyPI package** (PEP 440), per the versioning policy we settled: package and plugin versioned **independently**; the plugin pins a *compatible range* of the package.

## What it does
Two choice inputs compose a bump:
- `release`: `none` / `patch` / `minor` / `major` (a release bump clears any prerelease)
- `pre`: `keep` / `alpha` / `beta` / `rc` / `final`

Examples (from `0.0.0a0`):

| release | pre | → |
|---|---|---|
| none | alpha | `0.0.0a1` |
| none | beta | `0.0.0b0` |
| none | rc | `0.0.0rc0` |
| none | final | `0.0.0` |
| minor | alpha | `0.1.0a0` |
| patch | keep | `0.0.1` |

Monotonic (rejects `rc → alpha`), rejects no-ops. Verified locally across every transition, error case, and chained writes.

## Pieces
- **`tools/bump_version.py`** — stdlib-only; edits `[project].version` in `honest-scholar/pyproject.toml`, prints the new version. (`__version__` derives from installed metadata, so it's the single source of truth.)
- **`.github/workflows/bump-version.yml`** — runs the script, opens a `release: honest-scholar v<version>` PR (authored as you). Body documents the publish step. An optional `RELEASE_PAT` secret lets the bump commit trigger CI on the PR (GITHUB_TOKEN can't).
- **`ensure-tooling`** — pin updated from exact `==` to a **compatibility range** `honest-scholar>=<min>,<<next>`, matching the independent-versioning policy.

## Release flow
1. Run **Bump version** (pick `release`/`pre`) → review/merge the PR.
2. `git tag v<version> && git push origin v<version>` → `publish.yml` → PyPI (use the manual `Publish` dispatch for TestPyPI first).

Only the package is bumped here; `.claude-plugin/plugin.json` stays independent (bump it separately when the plugin changes).

## Note
This action opens a PR (main is protected); it does not push to `main`. `ruff` + `codespell` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
