### PR TITLE
docs: version-truth + lead-with-utility messaging (#28)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,7 +16,7 @@ authors:
     email: davor@synthpop.ai
 repository-code: "https://github.com/davorrunje/honest-scholar"
 url: "https://github.com/davorrunje/honest-scholar"
-version: 0.0.0a0
+version: 0.0.0b0
 license: Apache-2.0
 keywords:
   - research integrity

--- a/README.md
+++ b/README.md
@@ -13,24 +13,33 @@
 
 ---
 
-**`honest-scholar`** helps you keep research honest — *especially now that AI is in
-the loop*. It is a uniform, git-native Claude Code plugin for the *scientific*
-research workflow — idea → literature → hypothesis → test → publish-decision →
-paper → thesis — so a researcher and their collaborators work the same way and
-re-derive neither the workflow nor its rigor per project. The *engineering* is
-delegated to a bound **engineering backend** via the engineering-delegation
-contract, so `honest-scholar` stays domain- and tool-neutral.
+**`honest-scholar`** gives your whole *scientific* research workflow one uniform,
+git-native home inside Claude Code — idea → literature → hypothesis → test →
+publish-decision → paper → thesis — so you and your collaborators work the same way
+and never re-derive the workflow, or its rigor, per project. Concretely, it:
 
-It does **not** certify that your work is honest — there is no seal of honesty. It
-gives you the *mechanics* to do honest work and to disclose truthfully what you and
-the AI each did; readers judge the result.
+- **scouts and positions the literature** over the citation graph (OpenAlex +
+  Semantic Scholar) — forward/backward citations, co-citation and
+  bibliographic-coupling neighbours, a CSL-JSON bib, and a decision triage sidecar;
+- **runs the hypothesis → test → publish-decision lifecycle** with every result
+  traced to a run-ref, refuted ideas retired (not deleted), and named human sign-off
+  on each material decision;
+- **keeps datasets reproducible** — a tiered registry with SHA-256 fixity, a private
+  rclone mirror, datasheets, and Croissant import/export;
+- **builds and checks your understanding** with a Socratic tutor-examiner
+  (`defend`) so you can actually defend the work in review;
+- **delegates the *engineering*** (design, plans, code) to a bound engineering
+  backend, staying domain- and tool-neutral.
+
+Because AI is in the loop, it is also built so the science stays honestly *yours*
+and defensible (see [The mechanics of honesty](#the-mechanics-of-honesty)).
 
 > **New here?** Start with the **[User Guide](docs/USER-GUIDE.md)**.
 >
-> **Status: `v0.0.0`, early.** The design is complete and recorded (see
-> [Design & reasoning](#design--reasoning)); the skills are a first cut with some
-> supporting-script TODOs. See [`STATUS.md`](STATUS.md) for exactly what is done,
-> stubbed, or pending.
+> **Status: pre-release, actively developed.** The design is complete and recorded
+> (see [Design & reasoning](#design--reasoning)); the skills and their supporting
+> `honest-scholar` CLI are implemented. See [`STATUS.md`](STATUS.md) for the current
+> ledger.
 
 ## The mechanics of honesty
 
@@ -120,9 +129,9 @@ consuming repo's `.claude/settings.json`:
 }
 ```
 
-Pin a release with `"ref": "v0.0.0"` inside the marketplace `source` if you want a
-fixed version rather than the default branch. **Status:** early — see
-[`STATUS.md`](STATUS.md).
+By default this tracks the plugin's `main`. Once a plugin release is tagged you can
+pin it by adding a `"ref": "<tag>"` inside the marketplace `source` for a fixed
+version. See [`STATUS.md`](STATUS.md) for the current state.
 
 ## Design & reasoning
 
@@ -134,9 +143,9 @@ The design is captured in three complementary layers:
   with the options considered and the **rejected alternatives and why**.
 - **Reference digests** — the *evidence*: [`resources/references/`](resources/references/)
   — verified primary-source digests behind each skill and principle.
-- **Open proposals (drafts)** — [`docs/design/proposals/`](docs/design/proposals/):
-  first-draft specs for the not-yet-built supporting scripts and for cross-repo
-  thesis aggregation, pending discussion.
+- **Proposals** — [`docs/design/proposals/`](docs/design/proposals/): the design
+  specs for the `honest-scholar` CLI modules (now implemented) and for cross-repo
+  thesis aggregation.
 
 Also: the [User Guide](docs/USER-GUIDE.md), the commit-attribution / discovery
 convention ([`resources/commit-attribution.md`](resources/commit-attribution.md)),

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,69 +1,55 @@
-# honest-scholar — build status
+# honest-scholar — status
 
-Built 2026-07-17/18 (initial cut autonomously while the author was away, then
-extended). Commits are authored by **Davor Runje** with `Co-Authored-By: Claude`,
-unsigned. Released `v0.0.0`.
+An honest ledger of what is **done**, **in progress**, and **planned**.
+`honest-scholar` ships two independently-versioned artifacts:
 
-This file is the honest ledger of what is **done**, **drafted**, or **pending**.
-`honest-scholar` is a Claude Code plugin: its primary deliverable is the **skill
-instruction files** (`skills/*/SKILL.md`) plus templates, contracts, and the
-migrated design record. There is intentionally little heavy Python — skills
-orchestrate existing tools (git, gh, rclone, curl→OpenAlex/Semantic Scholar,
-pandoc) and delegate engineering to the bound engineering backend via the
-engineering-delegation contract.
+- the **plugin** — the skill instruction files (`skills/*/SKILL.md`) plus
+  templates, contracts, and the migrated design record (its primary deliverable);
+- the **`honest-scholar` package** — the CLI those skills call, published to PyPI
+  and installed isolated from your project's ML environment.
+
+Commits are authored by **Davor Runje** with a `Co-Authored-By: Claude` trailer.
 
 ## Done
 
-- Public repo created (`davorrunje/honest-scholar`), Apache-2.0.
-- Plugin manifest (`.claude-plugin/plugin.json`), README, `.gitignore`.
-- Design record migrated from the design session:
-  - `docs/design/` — meta-spec + 4 sub-specs.
-  - `decisions/` — 22 MADR ADRs + index.
-  - `resources/references/` — 8 verified-source digests.
-  - `assets/` + `docs/design/visual-identity.md` — v1 visual identity.
-- **All 10 `skills/*/SKILL.md`** authored from the sub-specs (each with valid
+- **All 10 skills** authored and reviewed (`skills/*/SKILL.md`, each with valid
   `name`/`description` frontmatter): `research-init`, `hypothesis-exploration`,
   `hypothesis-testing`, `paper-exploration`, `paper-synthesis`, `thesis`,
   `literature`, `dataset`, `progress`, `defend`.
-  *(The commit that introduced them says "7 skill files" — a cosmetic undercount;
-  all 10 landed in that commit.)*
-- Shared resources: `resources/contracts/experiment-backend.md`,
-  `resources/substrate/asset-registry.md`, `resources/rigor/rigor-kit.md`.
-- `resources/templates/` — 12 staged-doc templates (hypothesis / paper / thesis)
-  with the `progress` status-frontmatter, rigor prompts in strategy/findings,
-  named human sign-off on material-decision docs, and a Toulmin-sextet ledger.
-- **Released `v0.0.0`** — self-marketplace (`.claude-plugin/marketplace.json`,
-  `claude plugin validate` ✔); install via `/plugin marketplace add davorrunje/honest-scholar`
-  then `/plugin install honest-scholar@honest-scholar`. mononet enables it in `.claude/settings.json`
-  (mononet PR #131).
-- **`docs/USER-GUIDE.md`** — end-to-end onboarding (install → `research-init` →
-  the hypothesis/paper/thesis loop → progress/defend), domain-neutral example.
-- **Commit attribution / discovery** — `resources/commit-attribution.md` + a
-  `## Commit attribution` footer on every skill (`Generated-with: honest-scholar` +
-  `HonestScholar-Skill:` trailers).
-- **`docs/design/proposals/`** — 6 first-draft specs (for discussion) for the
-  supporting-script TODOs + cross-repo thesis aggregation. Each is tracked by an
-  issue: **honest-scholar#1–5** (literature graph client; dataset manifest tooling;
-  dataset retrieval/mirror; defend record helper; exploration backlog helper) and
-  **mononet#132** (cross-repo aggregation).
+- **The `honest-scholar` CLI is implemented** and JSON-emitting across all groups:
+  `literature` (citation graph over OpenAlex + Semantic Scholar), `dataset`
+  (manifest / Croissant / SHA-256 retrieval / rclone mirror / audit),
+  `defend record`, `backlog`, and `doctor` — with a strict-mypy, 100%-covered test
+  suite. The design specs live under `docs/design/proposals/`.
+- **Design record** migrated from the design session: `docs/design/` (meta-spec +
+  4 sub-specs), `decisions/` (MADR ADRs + index), `resources/references/` (verified
+  primary-source digests), and the v1 visual identity.
+- **Shared resources**: experiment-backend + engineering contracts, the asset
+  registry / substrate, the rigor kit, and the staged-doc templates (hypothesis /
+  paper / thesis) with the `progress` status-frontmatter, rigor prompts, named
+  human sign-off, and a Toulmin-sextet ledger.
+- **Docs**: `README.md`, `docs/USER-GUIDE.md`, `DISCLOSURE.md`, `RELEASING.md`,
+  `CONTRIBUTING.md`, and the commit-attribution / discovery convention.
+- **Packaging & CI**: self-marketplace (`.claude-plugin/marketplace.json`,
+  `claude plugin validate` ✔); CI matrix, coverage gate, and PyPI Trusted
+  Publishing via GitHub Releases.
 
-## Pending (needs the author, or a follow-up)
+## In progress
 
-- **Review of every SKILL.md** — first-cut drafts; adjust tone/behavior, esp. the
-  `defend` guardrail and the agency/understanding wording.
-- **Discuss the 6 draft proposals**, then implement the supporting scripts
-  (tracked: honest-scholar#1–5, mononet#132). Currently each skill uses an interim
-  tool-orchestrated approach.
-- Plan-time open items from the sub-specs (ledger schema, status-frontmatter
-  fields, `.honest-scholar/` naming, thesis-milestone schema, the engineering-backend
-  delegation seam).
-- Reconcile with PR #128's four earlier research-workflow reference docs in
-  `mononet` (superseded by this repo — close/repoint).
+- **First final release (`v0.1.0`)** — the release-readiness cleanup is underway
+  (see the `v0.1.0` milestone and the linked issues). The package currently
+  publishes as a pre-release (`0.0.0b0`) to TestPyPI/PyPI for validation.
 
-## How to review in the morning
+## Planned
 
-1. Read this file + `README.md`.
-2. Skim `docs/design/00-meta-spec.md` (the whole picture) and `decisions/README.md`.
-3. Read the `skills/*/SKILL.md` you care about most first — suggest `defend`,
+- A citable **arXiv report** describing the skills and their rationale — ideally
+  written *using* `honest-scholar` itself (the preferred citation once it exists).
+- Cross-repo thesis aggregation (design in `docs/design/proposals/`).
+
+## How to review
+
+1. Read this file + [`README.md`](README.md).
+2. Skim [`docs/design/00-meta-spec.md`](docs/design/00-meta-spec.md) (the whole
+   picture) and [`decisions/README.md`](decisions/README.md).
+3. Read the `skills/*/SKILL.md` you care about most — suggest `defend`,
    `hypothesis-testing`, `literature`.
-4. Anything wrong or off-tone: it is all committed in small steps, easy to amend.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -76,10 +76,11 @@ consuming repo's `.claude/settings.json`:
 }
 ```
 
-Commit that file and every collaborator gets the same skills auto-enabled. Pin a
-release with `"ref": "v0.0.0"` inside the marketplace `source` for a fixed
-version. Skills are invoked by name (`research-init`, `hypothesis-testing`, …) in
-your Claude Code session.
+Commit that file and every collaborator gets the same skills auto-enabled. This
+tracks the plugin's `main`; once a plugin release is tagged you can pin it with a
+`"ref": "<tag>"` inside the marketplace `source` for a fixed version. Skills are
+invoked by name (`research-init`, `hypothesis-testing`, …) in your Claude Code
+session.
 
 ## 3. First-time setup: `research-init`
 

--- a/honest-scholar/README.md
+++ b/honest-scholar/README.md
@@ -33,16 +33,16 @@ Pre-releases are on TestPyPI (`--index-url https://test.pypi.org/simple/
 
 ```
 honest-scholar --version
-honest-scholar doctor                                        # environment report (implemented)
-honest-scholar literature resolve|cites|refs|enrich|neighbors   # issue #1
-honest-scholar dataset    validate|ingest|emit                    # issue #2
-honest-scholar dataset    fetch|verify|mirror|audit               # issue #3
-honest-scholar defend     record                                # issue #4
-honest-scholar backlog    park|add|list|rank|promote|drop       # issue #5
+honest-scholar doctor                                           # environment report
+honest-scholar literature resolve|cites|refs|enrich|neighbors   # citation graph (OpenAlex + S2)
+honest-scholar dataset    validate|ingest|emit                  # manifest + Croissant
+honest-scholar dataset    fetch|verify|mirror|audit             # SHA-256 retrieval + rclone mirror
+honest-scholar defend     record                                # understanding-status record
+honest-scholar backlog    park|add|list|rank|promote|drop       # exploration backlog
 ```
 
-Currently only `doctor` and `--version` are implemented; the domain sub-commands
-are typed stubs exiting with a pointer to their tracking issue.
+Every command is implemented and emits JSON (the skills parse it). Network- and
+`rclone`-backed commands degrade gracefully when a key or the binary is absent.
 
 ## Learn more
 


### PR DESCRIPTION
## What

The **top-level docs cluster** of the release-readiness audit (#31) — the B1/B2 blockers — **plus the messaging rework you asked me to draft for review (#28).**

## Version truth (B2)

A false release claim is the worst inaccuracy for an honesty-branded project.

- **`STATUS.md`** no longer says *"Released `v0.0.0`"* (no such release ever happened; last artifact is the pre-release `0.0.0a0`, package is mid-beta). Rewritten as an accurate two-artifact ledger (plugin + package), dropping the interim / "pending proposals" framing and the leaked cross-repo **mononet** PR references (#128 / #131 / #132).
- **README + USER-GUIDE** no longer tell users to pin `"ref": "v0.0.0"` — a tag that doesn't exist. They now describe tracking `main` and pinning a real tag once a plugin release is cut.
- **`CITATION.cff`** tracks the current package version (`0.0.0b0`). *(Wiring the bump action to update it is a CI follow-up.)*

## Stale self-description (B1)

- The **PyPI landing page** (`honest-scholar/README.md`) — the first thing every `pip/uv install` user reads — no longer claims *"only `doctor` and `--version` are implemented; the domain sub-commands are typed stubs."* Every command is implemented; the CLI table drops the closed `# issue #N` annotations and says what each group does.

## Messaging — lead with utility (#28) ← **please review**

The audit found the README opened with three honesty framings + the disclaimer before naming a single capability, and *"does not certify honesty"* appeared **3×** on the reader's path.

- The **README opening now leads with what honest-scholar *does for research*** — citation-graph literature scouting (OpenAlex + S2), the hypothesis → test → publish-decision lifecycle with run-ref provenance, dataset SHA-256 fixity + Croissant, and the `defend` tutor — as a concrete bullet list, *then* the honesty framing.
- **"does not certify honesty" now appears once** (the single canonical disclaimer, in the disclosure section) instead of three times.

The honesty message is not weakened — it's still the tagline, a dedicated "mechanics of honesty" section, and the disclosure section. It just no longer buries the utility. Happy to dial the balance either way.

Part of #31; implements #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)