### PR TITLE
docs(skills): de-stub CLI-backed skills (the tooling shipped)

### DIFF
--- a/skills/dataset/SKILL.md
+++ b/skills/dataset/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   private rclone mirror, and SHA-256 fixity. Use when a run declares the data it
   needs, when adding/registering a dataset, or when fetching, verifying,
   mirroring, or auditing datasets so results resolve to exact bytes. Verbs:
-  init, register, fetch, verify, mirror, audit.
+  init, register, export, fetch, verify, mirror, audit.
 ---
 
 # dataset
@@ -110,8 +110,8 @@ datasets:
 **Tooling.** This is `honest_scholar/dataset/manifest.py`, exposed via
 `honest-scholar dataset validate` (loader/validator) and `honest-scholar dataset
 ingest|emit` (Croissant) — ensure via [`ensure-tooling`](../../resources/ensure-tooling.md);
-design in `../../docs/design/proposals/dataset-manifest-tooling.md` (issue #2).
-*Interim, until the module lands:*
+design in `../../docs/design/proposals/dataset-manifest-tooling.md`. By hand (if
+the CLI isn't available):
 - **loader/validator** — load with `python -c` + `yaml.safe_load` and eyeball the
   base record + tier-conditional required fields (self-describing `sha256:` values)
   against the table above.
@@ -164,9 +164,9 @@ file failing verification is treated as absent and the chain continues:
 **Tooling.** The resolution chain is `honest_scholar/dataset/retrieval.py`, exposed
 via `honest-scholar dataset fetch|verify|mirror|audit` — ensure via
 [`ensure-tooling`](../../resources/ensure-tooling.md); design in
-`../../docs/design/proposals/dataset-retrieval-mirror-tooling.md` (issue #3). rclone
+`../../docs/design/proposals/dataset-retrieval-mirror-tooling.md`. rclone
 is an optional external binary the wrappers shell out to, not a Python dep.
-*Interim, until the module lands:*
+By hand (if the CLI isn't available):
 - **Tier-B fetch** — `curl`/`wget` then `sha256sum` and manually compare to the
   manifest before use (the module will use `pooch.retrieve(url, known_hash="sha256:…")`
   into the content-addressed cache).

--- a/skills/defend/SKILL.md
+++ b/skills/defend/SKILL.md
@@ -66,12 +66,11 @@ the author elects to stop and record the gap.
 > **Tooling.** The record step is the `honest-scholar defend record` CLI command
 > (`honest_scholar/defend/record.py`) — ensure via
 > [`ensure-tooling`](../../resources/ensure-tooling.md); it appends the
-> `understanding` frontmatter block and persists the transcript (issue #4).
-> **Interim, until it lands:** edit the artifact's frontmatter directly — under the
-> `status:` block, set `understanding: {status: ok|gaps, unresolved: [...]}` to match
-> the schema `progress` reads (`../progress/SKILL.md`), and bump `status.last-updated`
-> (do **not** nest a date inside `understanding`). If a transcript is kept, write it
-> beside the artifact as `defend-<date>.md`.
+> `understanding` frontmatter block and persists the transcript. By hand (if the CLI
+> isn't available): under the `status:` block set `understanding: {status: ok|gaps,
+> unresolved: [...]}` to match the schema `progress` reads (`../progress/SKILL.md`),
+> and bump `status.last-updated` (do **not** nest a date inside `understanding`); if
+> a transcript is kept, write it beside the artifact as `defend-<date>.md`.
 
 ## Example (a methodology probe)
 

--- a/skills/hypothesis-exploration/SKILL.md
+++ b/skills/hypothesis-exploration/SKILL.md
@@ -67,11 +67,11 @@ carries provenance so any candidate can be traced to where it came from:
 > **Tooling.** Row append/transition is the `honest-scholar backlog
 > park|add|list|rank|promote|drop` CLI group
 > (`honest_scholar/exploration/backlog.py`) — ensure via
-> [`ensure-tooling`](../../resources/ensure-tooling.md) (issue #5); shared with
+> [`ensure-tooling`](../../resources/ensure-tooling.md); shared with
 > `paper-exploration`. `add` realizes the `generate` verb's row-append; `list` is a
-> read-only inspection command. **Interim, until it lands:** edit the `backlog.md`
-> table directly and keep the column order above so the `backlog` verbs (`rank`,
-> `promote`, `list`) can parse it.
+> read-only inspection command. By hand (if the CLI isn't available): edit the
+> `backlog.md` table directly, keeping the column order above so the `backlog`
+> verbs (`rank`, `promote`, `list`) can parse it.
 
 ## Generation moves
 

--- a/skills/literature/SKILL.md
+++ b/skills/literature/SKILL.md
@@ -53,7 +53,6 @@ Grounding: [../../resources/references/citation-scouting.md](../../resources/ref
 
 Steps 1–5 are `honest-scholar literature` commands (`resolve` / `cites` / `refs` /
 `enrich` / `neighbors`) — install via `ensure-tooling`; see [Tooling](#tooling).
-Until the module lands, orchestrate the API calls manually (Tooling shows how).
 
 1. **Fix the anchor set** — own papers + rival anchors from `.honest-scholar/config.yml`
    (or args). Resolve each to a stable id (DOI / arXiv / OpenAlex / S2).
@@ -198,20 +197,17 @@ before use** via [`ensure-tooling`](../../resources/ensure-tooling.md) (`uv tool
 install honest-scholar`, git/TestPyPI fallbacks). It wraps the OpenAlex + Semantic
 Scholar clients, the CSL-JSON bib loader/appender, and the triage-join +
 PRISMA-log / concept-matrix generators. Package deps: `requests` + `pyyaml` (+ the
-substrate's rclone mirror). Design: `../../docs/design/proposals/literature-citation-graph-client.md`
-(issue #1).
+substrate's rclone mirror). Design: `../../docs/design/proposals/literature-citation-graph-client.md`.
 
-> **Not yet implemented — interim (orchestrate the APIs manually until the module lands):**
+> **The endpoints the CLI wraps** (for reference, or a keyless manual check):
 > - Forward citations: `curl 'https://api.openalex.org/works?filter=cites:<WORKID>&mailto=<email>&per-page=200'`
 >   (paginate via `cursor=*`). Backward: read `referenced_works` on the anchor's work record.
 > - Contexts + SciCite intents + `isInfluential`:
 >   `curl 'https://api.semanticscholar.org/graph/v1/paper/<id>/citations?fields=contexts,intents,isInfluential,title,year,venue,authors'`
 >   (add the `x-api-key` header if a key is configured; omit and degrade to
->   OpenAlex-only otherwise).
+>   OpenAlex-only otherwise — `cites` marks the result `degraded` when it does).
 > - Recommendations (idea expansion):
 >   `https://api.semanticscholar.org/recommendations/v1/papers/forpaper/<id>`.
-> - Persist the raw JSON responses as the provenance root before enriching; edit
->   `references.json` / `triage.yml` directly for now.
 
 ## Commit attribution
 

--- a/skills/paper-exploration/SKILL.md
+++ b/skills/paper-exploration/SKILL.md
@@ -54,10 +54,11 @@ explicit human pick — the exploration/resolution firewall
 > **Tooling.** Row append/transition is the shared `honest-scholar backlog
 > park|add|list|rank|promote|drop` CLI group
 > (`honest_scholar/exploration/backlog.py`, shared with `hypothesis-exploration`)
-> — ensure via [`ensure-tooling`](../../resources/ensure-tooling.md) (issue #5),
+> — ensure via [`ensure-tooling`](../../resources/ensure-tooling.md),
 > operating on `portfolio-backlog.md` at the paper level. `add` realizes the
-> `generate` verb's row-append; `list` is a read-only inspection command.
-> **Interim, until it lands:** edit the `portfolio-backlog.md` table directly.
+> `generate` verb's row-append; `list` is a read-only inspection command. By hand
+> (if the CLI isn't available): edit the `portfolio-backlog.md` table directly,
+> keeping the column order.
 
 ## Generation lenses
 


### PR DESCRIPTION
## What

All 5 CLI-backed skills still told the author the tooling was *unimplemented* — but `literature`, `dataset`, `defend`, and the `backlog` group all shipped (issues #1–#5 are closed). This is the **B1 blocker cluster** from the release-readiness audit (#31): the skills instruct users to hand-orchestrate APIs and edit tables/frontmatter by hand for tooling that exists.

## Changes

- **defend / paper-exploration / hypothesis-exploration** — remove the `**Interim, until it lands:**` notes; demote the manual path to a concise `By hand (if the CLI isn't available)` fallback (still useful when `ensure-tooling` can't install the package).
- **literature** — drop the internal self-contradiction (`## Tooling` said "ensure via `ensure-tooling`" while the next blockquote said "Not yet implemented — orchestrate manually"); reframe the `curl` block as "the endpoints the CLI wraps" reference, and note that `cites` marks results `degraded` when the S2 key is absent. Remove the "Until the module lands…" sentence from the steps intro.
- **dataset** — add the `export` verb to the frontmatter description (the skill covers Croissant emit).
- Drop the stale `(issue #N)` pending framing throughout (all closed).

No behavioral/code changes — skills-only documentation truthing.

Part of #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)