### PR TITLE
ci(publish): deployment-link annotation + dedup via composite action

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -1,0 +1,61 @@
+name: Publish package
+description: >-
+  Download the built dist, publish it to a PyPI-compatible index via Trusted
+  Publishing (OIDC), and annotate the run with the project link + install hint.
+  The calling job must supply `environment:` and `permissions: id-token: write`.
+
+inputs:
+  index:
+    description: "Target index: 'testpypi' or 'pypi'."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@v4
+      with: { name: dist, path: dist }
+
+    - name: Resolve index endpoints
+      id: idx
+      shell: bash
+      run: |
+        if [ "${{ inputs.index }}" = "testpypi" ]; then
+          name="TestPyPI"
+          repo="https://test.pypi.org/legacy/"
+          project="https://test.pypi.org/project"
+          install="uv tool install --index https://test.pypi.org/simple/ "
+        elif [ "${{ inputs.index }}" = "pypi" ]; then
+          name="PyPI"
+          repo="https://upload.pypi.org/legacy/"
+          project="https://pypi.org/project"
+          install="uv tool install "
+        else
+          echo "::error::unknown index '${{ inputs.index }}' (want testpypi|pypi)"
+          exit 1
+        fi
+        {
+          echo "name=$name"
+          echo "repo=$repo"
+          echo "project=$project"
+          echo "install=$install"
+        } >> "$GITHUB_OUTPUT"
+
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: ${{ steps.idx.outputs.repo }}
+
+    - name: Report the published version
+      shell: bash
+      run: |
+        version=$(basename "$(ls dist/*.whl | head -1)" | cut -d- -f2)
+        url="${{ steps.idx.outputs.project }}/honest-scholar/${version}/"
+        echo "::notice title=Published to ${{ steps.idx.outputs.name }}::honest-scholar ${version} -> ${url}"
+        {
+          echo "### 📦 Published to ${{ steps.idx.outputs.name }}"
+          echo ""
+          echo "**honest-scholar ${version}** -> <${url}>"
+          echo ""
+          echo '```'
+          echo "${{ steps.idx.outputs.install }}honest-scholar==${version}"
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,25 +44,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
-        with: { name: dist, path: dist }
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/checkout@v5 # needed to resolve the local composite action
+      - uses: ./.github/actions/publish-package
         with:
-          repository-url: https://test.pypi.org/legacy/
-      - name: Report the published version
-        run: |
-          version=$(basename "$(ls dist/*.whl | head -1)" | cut -d- -f2)
-          url="https://test.pypi.org/project/honest-scholar/${version}/"
-          echo "::notice title=Published to TestPyPI::honest-scholar ${version} -> ${url}"
-          {
-            echo "### 📦 Published to TestPyPI"
-            echo ""
-            echo "**honest-scholar ${version}** -> <${url}>"
-            echo ""
-            echo '```'
-            echo "uv tool install --index https://test.pypi.org/simple/ honest-scholar==${version}"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          index: testpypi
 
   pypi:
     # Version tag → PyPI, or manual dispatch with target=pypi
@@ -73,20 +58,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
-        with: { name: dist, path: dist }
-      - uses: pypa/gh-action-pypi-publish@release/v1
-      - name: Report the published version
-        run: |
-          version=$(basename "$(ls dist/*.whl | head -1)" | cut -d- -f2)
-          url="https://pypi.org/project/honest-scholar/${version}/"
-          echo "::notice title=Published to PyPI::honest-scholar ${version} -> ${url}"
-          {
-            echo "### 📦 Published to PyPI"
-            echo ""
-            echo "**honest-scholar ${version}** -> <${url}>"
-            echo ""
-            echo '```'
-            echo "uv tool install honest-scholar==${version}"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/checkout@v5 # needed to resolve the local composite action
+      - uses: ./.github/actions/publish-package
+        with:
+          index: pypi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,20 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+      - name: Report the published version
+        run: |
+          version=$(basename "$(ls dist/*.whl | head -1)" | cut -d- -f2)
+          url="https://test.pypi.org/project/honest-scholar/${version}/"
+          echo "::notice title=Published to TestPyPI::honest-scholar ${version} -> ${url}"
+          {
+            echo "### 📦 Published to TestPyPI"
+            echo ""
+            echo "**honest-scholar ${version}** -> <${url}>"
+            echo ""
+            echo '```'
+            echo "uv tool install --index https://test.pypi.org/simple/ honest-scholar==${version}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   pypi:
     # Version tag → PyPI, or manual dispatch with target=pypi
@@ -62,3 +76,17 @@ jobs:
       - uses: actions/download-artifact@v4
         with: { name: dist, path: dist }
       - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Report the published version
+        run: |
+          version=$(basename "$(ls dist/*.whl | head -1)" | cut -d- -f2)
+          url="https://pypi.org/project/honest-scholar/${version}/"
+          echo "::notice title=Published to PyPI::honest-scholar ${version} -> ${url}"
+          {
+            echo "### 📦 Published to PyPI"
+            echo ""
+            echo "**honest-scholar ${version}** -> <${url}>"
+            echo ""
+            echo '```'
+            echo "uv tool install honest-scholar==${version}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Two related changes to the Publish workflow:

## 1. Deployment-link annotation
After a successful upload, each publish job surfaces the deployment link:
- a **`::notice::` annotation** (in the run's **Annotations**): `Published to TestPyPI: honest-scholar <version> -> <url>`
- a **job-summary block** with the project URL + install command

TestPyPI -> `https://test.pypi.org/project/honest-scholar/<version>/`; PyPI -> `https://pypi.org/project/honest-scholar/<version>/`. Version parsed from the built wheel filename.

## 2. Dedup via a local composite action
The `testpypi` and `pypi` jobs were near-identical (download → publish → report). Extracted the shared logic into **`.github/actions/publish-package`** (input `index: testpypi|pypi`) that resolves the index endpoints, publishes via Trusted Publishing, and writes the annotation/summary. Each job now just `checkout` + `uses: ./.github/actions/publish-package` — no duplicated shell.

Both YAML files validated; codespell clean. (Each job now checks out the repo so the local composite action resolves; OIDC/environment stay job-level and unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)