### PR TITLE
ci: release-safety guard, pin alignment, deeper plugin validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,12 +21,26 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8.3.1
+      - name: Guard — release tag matches package version
+        if: github.event_name == 'release'
+        run: |
+          version=$(grep -m1 '^version' honest-scholar/pyproject.toml | cut -d'"' -f2)
+          tag="${{ github.event.release.tag_name }}"
+          if [ "$tag" != "v$version" ]; then
+            echo "::error::release tag '$tag' does not match pyproject version 'v$version' — refusing to publish the wrong version"
+            exit 1
+          fi
+          echo "release tag '$tag' matches pyproject 'v$version'"
       - name: Build sdist + wheel
         working-directory: honest-scholar
         run: uv build
@@ -44,7 +58,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v5 # resolve the local report-published action
+      - uses: actions/checkout@v7 # resolve the local report-published action
       - uses: actions/download-artifact@v4
         with: { name: dist, path: dist }
       - uses: pypa/gh-action-pypi-publish@release/v1 # Docker action — must stay top-level
@@ -63,7 +77,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v5 # resolve the local report-published action
+      - uses: actions/checkout@v7 # resolve the local report-published action
       - uses: actions/download-artifact@v4
         with: { name: dist, path: dist }
       - uses: pypa/gh-action-pypi-publish@release/v1 # Docker action — must stay top-level

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # honest-scholar plugin — consumers create these in THEIR repos, never here
-.datasets-cache/
+.honest-scholar/cache/          # http + dataset caches (cli.py writes here)
 .honest-scholar/rclone.conf
 *.rclone.conf
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,9 +47,13 @@ Driven by three workflows — no local build / `twine` needed:
 
 3. **Validate on TestPyPI.** Actions → **Publish** → *Run workflow* with
    `target: testpypi` (the default). Check the run **summary** for the link, then
-   optionally smoke-test:
+   optionally smoke-test (the extra index resolves the runtime deps, which live
+   on real PyPI; `--prerelease=allow` is needed for an a/b/rc version):
    ```bash
-   uv tool install --index https://test.pypi.org/simple/ honest-scholar==<version>
+   uv tool install \
+     --index-url https://test.pypi.org/simple/ \
+     --extra-index-url https://pypi.org/simple/ \
+     --prerelease=allow honest-scholar==<version>
    honest-scholar --version
    ```
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,9 @@
 # Codecov configuration.
 #
-# The *enforcing* coverage gate is pytest's `--cov-fail-under` (see
-# honest-scholar/pyproject.toml), enabled once the package reaches 100%. Until
-# then Codecov reports coverage informationally and never blocks a PR, so a
-# below-target percentage during the module build-out does not red the checks.
+# The *enforcing* coverage gate is pytest's `fail_under = 100` (see
+# honest-scholar/pyproject.toml, ADR-0028) — it fails CI directly. Codecov is
+# reporting-only here (informational statuses) to avoid double-gating and Codecov
+# flakiness blocking a PR; the hard gate is the pytest run, not this service.
 coverage:
   status:
     project:

--- a/honest-scholar/pyproject.toml
+++ b/honest-scholar/pyproject.toml
@@ -14,7 +14,7 @@ license = "Apache-2.0"
 license-files = ["LICENSE"]
 keywords = ["research", "science", "cli", "literature", "dataset", "claude-code"]
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tools/validate-plugin.sh
+++ b/tools/validate-plugin.sh
@@ -3,15 +3,57 @@ set -euo pipefail
 
 # Validate the Claude Code plugin manifest.
 # Prefer the official `claude plugin validate` when the CLI is on PATH;
-# otherwise fall back to a JSON well-formedness check of the manifests.
+# otherwise fall back to a structural check (JSON well-formedness + required
+# keys), so a schema-invalid manifest does not pass CI just for parsing.
 cd "$(dirname "$0")/.."
 
 if command -v claude >/dev/null 2>&1; then
     echo "Validating plugin via 'claude plugin validate .'..."
     claude plugin validate .
 else
-    echo "'claude' not on PATH — falling back to JSON load of plugin manifests..."
-    python3 -c "import json, sys; [json.load(open(p)) for p in sys.argv[1:]]; print('plugin manifests are valid JSON')" \
-        .claude-plugin/plugin.json \
-        .claude-plugin/marketplace.json
+    echo "'claude' not on PATH — falling back to a structural manifest check..."
+    python3 - <<'PY'
+import json
+import sys
+
+errors = []
+
+
+def require(cond, msg):
+    if not cond:
+        errors.append(msg)
+
+
+with open(".claude-plugin/plugin.json", encoding="utf-8") as fh:
+    plugin = json.load(fh)
+require(isinstance(plugin, dict), "plugin.json: must be a JSON object")
+for key in ("name", "version", "description"):
+    require(bool(plugin.get(key)), f"plugin.json: missing/empty required key '{key}'")
+
+with open(".claude-plugin/marketplace.json", encoding="utf-8") as fh:
+    market = json.load(fh)
+require(isinstance(market, dict), "marketplace.json: must be a JSON object")
+require(bool(market.get("name")), "marketplace.json: missing/empty 'name'")
+plugins = market.get("plugins")
+require(
+    isinstance(plugins, list) and len(plugins) >= 1,
+    "marketplace.json: 'plugins' must be a non-empty list",
+)
+for i, entry in enumerate(plugins or []):
+    require(
+        isinstance(entry, dict) and entry.get("name"),
+        f"marketplace.json: plugins[{i}] missing 'name'",
+    )
+    require(
+        isinstance(entry, dict) and entry.get("source") is not None,
+        f"marketplace.json: plugins[{i}] missing 'source'",
+    )
+
+if errors:
+    print("plugin manifest validation FAILED:", file=sys.stderr)
+    for e in errors:
+        print(f"  - {e}", file=sys.stderr)
+    sys.exit(1)
+print("plugin manifests are structurally valid (JSON + required keys)")
+PY
 fi


### PR DESCRIPTION
## What

The **CI/build cluster** of the release-readiness audit (#31) — the SHOULD/NICE items around release safety, pin hygiene, and validation depth.

## publish.yml

- **tag↔version guard** — on a published Release, the build fails if the release tag ≠ `v<pyproject version>`. Previously a mistagged Release would silently publish the wrong version to PyPI.
- **action-pin alignment** — `checkout@v5`→`v7`, `setup-uv@v6`→`v8.3.1`, matching `ci.yml` / `bump-version.yml`. The publish path was the least-updated in the repo.
- **concurrency group** so overlapping publishes don't race.

## .gitignore

Ignore `.honest-scholar/cache/` — what `cli.py` actually writes (`cache/http`, `cache/datasets`) — instead of the stale `.datasets-cache/`. A consumer following the template would otherwise commit their caches.

## Deeper plugin validation

`tools/validate-plugin.sh`'s no-`claude` fallback did a bare `json.load`, so a **schema-invalid** manifest passed CI just for parsing. It now checks the required keys: `plugin.json` `name`/`version`/`description`, and `marketplace.json` `name` + a non-empty `plugins[]` each with `name`/`source`. (Verified: passes on the current manifests; the `claude plugin validate` path is still preferred when the CLI is present.)

## RELEASING.md

The TestPyPI smoke-test command set only the test index, so runtime deps (which live on **real** PyPI) wouldn't resolve and an `a/b/rc` version wouldn't install. Added `--extra-index-url https://pypi.org/simple/` and `--prerelease=allow` (consistent with the package README).

## Cosmetic truth

- pyproject classifier `2 - Pre-Alpha` → `4 - Beta` (the version is `0.0.0b0`).
- `codecov.yml` comment corrected — the 100% gate is **live** (pytest `fail_under`, ADR-0028); Codecov is reporting-only by design (avoids double-gating).

## Deliberately not changed

`pooch` stays a **core** dependency. `dataset fetch` is a first-class command, so demoting pooch to an optional extra would break a plain `uv tool install honest-scholar`. Noted here rather than left silent.

Part of #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)