### PR TITLE
fix(package): implement S2 enrichment + harden CLI/parser inputs

### DIFF
--- a/honest-scholar/honest_scholar/cli.py
+++ b/honest-scholar/honest_scholar/cli.py
@@ -1,8 +1,9 @@
 """The ``honest-scholar`` command-line interface.
 
-A Typer command tree mirroring the plugin's skill verbs. ``doctor`` is
-implemented; the domain sub-commands are typed stubs pending their tracking
-issues (see ADR-0024 and ``docs/design/proposals/tooling-package.md``).
+A Typer command tree mirroring the plugin's skill verbs: ``doctor``,
+``literature`` (citation graph), ``dataset`` (manifest / retrieval / mirror),
+``defend record``, and ``backlog`` are all implemented and emit JSON. See
+ADR-0024 and ``docs/design/proposals/tooling-package.md``.
 """
 
 from __future__ import annotations
@@ -121,7 +122,11 @@ def _lit_client() -> HttpClient:
     from honest_scholar.core.config import load_config
     from honest_scholar.core.http import HttpClient
 
-    config = load_config()
+    try:
+        config = load_config()
+    except ValueError as exc:
+        typer.echo(f"invalid .honest-scholar/config.yml: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
     lit = config.get("literature")
     mailto = lit.get("mailto") if isinstance(lit, dict) else None
     return HttpClient(
@@ -219,9 +224,12 @@ def neighbors(
     :param top: Number of neighbours per set.
     """
     client = _lit_client()
-    result = graph_mod.neighbors(
-        _openalex_id(client, identifier), client=client, kind=kind, top=top
-    )
+    resolved = _openalex_id(client, identifier)
+    try:
+        result = graph_mod.neighbors(resolved, client=client, kind=kind, top=top)
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
     typer.echo(json.dumps(result, indent=2))
     raise typer.Exit(code=0)
 

--- a/honest-scholar/honest_scholar/dataset/manifest.py
+++ b/honest-scholar/honest_scholar/dataset/manifest.py
@@ -201,14 +201,18 @@ def _decode_file_ref(raw: Any, where: str) -> FileRef:
     if not isinstance(raw, dict):
         raise ManifestError(f"{where}: each file must be a mapping")
     try:
-        size = raw.get("size")
-        return FileRef(
-            path=str(raw["path"]),
-            sha256=str(raw["sha256"]),
-            size=int(size) if size is not None else None,
-        )
+        path = str(raw["path"])
+        sha256 = str(raw["sha256"])
     except KeyError as exc:
         raise ManifestError(f"{where}: file missing required key {exc}") from exc
+    size = raw.get("size")
+    try:
+        size_int = int(size) if size is not None else None
+    except (ValueError, TypeError) as exc:
+        raise ManifestError(
+            f"{where}: 'size' must be an integer, got {size!r}"
+        ) from exc
+    return FileRef(path=path, sha256=sha256, size=size_int)
 
 
 def _decode_retrieval(raw: Any, where: str) -> Retrieval:
@@ -226,12 +230,18 @@ def _decode_citation(raw: Any, where: str) -> Citation:
     if not isinstance(raw, dict):
         raise ManifestError(f"{where}: 'citation' must be a mapping")
     year = raw.get("publicationYear", raw.get("publication_year"))
+    try:
+        year_int = int(year) if year is not None else None
+    except (ValueError, TypeError) as exc:
+        raise ManifestError(
+            f"{where}: 'publicationYear' must be an integer, got {year!r}"
+        ) from exc
     return Citation(
         identifier=_opt_str(raw.get("identifier")),
         creator=_opt_str(raw.get("creator")),
         title=_opt_str(raw.get("title")),
         publisher=_opt_str(raw.get("publisher")),
-        publication_year=int(year) if year is not None else None,
+        publication_year=year_int,
         resource_type=_opt_str(raw.get("resourceType", raw.get("resource_type"))),
     )
 
@@ -466,6 +476,10 @@ def croissant_for(entry: DatasetEntry) -> dict[str, Any]:
         "@type": "Dataset",
         "name": entry.title or entry.id,
     }
+    # Preserve the stable registry slug so an emit→ingest round-trip recovers the
+    # same `id` (and `title`) instead of collapsing both onto the human name.
+    if entry.title and entry.title != entry.id:
+        doc["alternateName"] = entry.id
     if entry.description:
         doc["description"] = entry.description
     if entry.version:
@@ -506,6 +520,10 @@ def entry_from_croissant(json_ld: dict[str, Any]) -> DatasetEntry:
     name = json_ld.get("name")
     if not name:
         raise ManifestError("croissant: document has no 'name' to derive an id from")
+    # A round-tripped export carries the stable slug in `alternateName`; external
+    # Croissant files won't, so fall back to `name` for the id.
+    entry_id = str(json_ld.get("alternateName") or name)
+    title = str(name) if str(name) != entry_id else None
 
     files: list[FileRef] = []
     for obj in json_ld.get("distribution") or []:
@@ -524,11 +542,19 @@ def entry_from_croissant(json_ld: dict[str, Any]) -> DatasetEntry:
             )
 
     return DatasetEntry(
-        id=str(name),
+        id=entry_id,
         version=_opt_str(json_ld.get("version")),
         license=_opt_str(json_ld.get("license")),
+        title=title,
         description=_opt_str(json_ld.get("description")),
         pid=_opt_str(json_ld.get("identifier")),
         files=files,
-        citation=Citation(title=str(name)) if json_ld.get("citeAs") else None,
+        citation=(
+            Citation(
+                title=title or str(name),
+                identifier=_opt_str(json_ld.get("identifier")),
+            )
+            if json_ld.get("citeAs")
+            else None
+        ),
     )

--- a/honest-scholar/honest_scholar/defend/record.py
+++ b/honest-scholar/honest_scholar/defend/record.py
@@ -88,9 +88,13 @@ def _set_field(fm_lines: list[str], key: str, value: str) -> list[str]:
             break
         match = key_pat.match(line)
         if match:
+            # A YAML comment needs whitespace before '#' (or the value is entirely
+            # a comment); a '#' *inside* a value is not a comment delimiter.
+            raw_value = match.group(1)
             comment = ""
-            if "#" in match.group(1):
-                comment = "  # " + match.group(1).split("#", 1)[1].strip()
+            cmatch = re.search(r"\s#(.*)$", f" {raw_value}")
+            if cmatch:
+                comment = f"  # {cmatch.group(1).strip()}"
             lines[i] = f"{child_indent}{key}: {value}{comment}"
             return lines
 

--- a/honest-scholar/honest_scholar/exploration/backlog.py
+++ b/honest-scholar/honest_scholar/exploration/backlog.py
@@ -125,20 +125,28 @@ class Backlog:
         """
         header: list[str] | None = None
         rows: list[Row] = []
+        candidate: list[str] | None = None
         for line in text.splitlines():
             if "|" not in line:
+                candidate = None  # prose breaks a pending header candidate
                 continue
             cells = _split_cells(line)
             if _is_separator(cells):
+                # The GFM separator confirms the preceding pipe line was the header;
+                # this is what distinguishes the table from stray prose pipes.
+                if header is None and candidate is not None:
+                    header = candidate
+                    candidate = None
                 continue
             if header is None:
-                header = cells
+                candidate = cells  # a header only if a separator follows it
                 continue
-            row = {
-                header[i]: (cells[i] if i < len(cells) else "")
-                for i in range(len(header))
-            }
-            rows.append(row)
+            rows.append(
+                {
+                    header[i]: (cells[i] if i < len(cells) else "")
+                    for i in range(len(header))
+                }
+            )
         return cls(level=level, rows=rows)
 
     @classmethod

--- a/honest-scholar/honest_scholar/literature/graph.py
+++ b/honest-scholar/honest_scholar/literature/graph.py
@@ -13,8 +13,8 @@ the module is exercised offline in tests. Design:
 
 .. note::
    Endpoint shapes follow the public OpenAlex / S2 documentation; the code is
-   covered by mocked-transport tests. Validation against the live services is a
-   follow-up (see the PR).
+   covered by mocked-transport tests. Validation against the live services is
+   tracked in honest-scholar#30.
 """
 
 from __future__ import annotations
@@ -122,6 +122,51 @@ def _fetch_work(client: HttpClient, openalex_id: str) -> dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
+def _arxiv_doi(arxiv_id: str) -> str:
+    """Build the arXiv DataCite DOI for an arXiv id, dropping any ``vN`` suffix.
+
+    arXiv registers one DOI per paper (``10.48550/arXiv.<id>``) with no version
+    component, so a versioned id like ``2205.11775v4`` must have the suffix
+    stripped before the lookup — otherwise it resolves to a non-existent DOI.
+    """
+    unversioned = re.sub(r"v\d+$", "", arxiv_id)
+    return f"10.48550/arXiv.{unversioned}"
+
+
+def _lookup_url(kind: str, norm: str) -> str | None:
+    """Map a ``(kind, normalized-id)`` pair to its OpenAlex work-lookup URL."""
+    return {
+        "openalex": f"{OPENALEX}/works/{norm}",
+        "doi": f"{OPENALEX}/works/doi:{norm}",
+        "arxiv": f"{OPENALEX}/works/doi:{_arxiv_doi(norm)}",
+    }.get(kind)
+
+
+def _s2_crossref(client: HttpClient, s2_id: str) -> tuple[str, str] | None:
+    """Cross-reference a Semantic Scholar id to a ``(kind, id)`` OpenAlex anchor.
+
+    OpenAlex has no S2 lookup, so an S2 id (``CorpusId:…`` / SHA) is resolved
+    through S2's ``externalIds`` to a DOI or arXiv id that OpenAlex *does* index.
+
+    :returns: ``("doi", …)`` / ``("arxiv", …)``, or ``None`` if S2 misses or the
+        paper carries no DOI/arXiv cross-reference.
+    """
+    from honest_scholar.core.http import HttpError
+
+    try:
+        paper = client.get_json(
+            f"{S2}/paper/{s2_id}", {"fields": "externalIds"}, s2=True
+        )
+    except HttpError:
+        return None
+    ext = (paper.get("externalIds") or {}) if isinstance(paper, dict) else {}
+    if ext.get("DOI"):
+        return "doi", str(ext["DOI"])
+    if ext.get("ArXiv"):
+        return "arxiv", str(ext["ArXiv"])
+    return None
+
+
 def resolve(identifier: str, *, client: HttpClient) -> dict[str, Any]:
     """Resolve any identifier to a canonical work record.
 
@@ -133,11 +178,15 @@ def resolve(identifier: str, *, client: HttpClient) -> dict[str, Any]:
     from honest_scholar.core.http import HttpError
 
     kind, norm = _classify(identifier)
-    lookup = {
-        "openalex": f"{OPENALEX}/works/{norm}",
-        "doi": f"{OPENALEX}/works/doi:{norm}",
-        "arxiv": f"{OPENALEX}/works/doi:10.48550/arXiv.{norm}",
-    }.get(kind)
+    if kind == "s2":
+        xref = _s2_crossref(client, norm)
+        if xref is None:
+            return {
+                "resolved": False,
+                "reason": f"could not cross-reference S2 id {norm!r} to a DOI/arXiv",
+            }
+        kind, norm = xref
+    lookup = _lookup_url(kind, norm)
     if lookup is None:
         return {"resolved": False, "reason": f"unsupported identifier kind: {kind}"}
     try:
@@ -198,26 +247,111 @@ def refs(openalex_id: str, *, client: HttpClient) -> list[str]:
     return [rid for ref in work.get("referenced_works", []) if (rid := _short_id(ref))]
 
 
+def _s2_paper_id(record: dict[str, Any]) -> str | None:
+    """Pick an S2-addressable id (``DOI:…`` / ``ARXIV:…``) for an enriched work."""
+    ids = record.get("id", {})
+    if ids.get("doi"):
+        return f"DOI:{ids['doi']}"
+    if ids.get("arxiv"):
+        unversioned = re.sub(r"v\d+$", "", str(ids["arxiv"]))
+        return f"ARXIV:{unversioned}"
+    return None
+
+
+def _s2_context(client: HttpClient, s2_paper_id: str) -> dict[str, Any]:
+    """Aggregate a work's incoming S2 citation edges into a per-work context bundle.
+
+    S2 exposes citation context / SciCite intent / ``isInfluential`` per *edge*
+    (``/paper/{id}/citations``); for a work in isolation we surface a representative
+    citing sentence and intent plus whether *any* citation is influential. Returns
+    ``{s2, context_snippet, intent, is_influential}`` (each ``None`` when absent);
+    an S2 miss/error yields all-``None`` (best effort — the key was still used).
+    """
+    from honest_scholar.core.http import HttpError
+
+    out: dict[str, Any] = {
+        "s2": None,
+        "context_snippet": None,
+        "intent": None,
+        "is_influential": None,
+    }
+    try:
+        meta = client.get_json(
+            f"{S2}/paper/{s2_paper_id}", {"fields": "externalIds"}, s2=True
+        )
+    except HttpError:
+        meta = {}
+    corpus = (
+        (meta.get("externalIds") or {}).get("CorpusId")
+        if isinstance(meta, dict)
+        else None
+    )
+    if corpus is not None:
+        out["s2"] = f"CorpusId:{corpus}"
+    try:
+        page = client.get_json(
+            f"{S2}/paper/{s2_paper_id}/citations",
+            {"fields": "contexts,intents,isInfluential", "limit": "100"},
+            s2=True,
+        )
+    except HttpError:
+        return out
+    edges = page.get("data", []) if isinstance(page, dict) else []
+    for edge in edges:
+        if not isinstance(edge, dict):
+            continue
+        if out["context_snippet"] is None and edge.get("contexts"):
+            out["context_snippet"] = edge["contexts"][0]
+        if out["intent"] is None and edge.get("intents"):
+            out["intent"] = edge["intents"][0]
+        if edge.get("isInfluential"):
+            out["is_influential"] = True
+    if out["is_influential"] is None and edges:
+        out["is_influential"] = False
+    return out
+
+
 def enrich(
     openalex_ids: list[str], *, client: HttpClient, with_context: bool = False
 ) -> list[dict[str, Any]]:
     """Enrich each work id with its metadata bundle.
 
+    With `with_context`, each record also carries ``context_snippet`` / ``intent``
+    / ``is_influential`` from Semantic Scholar (and its ``s2`` id). When **no S2
+    key** is configured those fields degrade to ``null`` with a ``degraded``
+    marker — distinct from "S2 was queried and returned nothing", where the fields
+    are ``null`` *without* the marker.
+
     :param openalex_ids: The works to enrich.
     :param client: The HTTP client.
-    :param with_context: Request S2 citation-context fields; when no S2 key is
-        configured they degrade to ``null`` with a ``degraded`` marker.
+    :param with_context: Attach the S2 citation-context bundle (see above).
     :returns: One enrichment record per id.
     """
     records: list[dict[str, Any]] = []
     for wid in openalex_ids:
         record = enrich_work(_fetch_work(client, wid))
         if with_context:
-            record["context_snippet"] = None
-            record["intent"] = None
-            record["is_influential"] = None
             if not client.s2_key:
+                record["context_snippet"] = None
+                record["intent"] = None
+                record["is_influential"] = None
                 record["degraded"] = ["context", "intent", "is_influential"]
+            else:
+                s2_id = _s2_paper_id(record)
+                bundle = (
+                    _s2_context(client, s2_id)
+                    if s2_id is not None
+                    else {
+                        "context_snippet": None,
+                        "intent": None,
+                        "is_influential": None,
+                    }
+                )
+                if bundle.get("s2"):
+                    record["id"]["s2"] = bundle["s2"]
+                record["context_snippet"] = bundle["context_snippet"]
+                record["intent"] = bundle["intent"]
+                record["is_influential"] = bundle["is_influential"]
         records.append(record)
     return records
 
@@ -269,7 +403,10 @@ def neighbors(
     :param top: Number of neighbours to return per set.
     :param frontier: Max citers/references sampled for the computation.
     :returns: ``{cocitation: [...], coupling: [...], capped: bool}``.
+    :raises ValueError: If `kind` is not ``cocite`` / ``couple`` / ``both``.
     """
+    if kind not in ("cocite", "couple", "both"):
+        raise ValueError(f"unknown kind {kind!r} (want cocite | couple | both)")
     out: dict[str, Any] = {}
     citers = cites(openalex_id, client=client, max_results=frontier)
     out["capped"] = len(citers) >= frontier

--- a/honest-scholar/tests/test_backlog.py
+++ b/honest-scholar/tests/test_backlog.py
@@ -307,3 +307,19 @@ def test_fresh_id_double_collision() -> None:
     board = b.Backlog(level="hypothesis")
     ids = {board.add("same title", "own")["id"] for _ in range(3)}
     assert len(ids) == 3  # base, base-2, base-3
+
+
+def test_loads_ignores_prose_pipes_before_table() -> None:
+    board = b.Backlog(level="hypothesis")
+    board.add("real claim", "own")
+    table = board.dumps()
+    # Prose above the table that itself contains stray pipes must NOT be mistaken
+    # for the header row (which is fixed by the following GFM separator).
+    doc = (
+        "|---|---|\n\n"  # a stray separator with no pending header candidate
+        "Notes: we compare cost | benefit | effort here.\n\n"
+        "Another | stray | prose line with no separator\n\n" + table
+    )
+    reloaded = b.Backlog.loads(doc, "hypothesis")
+    assert [r["one-line"] for r in reloaded.rows] == ["real claim"]
+    assert reloaded.columns == board.columns  # header taken from the real table

--- a/honest-scholar/tests/test_literature.py
+++ b/honest-scholar/tests/test_literature.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from honest_scholar import cli
@@ -413,3 +414,182 @@ def test_neighbors_couple_only_skips_self_citer() -> None:
     out = graph.neighbors("W1", client=_client(routes), kind="couple", frontier=10)
     assert out["coupling"] == [{"openalex": "W2", "score": 1}]  # self W1 skipped
     assert "cocitation" not in out
+
+
+# --- S2 enrichment + resolve cross-reference (honest-scholar#31) --------------
+
+_S2 = "https://api.semanticscholar.org/graph/v1"
+
+
+def test_resolve_versioned_arxiv_strips_suffix() -> None:
+    work = {"id": "https://openalex.org/W7", "display_name": "T"}
+    # the DOI has no version component; a v4 suffix must be dropped
+    client = _client(
+        {"https://api.openalex.org/works/doi:10.48550/arXiv.2205.11775": work}
+    )
+    assert graph.resolve("arXiv:2205.11775v4", client=client)["resolved"] is True
+
+
+def test_resolve_s2_id_crossrefs_via_doi() -> None:
+    client = _client(
+        {
+            f"{_S2}/paper/CorpusId:12345": {"externalIds": {"DOI": "10.1234/abc"}},
+            "https://api.openalex.org/works/doi:10.1234/abc": _WORK,
+        }
+    )
+    rec = graph.resolve("CorpusId:12345", client=client)
+    assert rec["resolved"] is True
+    assert rec["openalex"] == "W1"
+
+
+def test_resolve_s2_id_crossrefs_via_arxiv() -> None:
+    work = {"id": "https://openalex.org/W7", "display_name": "T"}
+    client = _client(
+        {
+            f"{_S2}/paper/CorpusId:7": {"externalIds": {"ArXiv": "2205.11775"}},
+            "https://api.openalex.org/works/doi:10.48550/arXiv.2205.11775": work,
+        }
+    )
+    assert graph.resolve("CorpusId:7", client=client)["openalex"] == "W7"
+
+
+def test_resolve_s2_crossref_miss_is_not_fatal() -> None:
+    rec = graph.resolve("CorpusId:404", client=_client({}))  # S2 404
+    assert rec["resolved"] is False
+    assert "cross-reference" in rec["reason"]
+
+
+def test_resolve_s2_no_external_ids_is_miss() -> None:
+    client = _client({f"{_S2}/paper/CorpusId:8": {"externalIds": {}}})
+    assert graph.resolve("CorpusId:8", client=client)["resolved"] is False
+
+
+def test_enrich_with_key_populates_s2_context() -> None:
+    client = _client(
+        {
+            "https://api.openalex.org/works/W1": _WORK,
+            f"{_S2}/paper/DOI:10.1234/abc": {"externalIds": {"CorpusId": 999}},
+            f"{_S2}/paper/DOI:10.1234/abc/citations": {
+                "data": [
+                    {
+                        "contexts": ["as shown in"],
+                        "intents": ["methodology"],
+                        "isInfluential": True,
+                    },
+                    # a second edge: snippet/intent already set, so it is skipped
+                    {
+                        "contexts": ["also"],
+                        "intents": ["background"],
+                        "isInfluential": False,
+                    },
+                ]
+            },
+        },
+        s2_key="k",
+    )
+    rec = graph.enrich(["W1"], client=client, with_context=True)[0]
+    assert "degraded" not in rec
+    assert rec["context_snippet"] == "as shown in"
+    assert rec["intent"] == "methodology"
+    assert rec["is_influential"] is True
+    assert rec["id"]["s2"] == "CorpusId:999"
+
+
+def test_enrich_with_key_via_arxiv_id() -> None:
+    work = {
+        "id": "https://openalex.org/W2",
+        "ids": {"arxiv": "https://arxiv.org/abs/2205.11775v2"},
+    }
+    client = _client(
+        {
+            "https://api.openalex.org/works/W2": work,
+            f"{_S2}/paper/ARXIV:2205.11775": {"externalIds": {}},  # no CorpusId
+            f"{_S2}/paper/ARXIV:2205.11775/citations": {
+                "data": ["not-a-dict", {"contexts": ["x"], "intents": []}]
+            },
+        },
+        s2_key="k",
+    )
+    rec = graph.enrich(["W2"], client=client, with_context=True)[0]
+    assert rec["context_snippet"] == "x"
+    assert rec["intent"] is None
+    assert rec["is_influential"] is False  # edges present, none influential
+    assert rec["id"]["s2"] is None
+
+
+def test_enrich_with_key_no_addressable_id() -> None:
+    work = {"id": "https://openalex.org/W3", "display_name": "T"}  # no doi/arxiv
+    client = _client({"https://api.openalex.org/works/W3": work}, s2_key="k")
+    rec = graph.enrich(["W3"], client=client, with_context=True)[0]
+    assert rec["context_snippet"] is None
+    assert "degraded" not in rec
+
+
+def test_enrich_with_key_empty_citations_leaves_influential_none() -> None:
+    client = _client(
+        {
+            "https://api.openalex.org/works/W1": _WORK,
+            f"{_S2}/paper/DOI:10.1234/abc": {"externalIds": {"CorpusId": 1}},
+            f"{_S2}/paper/DOI:10.1234/abc/citations": {"data": []},
+        },
+        s2_key="k",
+    )
+    rec = graph.enrich(["W1"], client=client, with_context=True)[0]
+    assert rec["is_influential"] is None
+
+
+def test_enrich_with_key_citations_error_returns_partial() -> None:
+    # meta resolves (s2 id set) but the citations sub-resource 404s
+    client = _client(
+        {
+            "https://api.openalex.org/works/W1": _WORK,
+            f"{_S2}/paper/DOI:10.1234/abc": {"externalIds": {"CorpusId": 2}},
+        },
+        s2_key="k",
+    )
+    rec = graph.enrich(["W1"], client=client, with_context=True)[0]
+    assert rec["id"]["s2"] == "CorpusId:2"
+    assert rec["context_snippet"] is None
+
+
+def test_enrich_with_key_meta_error_still_reads_citations() -> None:
+    # meta 404s (no CorpusId) but citations resolve
+    client = _client(
+        {
+            "https://api.openalex.org/works/W1": _WORK,
+            f"{_S2}/paper/DOI:10.1234/abc/citations": {
+                "data": [
+                    {"contexts": ["c"], "intents": ["result"], "isInfluential": False}
+                ]
+            },
+        },
+        s2_key="k",
+    )
+    rec = graph.enrich(["W1"], client=client, with_context=True)[0]
+    assert rec["id"]["s2"] is None
+    assert rec["context_snippet"] == "c"
+    assert rec["is_influential"] is False
+
+
+def test_neighbors_rejects_unknown_kind() -> None:
+    with pytest.raises(ValueError, match="unknown kind"):
+        graph.neighbors("W1", client=_client({}), kind="bogus")
+
+
+def test_cli_neighbors_bad_kind_exits_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    routes = {"https://api.openalex.org/works/W1": _WORK}
+    monkeypatch.setattr(cli, "_lit_client", lambda: _client(routes))
+    result = runner.invoke(app, ["literature", "neighbors", "W1", "--kind", "bogus"])
+    assert result.exit_code == 1
+
+
+def test_lit_client_rejects_non_mapping_config(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    cfg = tmp_path / ".honest-scholar"
+    cfg.mkdir()
+    (cfg / "config.yml").write_text("- not\n- a mapping\n", encoding="utf-8")
+    with pytest.raises(typer.Exit) as exc:
+        cli._lit_client()
+    assert exc.value.exit_code == 1

--- a/honest-scholar/tests/test_manifest.py
+++ b/honest-scholar/tests/test_manifest.py
@@ -365,3 +365,50 @@ def test_croissant_minimal_entry_omits_absent_fields() -> None:
     assert doc["name"] == "bare"
     for absent in ("version", "license", "description", "identifier", "distribution"):
         assert absent not in doc
+
+
+# --- input hardening + round-trip fidelity (honest-scholar#31) ---------------
+
+
+def test_decode_file_non_numeric_size_is_clean_error(tmp_path: Path) -> None:
+    text = (
+        "datasets:\n  - id: x\n    files:\n"
+        f"      - path: f\n        sha256: {_HEX}\n        size: not-a-number\n"
+    )
+    with pytest.raises(m.ManifestError, match="'size' must be an integer"):
+        m.load(_write(tmp_path, text))
+
+
+def test_decode_citation_non_numeric_year_is_clean_error(tmp_path: Path) -> None:
+    text = (
+        "datasets:\n  - id: x\n    citation:\n"
+        "      title: T\n      publicationYear: last-year\n"
+    )
+    with pytest.raises(m.ManifestError, match="'publicationYear' must be an integer"):
+        m.load(_write(tmp_path, text))
+
+
+def test_croissant_round_trip_preserves_id_and_title() -> None:
+    entry = m.DatasetEntry(
+        id="stable-slug",
+        version="1.0",
+        license="MIT",
+        title="A Human Title",
+        files=[m.FileRef(path="f", sha256=_HEX)],
+        citation=m.Citation(title="A Human Title", identifier="doi:10.1/x"),
+        pid="doi:10.1/x",
+    )
+    doc = m.croissant_for(entry)
+    assert doc["name"] == "A Human Title"
+    assert doc["alternateName"] == "stable-slug"  # slug preserved for round-trip
+    back = m.entry_from_croissant(doc)
+    assert back.id == "stable-slug"  # id is NOT collapsed onto the human name
+    assert back.title == "A Human Title"
+    assert back.citation is not None
+    assert back.citation.identifier == "doi:10.1/x"
+
+
+def test_croissant_no_alternate_name_when_title_equals_id() -> None:
+    doc = m.croissant_for(m.DatasetEntry(id="same", title="same"))
+    assert "alternateName" not in doc
+    assert m.entry_from_croissant(doc).id == "same"

--- a/honest-scholar/uv.lock
+++ b/honest-scholar/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "honest-scholar"
-version = "0.0.0a0"
+version = "0.0.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "pooch" },


### PR DESCRIPTION
## What

The **package-code cluster** of the release-readiness audit (#31): the B3 blocker plus the SHOULD "crash-on-bad-input" and robustness items. No CLI surface changes; the 100% coverage gate holds (184 tests).

## B3 — Semantic Scholar enrichment was advertised but never called

- **`enrich(--context)` now actually queries S2.** It aggregates a work's incoming citation edges (`/paper/{id}/citations`) into `context_snippet` / `intent` / `is_influential` and attaches the `CorpusId`. Critically, the `degraded` marker now means **only** "no key → not queried"; a *key-present-but-empty* S2 result leaves the fields `null` **without** the marker, so a caller can finally distinguish "S2 returned nothing" from "S2 was never queried."
- **`resolve` accepts the S2 ids it advertises.** An S2 id (`CorpusId:…` / SHA) is cross-referenced through S2 `externalIds` to a DOI/arXiv that OpenAlex indexes (OpenAlex has no direct S2 lookup).
- **Versioned arXiv ids** (`2205.11775v4`) drop the `vN` suffix before building the DataCite DOI — previously they resolved to a non-existent `…arXiv.2205.11775v4` DOI.
- **`neighbors` rejects an unknown `--kind`** (was a silent empty result, unlike the guarded `--level`).

### Design note (edge- vs. work-scoped context)
S2 exposes context / SciCite intent / `isInfluential` per **citation edge**. For a work in isolation `enrich` surfaces a *representative* citing sentence + intent and whether *any* citation is influential. This honors the proposal's documented `enrich` field bundle without inventing a per-work value that doesn't exist. Live-service validation remains tracked in #30.

## Input hardening (tracebacks → clean errors)

- **manifest** — non-numeric `size:` / `publicationYear:` now raise `ManifestError` (were uncaught `ValueError`s: `int()` was inside a `try` catching only `KeyError`, or not guarded at all).
- **cli** — a non-mapping `.honest-scholar/config.yml` exits 1 with a message instead of a traceback from `_lit_client`.

## Robustness

- **Croissant** emit→ingest round-trip preserves the registry **slug** (carried in `alternateName`) and **title**, instead of collapsing both onto the human `name` (id mutation).
- **defend record** — comment preservation only treats a `#` preceded by whitespace as a YAML comment; a `#` *inside* a value is no longer misread as a delimiter.
- **backlog parser** — the GFM separator row now identifies the header, so stray prose pipes above the table no longer get parsed as the header.

## Also

- Corrected the `cli.py` module docstring (it called the sub-commands "typed stubs" — a B1 stale-self-description item; they are all implemented).

Part of #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)