### PR TITLE
release: honest-scholar v0.0.0b0

### DIFF
--- a/honest-scholar/pyproject.toml
+++ b/honest-scholar/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "honest-scholar"
-version = "0.0.0a1"
+version = "0.0.0b0"
 description = "honest-scholar — a CLI for honest, defensible AI-assisted research (tooling for the honest-scholar plugin)"
 authors = [{ name = "Davor Runje", email = "davor@synthpop.ai" }]
 maintainers = [{ name = "Davor Runje", email = "davor@synthpop.ai" }]


### PR DESCRIPTION
Bumps the **honest-scholar package** to `v0.0.0b0`
(`--release none --pre beta`).

The plugin (`.claude-plugin/plugin.json`) is versioned independently and is
**not** touched here.

### Publish after merging
```bash
git switch main && git pull
git tag v0.0.0b0
git push origin v0.0.0b0   # → publish.yml → PyPI
```
To validate on **TestPyPI** first, run the `Publish` workflow via
*workflow_dispatch* before tagging.

> If no CI checks appear on this PR, it was created with `GITHUB_TOKEN`
> (which can't trigger workflows). Add a `RELEASE_PAT` repo secret so the
> bump commit triggers CI, or re-run CI / admin-merge.