### PR TITLE
docs+ci: RELEASING.md (plugin + package) + Release-driven PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,15 @@
 name: Publish
 
 # Publishes the honest-scholar package via PyPI Trusted Publishing (OIDC — no
-# tokens). A version tag publishes to PyPI; manual dispatch publishes to the
-# chosen `target` index (default **TestPyPI**, for pre-release validation).
-# Requires pending/registered trusted publishers on both indexes for repo
-# davorrunje/honest-scholar, workflow publish.yml, environments testpypi / pypi
-# (see README / DISCLOSURE docs).
+# tokens). A published **GitHub Release** publishes to PyPI; manual dispatch
+# publishes to the chosen `target` index (default **TestPyPI**, for pre-release
+# validation). Requires pending/registered trusted publishers on both indexes
+# for repo davorrunje/honest-scholar, workflow publish.yml, environments
+# testpypi / pypi (see README / RELEASING docs).
 
 on:
-  push:
-    tags: ["v*"]   # includes pre-releases like v0.0.0a0
+  release:
+    types: [published]   # includes pre-releases (a/b/rc) marked as such
   workflow_dispatch:
     inputs:
       target:
@@ -55,8 +55,8 @@ jobs:
           index: testpypi
 
   pypi:
-    # Version tag → PyPI, or manual dispatch with target=pypi
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi') }}
+    # Published GitHub Release → PyPI, or manual dispatch with target=pypi
+    if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi') }}
     needs: build
     runs-on: ubuntu-latest
     environment: pypi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,13 @@ each consuming repo binds whatever engineering backend it uses (or none) via
 - **Test-install locally:** `/plugin marketplace add ./` then
   `/plugin install honest-scholar@honest-scholar`.
 
+## Releasing
+
+Cutting a release of the **PyPI package** (Bump version → merge → Publish to
+TestPyPI/PyPI via Trusted Publishing) is documented in
+[`RELEASING.md`](RELEASING.md). The package is versioned independently of the
+plugin.
+
 ## Domain-neutrality
 
 `honest-scholar` must stay domain-neutral: no ML-, monotonic-network-, or repo-specific

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,85 @@
+# Releasing the `honest-scholar` package
+
+How to cut a release of the **PyPI package** (the `honest-scholar/` subdirectory —
+the CLI tooling). It is versioned **independently** of the Claude Code plugin
+(`.claude-plugin/plugin.json`); see [Versioning](#versioning).
+
+Everything is driven by three GitHub Actions workflows — no local build or
+`twine` needed:
+
+| Workflow | What it does |
+|---|---|
+| **Bump version** (`bump-version.yml`) | Compute the next PEP 440 version, open a release PR. |
+| **CI** (`ci.yml`) | Lint + type-check + tests (100% coverage gate) on every PR. |
+| **Publish** (`publish.yml`) | Build + upload to TestPyPI / PyPI via Trusted Publishing (OIDC). |
+
+## Versioning
+
+- **PEP 440.** Source of truth is `[project].version` in
+  `honest-scholar/pyproject.toml`; the runtime `honest_scholar.__version__`
+  derives from the installed package metadata.
+- **Independent from the plugin.** The plugin (`plugin.json`) has its own version
+  and pins a *compatible range* of the package via `ensure-tooling`
+  (`honest-scholar>=<min>,<<next>`). Bumping the package does not bump the plugin
+  and vice-versa.
+- **Tag format:** `v<version>` in PEP 440 spelling, e.g. `v0.1.0`, `v0.1.0rc1`,
+  `v0.0.0a2`.
+
+## Release steps
+
+1. **Bump the version.** Actions → **Bump version** → *Run workflow* on `main`.
+   Pick:
+   - `release`: `none` / `patch` / `minor` / `major` (a release bump clears any
+     prerelease),
+   - `pre`: `keep` / `alpha` / `beta` / `rc` / `final`.
+
+   | want | release | pre | result (from `0.0.0a1`) |
+   |---|---|---|---|
+   | next alpha | none | alpha | `0.0.0a2` |
+   | promote to rc | none | rc | `0.0.0rc0` |
+   | cut the final | none | final | `0.0.0` |
+   | start 0.1.0's alpha | minor | alpha | `0.1.0a0` |
+   | patch release | patch | keep | `0.0.1` |
+
+   It edits `pyproject.toml` and opens a **`release: honest-scholar v<version>`**
+   PR (branch `release/v<version>`). The run summary shows `old → new` + the PR
+   link.
+
+2. **Review & merge the release PR** into `main` (wait for CI to pass).
+
+3. **Validate on TestPyPI.** Actions → **Publish** → *Run workflow* with
+   `target: testpypi` (the default). Check the run's **summary** for the project
+   link, and optionally smoke-test the install:
+   ```bash
+   uv tool install --index https://test.pypi.org/simple/ honest-scholar==<version>
+   honest-scholar --version
+   ```
+
+4. **Publish to PyPI.** Either:
+   ```bash
+   git switch main && git pull
+   git tag v<version>
+   git push origin v<version>        # the tag triggers Publish → PyPI
+   ```
+   …or Actions → **Publish** → *Run workflow* with `target: pypi`. The run
+   summary/annotation shows the published `https://pypi.org/project/honest-scholar/<version>/`.
+
+## One-time setup (already done; here for reference)
+
+- **Trusted Publishing (OIDC, no tokens).** Registered publishers on both PyPI
+  and TestPyPI for repo `davorrunje/honest-scholar`, workflow `publish.yml`,
+  environments `testpypi` / `pypi`.
+- **`RELEASE_PAT` secret** — a fine-grained PAT (Contents: read/write, Pull
+  requests: read/write) so **Bump version** can open the release PR *and* have CI
+  run on it. Without it the bump still runs but the PR won't get CI checks.
+
+## Notes / gotchas
+
+- **Immutable versions.** PyPI (and TestPyPI) reject re-uploading a version that
+  already exists — bump to a new one rather than re-publishing.
+- **Prereleases** (`aN`/`bN`/`rcN`) publish like any version; `pip`/`uv` won't
+  install them by default unless asked (`--prerelease=allow` / an explicit
+  `==<prerelease>`).
+- **Plugin release** is separate: bump `.claude-plugin/plugin.json` when the
+  plugin/skills change, and bump the package's compatibility pin in
+  `ensure-tooling` when a skill starts using a new CLI capability.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,37 +1,37 @@
-# Releasing the `honest-scholar` package
+# Releasing
 
-How to cut a release of the **PyPI package** (the `honest-scholar/` subdirectory —
-the CLI tooling). It is versioned **independently** of the Claude Code plugin
-(`.claude-plugin/plugin.json`); see [Versioning](#versioning).
+`honest-scholar` ships **two independently-versioned artifacts**:
 
-Everything is driven by three GitHub Actions workflows — no local build or
-`twine` needed:
+| Artifact | What | Distributed via | Version source |
+|---|---|---|---|
+| **Plugin** | the Claude Code plugin (skills + docs) | this repo's git **marketplace** | `.claude-plugin/plugin.json` (semver) |
+| **Package** | the `honest-scholar` CLI tooling (`honest-scholar/`) | **PyPI** | `honest-scholar/pyproject.toml` (PEP 440) |
 
-| Workflow | What it does |
+They version **independently** — a skill edit needn't cut a PyPI release, and a
+CLI fix needn't re-cut the plugin. The plugin declares a *compatible range* of
+the package (`honest-scholar>=<min>,<<next>`) in
+[`resources/ensure-tooling.md`](resources/ensure-tooling.md); that pin is the
+coupling, not a shared version string.
+
+> **`v<version>` tags / GitHub Releases are _package_ releases** (PEP 440
+> spelling, e.g. `v0.1.0rc1`) and trigger the PyPI publish. Because a Release is
+> a whole-repo snapshot, it also doubles as a pinnable point for the plugin.
+
+---
+
+## Releasing the package (PyPI)
+
+Driven by three workflows — no local build / `twine` needed:
+
+| Workflow | Role |
 |---|---|
-| **Bump version** (`bump-version.yml`) | Compute the next PEP 440 version, open a release PR. |
-| **CI** (`ci.yml`) | Lint + type-check + tests (100% coverage gate) on every PR. |
-| **Publish** (`publish.yml`) | Build + upload to TestPyPI / PyPI via Trusted Publishing (OIDC). |
+| **Bump version** (`bump-version.yml`) | compute the next PEP 440 version, open a release PR |
+| **CI** (`ci.yml`) | lint + types + tests (100% coverage gate) on every PR |
+| **Publish** (`publish.yml`) | build + upload to TestPyPI / PyPI via Trusted Publishing (OIDC) |
 
-## Versioning
-
-- **PEP 440.** Source of truth is `[project].version` in
-  `honest-scholar/pyproject.toml`; the runtime `honest_scholar.__version__`
-  derives from the installed package metadata.
-- **Independent from the plugin.** The plugin (`plugin.json`) has its own version
-  and pins a *compatible range* of the package via `ensure-tooling`
-  (`honest-scholar>=<min>,<<next>`). Bumping the package does not bump the plugin
-  and vice-versa.
-- **Tag format:** `v<version>` in PEP 440 spelling, e.g. `v0.1.0`, `v0.1.0rc1`,
-  `v0.0.0a2`.
-
-## Release steps
-
-1. **Bump the version.** Actions → **Bump version** → *Run workflow* on `main`.
-   Pick:
-   - `release`: `none` / `patch` / `minor` / `major` (a release bump clears any
-     prerelease),
-   - `pre`: `keep` / `alpha` / `beta` / `rc` / `final`.
+1. **Bump the version.** Actions → **Bump version** → *Run workflow* on `main`:
+   - `release`: `none` / `patch` / `minor` / `major` (a release bump clears any prerelease)
+   - `pre`: `keep` / `alpha` / `beta` / `rc` / `final`
 
    | want | release | pre | result (from `0.0.0a1`) |
    |---|---|---|---|
@@ -41,45 +41,75 @@ Everything is driven by three GitHub Actions workflows — no local build or
    | start 0.1.0's alpha | minor | alpha | `0.1.0a0` |
    | patch release | patch | keep | `0.0.1` |
 
-   It edits `pyproject.toml` and opens a **`release: honest-scholar v<version>`**
-   PR (branch `release/v<version>`). The run summary shows `old → new` + the PR
-   link.
+   It edits `pyproject.toml` and opens a **`release: honest-scholar v<version>`** PR.
 
-2. **Review & merge the release PR** into `main` (wait for CI to pass).
+2. **Review & merge the release PR** into `main` (wait for CI).
 
 3. **Validate on TestPyPI.** Actions → **Publish** → *Run workflow* with
-   `target: testpypi` (the default). Check the run's **summary** for the project
-   link, and optionally smoke-test the install:
+   `target: testpypi` (the default). Check the run **summary** for the link, then
+   optionally smoke-test:
    ```bash
    uv tool install --index https://test.pypi.org/simple/ honest-scholar==<version>
    honest-scholar --version
    ```
 
-4. **Publish to PyPI.** Either:
+4. **Publish to PyPI — create a GitHub Release.** The published Release creates
+   the tag, writes a changelog, and triggers Publish → PyPI:
    ```bash
    git switch main && git pull
-   git tag v<version>
-   git push origin v<version>        # the tag triggers Publish → PyPI
+   gh release create v<version> --generate-notes                # final
+   gh release create v<version> --generate-notes --prerelease   # a / b / rc
    ```
-   …or Actions → **Publish** → *Run workflow* with `target: pypi`. The run
-   summary/annotation shows the published `https://pypi.org/project/honest-scholar/<version>/`.
+   (or use the Releases UI — tick *"Set as a pre-release"* for `a`/`b`/`rc`). The
+   Publish run's summary/annotation shows
+   `https://pypi.org/project/honest-scholar/<version>/`.
 
-## One-time setup (already done; here for reference)
+   > Re-running a publish without a new Release (e.g. after a transient failure):
+   > Actions → **Publish** → `target: pypi`. Don't push a bare `v*` tag — the
+   > trigger is the **Release**, not the tag.
 
-- **Trusted Publishing (OIDC, no tokens).** Registered publishers on both PyPI
-  and TestPyPI for repo `davorrunje/honest-scholar`, workflow `publish.yml`,
+---
+
+## Releasing the plugin
+
+The plugin has **no build or upload step** — it's served from git through the
+marketplace (`/plugin marketplace add davorrunje/honest-scholar`). A "release" is
+just a versioned, validated snapshot users can pin.
+
+1. **Bump** `.claude-plugin/plugin.json` `version` (semver: `patch` / `minor` /
+   `major`).
+2. **Re-pin the package if needed.** If the plugin's skills now rely on a newer
+   CLI capability, raise the compatibility floor in
+   [`resources/ensure-tooling.md`](resources/ensure-tooling.md)
+   (`honest-scholar>=<min>`).
+3. **Validate:** `claude plugin validate .`.
+4. **Open a PR and merge to `main`.**
+5. **How users pin it.** In their `.claude/settings.json` marketplace source,
+   users either track the default branch or pin `"ref": "v<version>"` — a package
+   `v*` Release is a whole-repo snapshot, so it pins the plugin at that commit
+   too. For a **plugin-only** release (no package change), do **not** create a
+   `v*` Release (it would re-trigger a package publish of an unchanged version →
+   PyPI 409); if you want a dedicated pin marker, tag `plugin-v<version>`.
+
+> There's no automated plugin-bump action yet (the **Bump version** action bumps
+> only the package). Bump `plugin.json` by hand for now.
+
+---
+
+## One-time setup (already done; for reference)
+
+- **Trusted Publishing (OIDC, no tokens)** — registered publishers on PyPI and
+  TestPyPI for repo `davorrunje/honest-scholar`, workflow `publish.yml`,
   environments `testpypi` / `pypi`.
 - **`RELEASE_PAT` secret** — a fine-grained PAT (Contents: read/write, Pull
   requests: read/write) so **Bump version** can open the release PR *and* have CI
-  run on it. Without it the bump still runs but the PR won't get CI checks.
+  run on it.
 
 ## Notes / gotchas
 
-- **Immutable versions.** PyPI (and TestPyPI) reject re-uploading a version that
-  already exists — bump to a new one rather than re-publishing.
-- **Prereleases** (`aN`/`bN`/`rcN`) publish like any version; `pip`/`uv` won't
-  install them by default unless asked (`--prerelease=allow` / an explicit
-  `==<prerelease>`).
-- **Plugin release** is separate: bump `.claude-plugin/plugin.json` when the
-  plugin/skills change, and bump the package's compatibility pin in
-  `ensure-tooling` when a skill starts using a new CLI capability.
+- **Immutable versions.** PyPI/TestPyPI reject re-uploading an existing version —
+  bump to a new one rather than re-publishing.
+- **Prereleases** (`aN`/`bN`/`rcN`) publish like any version but aren't installed
+  by default (`pip`/`uv` need `--prerelease=allow` or an explicit `==<prerelease>`).
+- **Two artifacts, two cadences.** Keep the plugin and package versions moving on
+  their own schedules; the `ensure-tooling` pin is what keeps them compatible.


### PR DESCRIPTION
Documents the release process for **both** artifacts and switches the PyPI publish to be driven by a **GitHub Release**.

## `publish.yml` — Release-driven
- Trigger changed from `push: tags: [v*]` to **`release: [published]`**. Creating a GitHub Release now gives the changelog + canonical `/releases` page + the publish trigger in one step.
- `pypi` job gates on `github.event_name == 'release'` (or manual dispatch `target: pypi`). TestPyPI stays on manual dispatch.
- Single trigger avoids the double-publish a tag+Release combo would cause.

## `RELEASING.md` — both artifacts
Restructured from package-only into:
- **Releasing the package (PyPI):** Bump version → merge → validate on TestPyPI → `gh release create v<version> --generate-notes [--prerelease]` → PyPI.
- **Releasing the plugin:** bump `plugin.json` + the `ensure-tooling` compat pin + `claude plugin validate` + merge; marketplace distribution + how users pin (`plugin-v*` for plugin-only markers).
- A versioning table making the independent plugin/package versions explicit.

Linked from `CONTRIBUTING.md`. YAML validated, codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)