### PR TITLE
docs(design): fix broken links, flip statuses to implemented, add 3 ADRs

### DIFF
--- a/decisions/0026-independent-versioning-compat-pin.md
+++ b/decisions/0026-independent-versioning-compat-pin.md
@@ -1,0 +1,60 @@
+# ADR-0026: Independent plugin/package versioning with a compatibility pin
+
+- Status: accepted · Date: 2026-07-19 · Deciders: Davor Runje
+
+## Context
+
+`honest-scholar` ships two artifacts on different release cadences: the **plugin**
+(markdown skills, distributed via the git self-marketplace) and the
+**`honest-scholar` package** (the Typer CLI the skills call, published to PyPI,
+ADR-0024). A skill change and a CLI change rarely land together, and the plugin has
+no build step while the package follows PEP 440. Locking the two to one version
+number would force empty "release" bumps on whichever artifact didn't change and
+couple two independent audiences (plugin users vs. `pip`/`uv` installers).
+
+## Decision drivers
+
+- The two artifacts change independently; a shared version invents false churn.
+- A skill still needs *some* guarantee that the CLI it shells out to speaks the
+  commands it expects — independence must not mean silent drift.
+- Keep the release mechanics simple and each version scheme idiomatic (semver for
+  the plugin manifest; PEP 440 for the Python package).
+
+## Considered options
+
+1. **Independent versions + a compatibility pin** — the plugin (`plugin.json`,
+   semver) and the package (`pyproject.toml`, PEP 440) version separately; the
+   skills' `ensure-tooling` bootstrap pins a compatible package range
+   (`honest-scholar>=<min>,<<next-major>`).
+2. **Locked versions** — one number bumped in lockstep across both.
+3. **No pin** — independent, with skills tolerating any installed CLI version.
+
+## Decision
+
+Option 1. The plugin and package version independently. The
+[`ensure-tooling`](../resources/ensure-tooling.md) bootstrap installs/upgrades the
+package to a **compatible range** so a skill never runs against a CLI that predates
+a command it needs. The version-bump automation touches only the package
+(`.github/workflows/bump-version.yml`); the plugin manifest is bumped by hand when
+skills change.
+
+## Consequences
+
+- Each artifact releases on its own cadence with an idiomatic version scheme.
+- The compat range is the contract seam: widen the lower bound when a skill starts
+  relying on a newly added command; bump the upper bound at a CLI major.
+- `CITATION.cff` tracks the **package** version (the citable artifact); it must be
+  kept in step with `pyproject.toml` at release (currently manual).
+
+## Rejected alternatives
+
+- **Locked versions** — forces no-op bumps on the unchanged artifact and couples
+  two unrelated release audiences.
+- **No pin** — reintroduces the silent-drift failure mode (a skill invoking a
+  command an older CLI doesn't have).
+
+## Links
+
+`resources/ensure-tooling.md`; `.claude-plugin/plugin.json`;
+`honest-scholar/pyproject.toml`; `.github/workflows/bump-version.yml`; ADR-0024
+(tooling package + bootstrap).

--- a/decisions/0027-release-driven-oidc-publish.md
+++ b/decisions/0027-release-driven-oidc-publish.md
@@ -1,0 +1,58 @@
+# ADR-0027: Publish the package via GitHub Releases + PyPI Trusted Publishing
+
+- Status: accepted · Date: 2026-07-19 · Deciders: Davor Runje
+
+## Context
+
+The `honest-scholar` package (ADR-0024) is distributed on PyPI, with release
+candidates validated on TestPyPI first. Publishing needs a trigger (when does a
+build go out?) and credentials (how does CI authenticate to the index?). Long-lived
+PyPI API tokens stored as repo secrets are a standing exfiltration risk and drift
+out of rotation; an ad-hoc "push a tag and hope CI runs" flow gives no human
+gate between merging a version bump and shipping it.
+
+## Decision drivers
+
+- **No long-lived secrets** — a leaked token can publish arbitrary releases.
+- A clear, auditable **human gate**: publishing to real PyPI should be a
+  deliberate, recorded act, not a side effect of a merge.
+- Keep **TestPyPI validation** cheap and on-demand before a real release.
+- Reuse GitHub-native primitives; avoid bespoke release scripts.
+
+## Considered options
+
+1. **GitHub Release (published) → PyPI via Trusted Publishing (OIDC); manual
+   `workflow_dispatch` → TestPyPI/PyPI.** Publishing a GitHub Release fires
+   `publish.yml`, which mints a short-lived OIDC token scoped to the repo +
+   workflow + environment and uploads to PyPI. A manual dispatch targets the chosen
+   index (default TestPyPI) for pre-release validation.
+2. **Tag-triggered publish with a stored `PYPI_API_TOKEN`.**
+3. **Fully manual `uv publish` from a maintainer's machine.**
+
+## Decision
+
+Option 1. `.github/workflows/publish.yml` runs on `release: [published]` (real
+PyPI) and on `workflow_dispatch` with a `target` input (`testpypi` default,
+`pypi`), authenticating with **PyPI Trusted Publishing (OIDC)** — no tokens.
+Registered trusted publishers exist for both indexes (environments `testpypi` /
+`pypi`). The Docker-based `pypa/gh-action-pypi-publish` step stays at the job top
+level (it cannot be nested in a local composite action); a pure-shell composite
+action annotates the run with the published version.
+
+## Consequences
+
+- Zero long-lived publishing secrets; every upload uses an ephemeral, scoped token.
+- The GitHub Release *is* the human gate and the changelog anchor; pre-releases
+  (a/b/rc) publish when the Release is marked as such.
+- TestPyPI dry-runs are a one-click `workflow_dispatch` before cutting a Release.
+- Requires the trusted-publisher registration to be maintained on both indexes.
+
+## Rejected alternatives
+
+- **Stored API token** — long-lived secret; broader blast radius; rotation burden.
+- **Manual local publish** — unauditable, non-reproducible, bypasses CI.
+
+## Links
+
+`.github/workflows/publish.yml`; `.github/actions/report-published/`;
+`RELEASING.md`; ADR-0024 (tooling package); ADR-0026 (independent versioning).

--- a/decisions/0028-100-percent-coverage-gate.md
+++ b/decisions/0028-100-percent-coverage-gate.md
@@ -1,0 +1,58 @@
+# ADR-0028: 100% statement + branch coverage gate on the package
+
+- Status: accepted · Date: 2026-07-19 · Deciders: Davor Runje
+
+## Context
+
+The `honest-scholar` package (ADR-0024) is small, pure-functional at its core, and
+built for **reproducibility and honesty** — it is the tooling an integrity-focused
+plugin tells researchers to trust. Its modules parse untrusted input (manifests,
+Croissant, backlog markdown, API JSON) and degrade across missing keys/binaries,
+so the branch behaviour *is* the contract. A partial coverage target invites exactly
+the untested error/degradation paths that later surface as tracebacks in front of a
+user.
+
+## Decision drivers
+
+- The package is small enough that 100% is achievable, not aspirational.
+- Error/degradation branches are the ones most likely to break and least likely to
+  be exercised by hand — precisely what a branch-coverage gate forces.
+- A hard gate keeps every PR honest about its own tests; no slow erosion.
+- Genuinely unreachable/defensive lines shouldn't distort the number.
+
+## Considered options
+
+1. **Hard 100% statement + branch gate (`--cov-branch`, `fail_under = 100`),
+   Codecov for reporting, `# pragma: no cover` on the few genuinely
+   untestable branches (real network errors, the pooch fetch).**
+2. A softer threshold (e.g. 90%) with a ratchet.
+3. Coverage reported but not gated.
+
+## Decision
+
+Option 1. `pyproject.toml` sets `--cov-branch` and `fail_under = 100`; CI fails a
+PR that drops below. Codecov (tokenless OIDC) provides the diff view. The **only**
+exemptions are `# pragma: no cover` on branches that cannot be driven in-process
+(an actual `requests` network exception; the real `pooch` fetch), each annotated
+with the reason. New code arrives with the tests that cover it, including its
+error and degradation paths.
+
+## Consequences
+
+- Every branch — including "no S2 key → degrade", "bad input → clean error",
+  "binary absent → report" — is exercised by a test.
+- The gate is load-bearing on the "honest tooling" claim: the CLI a researcher
+  is told to trust is fully exercised.
+- Contributors must test error paths, not just happy paths; the pragma list is the
+  single audited place where that rule is relaxed.
+
+## Rejected alternatives
+
+- **Softer threshold / ratchet** — permits untested error branches indefinitely;
+  the ratchet tends to stall just below 100%.
+- **Ungated reporting** — coverage decays without a failing signal.
+
+## Links
+
+`honest-scholar/pyproject.toml` (`[tool.pytest.ini_options]`, `[tool.coverage]`);
+`codecov.yml`; `.github/workflows/ci.yml`; ADR-0024 (tooling package).

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -37,5 +37,8 @@ Migrates to the plugin's `decisions/` alongside `resources/references/`.
 | [0023](0023-engineering-delegation-contract.md) | Delegate engineering via a contract, not a named tool | accepted |
 | [0024](0024-tooling-package-and-bootstrap.md) | Supporting tooling = one package (Typer CLI, optional MCP) + markdown `ensure-tooling` bootstrap | accepted |
 | [0025](0025-disclosure-and-citation-growth.md) | Honest AI-use disclosure + citation as the growth mechanism (auto-proposed by `paper-synthesis`) | accepted |
+| [0026](0026-independent-versioning-compat-pin.md) | Independent plugin/package versioning with a compatibility pin | accepted |
+| [0027](0027-release-driven-oidc-publish.md) | Publish via GitHub Releases + PyPI Trusted Publishing (OIDC, no tokens) | accepted |
+| [0028](0028-100-percent-coverage-gate.md) | 100% statement + branch coverage gate on the package | accepted |
 
 Format: MADR (Markdown Any Decision Records). Deciders: Davor Runje (with Claude).

--- a/docs/design/00-meta-spec.md
+++ b/docs/design/00-meta-spec.md
@@ -2,15 +2,23 @@
 
 **Date:** 2026-07-17
 **Author:** Davor Runje
-**Status:** Brainstorming output; parent meta-spec, pending four sub-specs and implementation plans.
+**Status:** Implemented. Parent meta-spec for the `honest-scholar` plugin; the four
+sub-specs (§8) and the CLI proposals (`proposals/`) are realized in this repo.
+Retained as the design record.
 
 > **Scope of this document.** This is the *parent* spec for a new, standalone
 > Claude Code plugin — **`honest-scholar`** — that packages the scientific
-> research-workflow skills currently being designed inside `mononet`
+> research-workflow skills originally designed inside `mononet`
 > (`docs/superpowers/specs/2026-07-15-*`). It establishes the global picture:
 > identity, scope, plugin architecture, the plugin↔consumer boundary, the
-> onboarding skill, distribution, and how the existing in-repo work migrates.
+> onboarding skill, distribution, and how the existing in-repo work migrated.
 > The detailed designs live in four sub-specs (§8). **Read this first.**
+>
+> **Historical note.** The plugin has since been extracted into its own
+> repository (`davorrunje/honest-scholar`) and the migration described in §9 is
+> complete. This document is retained as the design record; where it cites
+> `mononet` PRs or `docs/superpowers/` paths, that is the origin context, not a
+> live dependency.
 
 ## ⚑ Guiding principle — assistants, not researchers
 
@@ -34,9 +42,9 @@ examines and teaches until you can.
 
 Elaborated in §2.1–§2.2; fully grounded, with verified sources and enforceable
 guardrails, in
-[`honest-scholar/references/agency-principle.md`](../honest-scholar/references/agency-principle.md)
+[`resources/references/agency-principle.md`](../../resources/references/agency-principle.md)
 and
-[`honest-scholar/references/understanding-and-defense.md`](../honest-scholar/references/understanding-and-defense.md).
+[`resources/references/understanding-and-defense.md`](../../resources/references/understanding-and-defense.md).
 
 ## 1. Goals & non-goals
 
@@ -137,7 +145,7 @@ judgement points" rule is demanded by the automation-bias literature
 LLM citation fabrication. The positive framing is the augmentation tradition
 (Engelbart 1962; Bush 1945): amplify judgement, do not replace it. Full digest
 with verified sources and the enforceable guardrails:
-[`honest-scholar/references/agency-principle.md`](../honest-scholar/references/agency-principle.md).
+[`resources/references/agency-principle.md`](../../resources/references/agency-principle.md).
 
 ### 2.2 Understanding principle
 
@@ -169,7 +177,7 @@ decision advance past something the author cannot explain or defend — silently
   cited works) and, for novel claims, teaches how to reason and defend.
 
 Fully grounded, with sources and constraints, in
-[`honest-scholar/references/understanding-and-defense.md`](../honest-scholar/references/understanding-and-defense.md).
+[`resources/references/understanding-and-defense.md`](../../resources/references/understanding-and-defense.md).
 
 ### 2.3 The firewall
 
@@ -356,7 +364,7 @@ respecting the firewall by producing evidence the human acts on).
   learning-styles myth) and would violate agency; the rule is *match the voice to
   the task and the author's stated choice, never to an inferred personality.*
   Grounded in
-  [`honest-scholar/references/mentor-personas.md`](../honest-scholar/references/mentor-personas.md).
+  [`resources/references/mentor-personas.md`](../../resources/references/mentor-personas.md).
 
 ## 4. Plugin repo layout
 
@@ -397,7 +405,7 @@ plus the eight generated this session — **citation scouting**, **related-works
 synthesis**, **dataset-management standards**, **dataset tooling / mirror
 architecture**, **thesis-by-publication & progress tracking**, the
 **agency principle**, **the understanding principle & defense**, and **mentor /
-reviewer personas** (all already persisted under `honest-scholar/references/`). These are
+reviewer personas** (all already persisted under `resources/references/`). These are
 the evidentiary base for the sub-specs and must be persisted, not left in
 conversation.
 
@@ -505,7 +513,11 @@ This meta-spec defers detail to four sub-specs (each date-prefixed under
 
 ## 9. Migration of existing in-repo work
 
-The scientific-workflow work currently lives inside `mononet`. It relocates:
+> **Status: complete.** This migration has been executed — the plugin now lives in
+> `davorrunje/honest-scholar` and `mononet` consumes it. The plan is retained below
+> for provenance; the `mononet` PR / path references are the origin context.
+
+The scientific-workflow work originally lived inside `mononet`. It relocated:
 
 - **PR #128** (four research-workflow specs + `docs/research/README.md` + four
   reference digests) → **retargets the `honest-scholar` plugin repo** instead of
@@ -514,9 +526,8 @@ The scientific-workflow work currently lives inside `mononet`. It relocates:
 - **PR #127** (benchmark experiment orchestration) → **stays in `mononet`** as
   its implementation of the experiment-backend contract; it is re-described as
   "mononet's experiment backend" rather than a general facility.
-- The methodology digests (this session's eight + #128's four) → become
-  `resources/references/` in the plugin. This session's eight are already staged
-  under `docs/superpowers/honest-scholar/references/`.
+- The methodology digests (the design session's eight + #128's four) → became
+  `resources/references/` in the plugin (their current home).
 - `mononet` becomes the reference **consumer**: it runs `research-init adopt`
   against itself once the plugin exists.
 
@@ -532,9 +543,9 @@ implementation plans, then the plugin repo is created and `mononet` adopts it.
 - **Plugin license** — *resolved:* Apache-2.0 (ADR-0022).
 - **`literature` one-skill-with-modes** — carried as decided (`scout`/`position`
   in one skill); reconfirm at sub-spec time.
-- **Mirror hash algorithm** — MD5 (lowest common denominator across Google
-  Drive + S3 via rclone) vs SHA-256 (stronger, but disjoint backend hash sets);
-  resolve in sub-spec 3/4.
+- **Mirror hash algorithm** — *resolved:* SHA-256 is authoritative (identity ==
+  integrity == citation-verifiability); rclone's per-backend hash is a transport
+  check only, and bytes are always re-hashed against the manifest (ADR-0011).
 - **`.honest-scholar/` vs existing conventions** — confirm the config directory name
   and that it does not collide with existing repo conventions.
 - **Thesis milestone schema** — the shape of `milestones.yml` (institution

--- a/docs/design/01-lifecycle.md
+++ b/docs/design/01-lifecycle.md
@@ -2,22 +2,22 @@
 
 **Date:** 2026-07-17
 **Author:** Davor Runje
-**Status:** Brainstorming output; sub-spec of the `honest-scholar` meta-spec, pending implementation plan.
+**Status:** Implemented. Sub-spec of the `honest-scholar` meta-spec; realized in this repo (skills + CLI).
 
-> Sub-spec of [2026-07-17-honest-scholar-plugin-design.md](2026-07-17-honest-scholar-plugin-design.md).
+> Sub-spec of [00-meta-spec.md](00-meta-spec.md).
 > The integrative capstone: the three-level lifecycle, the five pipeline skills,
 > the rigor kit, and the two cross-cutting skills (`progress`, `defend`). Consumes
 > the experiment-backend contract of
-> [sub-spec 4](2026-07-17-honest-scholar-4-substrate-and-experiment-contract-design.md) §3
+> [sub-spec 4](04-substrate-and-contract.md) §3
 > and the `literature`/`dataset` capabilities of
-> [sub-spec 2](2026-07-17-honest-scholar-2-literature-design.md) /
-> [sub-spec 3](2026-07-17-honest-scholar-3-dataset-design.md). Governed by the ⚑ agency
+> [sub-spec 2](02-literature.md) /
+> [sub-spec 3](03-dataset.md). Governed by the ⚑ agency
 > (§2.1) and Understanding (§2.2) principles.
 > Refines the four `2026-07-15-*` research-workflow specs (which migrate here) and
 > adds the thesis level, progress, and defend. Grounding:
-> [thesis-and-progress-tracking](../honest-scholar/references/thesis-and-progress-tracking.md),
-> [understanding-and-defense](../honest-scholar/references/understanding-and-defense.md),
-> [mentor-personas](../honest-scholar/references/mentor-personas.md).
+> [thesis-and-progress-tracking](../../resources/references/thesis-and-progress-tracking.md),
+> [understanding-and-defense](../../resources/references/understanding-and-defense.md),
+> [mentor-personas](../../resources/references/mentor-personas.md).
 
 ## 1. The three-level mirror & flywheels
 

--- a/docs/design/02-literature.md
+++ b/docs/design/02-literature.md
@@ -2,14 +2,14 @@
 
 **Date:** 2026-07-17
 **Author:** Davor Runje
-**Status:** Brainstorming output; sub-spec of the `honest-scholar` meta-spec, pending implementation plan.
+**Status:** Implemented. Sub-spec of the `honest-scholar` meta-spec; realized in this repo (skills + CLI).
 
-> Sub-spec of [2026-07-17-honest-scholar-plugin-design.md](2026-07-17-honest-scholar-plugin-design.md).
+> Sub-spec of [00-meta-spec.md](00-meta-spec.md).
 > Builds on the asset substrate of
-> [sub-spec 4](2026-07-17-honest-scholar-4-substrate-and-experiment-contract-design.md) §2.
+> [sub-spec 4](04-substrate-and-contract.md) §2.
 > Governed by the ⚑ agency (§2.1) and Understanding (§2.2) principles.
-> Grounding: [citation-scouting](../honest-scholar/references/citation-scouting.md),
-> [related-works-synthesis](../honest-scholar/references/related-works-synthesis.md).
+> Grounding: [citation-scouting](../../resources/references/citation-scouting.md),
+> [related-works-synthesis](../../resources/references/related-works-synthesis.md).
 
 ## 1. The `literature` skill
 

--- a/docs/design/03-dataset.md
+++ b/docs/design/03-dataset.md
@@ -2,15 +2,15 @@
 
 **Date:** 2026-07-17
 **Author:** Davor Runje
-**Status:** Brainstorming output; sub-spec of the `honest-scholar` meta-spec, pending implementation plan.
+**Status:** Implemented. Sub-spec of the `honest-scholar` meta-spec; realized in this repo (skills + CLI).
 
-> Sub-spec of [2026-07-17-honest-scholar-plugin-design.md](2026-07-17-honest-scholar-plugin-design.md).
+> Sub-spec of [00-meta-spec.md](00-meta-spec.md).
 > Builds on the asset substrate of
-> [sub-spec 4](2026-07-17-honest-scholar-4-substrate-and-experiment-contract-design.md) §2
+> [sub-spec 4](04-substrate-and-contract.md) §2
 > and feeds the experiment-backend contract (§3). Governed by the ⚑ agency (§2.1)
 > and Understanding (§2.2) principles.
-> Grounding: [dataset-management-standards](../honest-scholar/references/dataset-management-standards.md),
-> [dataset-tooling-mirror](../honest-scholar/references/dataset-tooling-mirror.md).
+> Grounding: [dataset-management-standards](../../resources/references/dataset-management-standards.md),
+> [dataset-tooling-mirror](../../resources/references/dataset-tooling-mirror.md).
 
 ## 1. The `dataset` skill
 

--- a/docs/design/04-substrate-and-contract.md
+++ b/docs/design/04-substrate-and-contract.md
@@ -2,15 +2,15 @@
 
 **Date:** 2026-07-17
 **Author:** Davor Runje
-**Status:** Brainstorming output; sub-spec of the `honest-scholar` meta-spec, pending implementation plan.
+**Status:** Implemented. Sub-spec of the `honest-scholar` meta-spec; realized in this repo (skills + CLI).
 
-> Sub-spec of [2026-07-17-honest-scholar-plugin-design.md](2026-07-17-honest-scholar-plugin-design.md).
+> Sub-spec of [00-meta-spec.md](00-meta-spec.md).
 > Defines the foundation that sub-specs 2 (literature) and 3 (dataset) build on:
 > the **asset-provenance substrate** (registry pattern + private mirror + fixity +
 > persistent-ID) and the **experiment-backend contract**. Governed by the meta-spec's
 > ⚑ guiding principle (assistants, not researchers) and its light-dependency posture.
-> Grounding: [dataset-management-standards](../honest-scholar/references/dataset-management-standards.md),
-> [dataset-tooling-mirror](../honest-scholar/references/dataset-tooling-mirror.md).
+> Grounding: [dataset-management-standards](../../resources/references/dataset-management-standards.md),
+> [dataset-tooling-mirror](../../resources/references/dataset-tooling-mirror.md).
 
 ## 1. Purpose
 

--- a/docs/design/proposals/dataset-manifest-tooling.md
+++ b/docs/design/proposals/dataset-manifest-tooling.md
@@ -1,6 +1,6 @@
 # Proposal: `datasets.yml` manifest tooling — loader/validator + Croissant interop
 
-`Status: draft (for discussion) · Date: 2026-07-18 · Skill: dataset`
+`Status: implemented (designed 2026-07-18) · Skill: dataset`
 
 ## Context
 

--- a/docs/design/proposals/dataset-retrieval-mirror-tooling.md
+++ b/docs/design/proposals/dataset-retrieval-mirror-tooling.md
@@ -1,6 +1,6 @@
 # Proposal: Dataset retrieval, private-mirror & fixity tooling
 
-`Status: draft (for discussion) · Date: 2026-07-18 · Skill: dataset`
+`Status: implemented (designed 2026-07-18) · Skill: dataset`
 
 ## Context
 

--- a/docs/design/proposals/defend-record-helper.md
+++ b/docs/design/proposals/defend-record-helper.md
@@ -1,6 +1,6 @@
 # Proposal: `defend record` — a helper to persist understanding status + the accountability trail
 
-`Status: draft (for discussion) · Date: 2026-07-18 · Skill: defend`
+`Status: implemented (designed 2026-07-18) · Skill: defend`
 
 ## Context
 

--- a/docs/design/proposals/exploration-backlog-helper.md
+++ b/docs/design/proposals/exploration-backlog-helper.md
@@ -1,6 +1,6 @@
 # Proposal: Shared `backlog` helper for the two exploration skills
 
-`Status: draft (for discussion) · Date: 2026-07-18 · Skill: hypothesis-exploration / paper-exploration`
+`Status: implemented (designed 2026-07-18) · Skill: hypothesis-exploration / paper-exploration`
 
 ## Context
 

--- a/docs/design/proposals/literature-citation-graph-client.md
+++ b/docs/design/proposals/literature-citation-graph-client.md
@@ -1,6 +1,6 @@
 # Proposal: Citation-graph client (`honest_scholar/literature/graph.py`)
 
-`Status: draft (for discussion) · Date: 2026-07-18 · Skill: literature`
+`Status: implemented (designed 2026-07-18) · Skill: literature`
 
 ## Context
 

--- a/docs/design/proposals/tooling-package.md
+++ b/docs/design/proposals/tooling-package.md
@@ -1,6 +1,6 @@
 # Proposal: `honest-scholar` package (Typer CLI, optional MCP)
 
-`Status: draft (for discussion) · Date: 2026-07-18 · Umbrella for the supporting-script proposals`
+`Status: implemented (designed 2026-07-18) · Umbrella for the supporting-script proposals`
 
 ## Context
 
@@ -8,7 +8,7 @@ Per ADR-0024, the plugin's executable tooling ships as **one Python package**,
 not loose `scripts/*.py`. The five supporting-script proposals become **modules**
 of this package; this doc is the umbrella that organizes them and defines the
 shared shape (packaging, CLI, bootstrap, optional MCP). The plugin stays
-pure-markdown; skills call the CLI after the [`ensure-tooling`](../../resources/ensure-tooling.md)
+pure-markdown; skills call the CLI after the [`ensure-tooling`](../../../resources/ensure-tooling.md)
 procedure.
 
 ## Package
@@ -60,7 +60,7 @@ CLI-first); nothing depends on it. Adding it is a wrapper, not a rewrite.
 
 ## Bootstrap
 
-Install/upgrade is handled entirely by [`ensure-tooling`](../../resources/ensure-tooling.md):
+Install/upgrade is handled entirely by [`ensure-tooling`](../../../resources/ensure-tooling.md):
 detect `uv`→`pipx`→`python3`, install isolated + pinned (prefer `uv tool install`,
 which also provisions Python), record the CLI in `.honest-scholar/config.yml`, stop with
 instructions if the env can't self-heal.
@@ -105,11 +105,11 @@ uvx --from "git+https://github.com/davorrunje/honest-scholar.git#subdirectory=ho
 
 ## Acceptance criteria
 
-- [ ] `honest-scholar` skeleton: `pyproject.toml`, `core/`, Typer `cli.py`, `tests/`.
-- [ ] `honest-scholar --version` works via an isolated `uv tool` / `pipx` / venv install.
-- [ ] `ensure-tooling` provisions it on a machine with only `uv` (no prior Python).
-- [ ] Each module implemented per its own proposal; CLI subcommands wired.
-- [ ] Skills updated: interim manual / direct-tool-call orchestration replaced with
+- [x] `honest-scholar` skeleton: `pyproject.toml`, `core/`, Typer `cli.py`, `tests/`.
+- [x] `honest-scholar --version` works via an isolated `uv tool` / `pipx` / venv install.
+- [x] `ensure-tooling` provisions it on a machine with only `uv` (no prior Python).
+- [x] Each module implemented per its own proposal; CLI subcommands wired.
+- [x] Skills updated: interim manual / direct-tool-call orchestration replaced with
       `ensure-tooling` + `honest-scholar …` calls.
 - [ ] (Later) MCP wrapper exposing the same functions.
 


### PR DESCRIPTION
## What

The **design-record cluster** of the release-readiness audit (#31): the B4 broken-link blocker plus the design-record SHOULDs/NICEs.

## B4 — ~20 broken internal links (two systemic patterns)

1. Sub-spec cross-links pointed at the **pre-rename** filenames (`2026-07-17-honest-scholar-*-design.md`) — the docs were renumbered `00`–`04`. Retargeted.
2. Grounding links pointed at `../honest-scholar/references/*` — the digests live at `resources/references/*`. Fixed both the link targets **and** the backtick display paths (which still read like a real path).

Also fixed `tooling-package.md`'s link-depth bug (`../../` → `../../../`; it sits one level deeper in `proposals/`). A link-checker over `docs/design/` + `decisions/` now passes (the only miss is a `files[]` code-span false positive).

## Stale "pre-implementation" self-description

- **Meta-spec + 4 sub-specs**: Status `"Brainstorming output … pending implementation plan"` → `"Implemented … realized in this repo"`.
- **6 proposals** (the 5 shipped CLI modules + `tooling-package`): Status `"draft (for discussion)"` → `"implemented (designed 2026-07-18)"`; the `tooling-package` acceptance list is checked (the "(Later)" MCP wrapper stays unchecked). `cross-repo-thesis-aggregation` stays a draft (genuinely not built).

## Meta-spec §9 leak + §10 open item

- **§9** (the migration plan) gets a **"Status: complete"** banner and past tense; the intro gets a historical note that the plugin was extracted into its own repo and the `mononet` PR / `docs/superpowers/` references are origin context, not a live dependency. (History preserved, not erased.)
- **§10** "mirror hash MD5 vs SHA-256" marked **resolved by ADR-0011**.

## Three missing release-engineering ADRs

The decision log stopped at ADR-0025; these three shipped decisions had no record:

- **0026** — independent plugin/package versioning + compatibility pin
- **0027** — GitHub-Release-driven publish via PyPI Trusted Publishing (OIDC, no tokens)
- **0028** — 100% statement + branch coverage gate

…added and indexed in `decisions/README.md`.

Part of #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)