### PR TITLE
test(live): opt-in live validation of literature + dataset retrieval (closes #30)

### DIFF
--- a/.github/workflows/live-validation.yml
+++ b/.github/workflows/live-validation.yml
@@ -1,0 +1,37 @@
+name: Live validation
+
+# Opt-in end-to-end checks against REAL services — live OpenAlex / Semantic
+# Scholar, and real pooch + rclone (honest-scholar#30). NOT part of the required
+# PR gate (the hermetic suite + 100% coverage gate is in ci.yml); this is a
+# manual / weekly job that catches upstream endpoint or tool drift.
+#
+# S2_API_KEY is optional: without it the keyless-degrade path is exercised and the
+# S2-keyed assertions skip. OPENALEX_MAILTO joins the OpenAlex polite pool.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  live:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8.3.1
+      - name: Install rclone
+        run: |
+          curl -fsSL -o rclone.zip https://downloads.rclone.org/rclone-current-linux-amd64.zip
+          unzip -q rclone.zip
+          sudo cp rclone-*/rclone /usr/local/bin/rclone
+          rclone version
+      - name: Run the live suite
+        working-directory: honest-scholar
+        env:
+          HONEST_SCHOLAR_LIVE: "1"
+          OPENALEX_MAILTO: davor@synthpop.ai
+          S2_API_KEY: ${{ secrets.S2_API_KEY }}
+        run: uv run pytest -m live --no-cov -v

--- a/honest-scholar/honest_scholar/dataset/retrieval.py
+++ b/honest-scholar/honest_scholar/dataset/retrieval.py
@@ -13,7 +13,8 @@ without the network or the binary. Design:
 
 .. note::
    The pooch/rclone command shapes follow their public docs and are covered by
-   mocked tests; live validation is a follow-up (see the PR).
+   mocked tests; the opt-in live suite (``tests/test_live_retrieval.py``,
+   ``-m live``) exercises them against real ``pooch`` + ``rclone`` (honest-scholar#30).
 """
 
 from __future__ import annotations

--- a/honest-scholar/pyproject.toml
+++ b/honest-scholar/pyproject.toml
@@ -99,6 +99,9 @@ no_implicit_reexport = true
 [tool.pytest.ini_options]
 addopts = '--cov=honest_scholar --cov-branch --cov-report=term-missing --cov-report=xml'
 testpaths = ["tests"]
+markers = [
+    "live: opt-in integration test against real services (network / rclone); skipped unless HONEST_SCHOLAR_LIVE=1",
+]
 
 [tool.coverage.report]
 fail_under = 100

--- a/honest-scholar/tests/test_cli.py
+++ b/honest-scholar/tests/test_cli.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from typer.testing import CliRunner
 
-from honest_scholar import __version__
+from honest_scholar import __version__, cli
 from honest_scholar.cli import app
+
+if TYPE_CHECKING:
+    import pytest
 
 runner = CliRunner()
 
@@ -29,6 +34,38 @@ def test_doctor_runs() -> None:
     assert "python" in result.stdout.lower()
     assert "rclone" in result.stdout.lower()
     assert "uv" in result.stdout.lower()
+
+
+class _Proc:
+    def __init__(self, stdout: str = "", stderr: str = "") -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_tool_report_found_with_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Deterministic — does not depend on any tool actually being on PATH.
+    monkeypatch.setattr(
+        "honest_scholar.cli.shutil.which", lambda name: f"/usr/bin/{name}"
+    )
+    monkeypatch.setattr(
+        "honest_scholar.cli.subprocess.run", lambda *a, **k: _Proc("mytool 1.2.3\n")
+    )
+    report = cli._tool_report("mytool")
+    assert "1.2.3" in report
+    assert "/usr/bin/mytool" in report
+
+
+def test_tool_report_found_but_no_version_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("honest_scholar.cli.shutil.which", lambda name: "/bin/x")
+    monkeypatch.setattr("honest_scholar.cli.subprocess.run", lambda *a, **k: _Proc())
+    assert "version unknown" in cli._tool_report("x")
+
+
+def test_tool_report_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("honest_scholar.cli.shutil.which", lambda name: None)
+    assert cli._tool_report("nope") == "nope: not found"
 
 
 def test_dataset_command_tree_matches_audited_specs() -> None:

--- a/honest-scholar/tests/test_live_literature.py
+++ b/honest-scholar/tests/test_live_literature.py
@@ -1,0 +1,115 @@
+"""Opt-in live integration tests: real OpenAlex + Semantic Scholar (honest-scholar#30).
+
+Skipped unless ``HONEST_SCHOLAR_LIVE=1``. These exercise the real endpoint shapes,
+cursor pagination, and the S2 enrichment/cross-reference paths that the hermetic
+suite can only mock — the integration risk a *final* release must retire.
+
+    HONEST_SCHOLAR_LIVE=1 OPENALEX_MAILTO=you@example.org \
+        uv run pytest -m live --no-cov
+
+S2-keyed assertions are additionally gated on ``S2_API_KEY`` because keyless S2 is
+aggressively rate-limited; a keyless call is only asserted to degrade *gracefully*.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from honest_scholar.core.http import HttpClient
+from honest_scholar.literature import graph
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        os.environ.get("HONEST_SCHOLAR_LIVE") != "1",
+        reason="live test — set HONEST_SCHOLAR_LIVE=1 (needs network)",
+    ),
+]
+
+_MAILTO = os.environ.get("OPENALEX_MAILTO", "davor@synthpop.ai")
+_S2_KEY = os.environ.get("S2_API_KEY")
+# A stable, well-connected anchor: Piwowar et al. 2018, "The state of OA".
+_ANCHOR = "W2741809807"
+# The group's ICML'23 paper (arXiv), for the arXiv + S2 cross-reference paths.
+_CMNN_ARXIV = "arXiv:2205.11775"
+_CMNN_CORPUSID = "CorpusId:249017894"
+
+_requires_s2 = pytest.mark.skipif(
+    not _S2_KEY, reason="needs S2_API_KEY (keyless S2 rate-limits too hard to assert)"
+)
+
+
+@pytest.fixture
+def client() -> HttpClient:
+    return HttpClient(cache_dir=None, mailto=_MAILTO, s2_key=_S2_KEY)
+
+
+def test_resolve_openalex_anchor(client: HttpClient) -> None:
+    rec = graph.resolve(_ANCHOR, client=client)
+    assert rec["resolved"] is True
+    assert rec["openalex"] == _ANCHOR
+    assert rec["year"]
+
+
+def test_resolve_arxiv_and_versioned(client: HttpClient) -> None:
+    rec = graph.resolve(_CMNN_ARXIV, client=client)
+    assert rec["resolved"] is True
+    assert "monotonic" in (rec["title"] or "").lower()
+    # A versioned id must strip the vN suffix and still resolve (honest-scholar#31 B3).
+    assert graph.resolve(_CMNN_ARXIV + "v4", client=client)["resolved"] is True
+
+
+def test_refs_nonempty_for_published_work(client: HttpClient) -> None:
+    refs = graph.refs(_ANCHOR, client=client)
+    assert refs
+    assert all(rid.startswith("W") for rid in refs)
+
+
+def test_cites_paginates_with_cap(client: HttpClient) -> None:
+    rows = graph.cites(_ANCHOR, client=client, max_results=5)
+    assert 1 <= len(rows) <= 5
+    assert all(row["provenance"]["via"] == "openalex" for row in rows)
+    assert all(row["id"]["openalex"] for row in rows)
+
+
+def test_neighbors_cocite(client: HttpClient) -> None:
+    out = graph.neighbors(_ANCHOR, client=client, kind="cocite", top=5, frontier=10)
+    assert "cocitation" in out
+    assert "capped" in out
+
+
+def test_enrich_degrades_without_key() -> None:
+    # Deterministic even keyless: no S2 key → the degraded marker is present.
+    keyless = HttpClient(cache_dir=None, mailto=_MAILTO, s2_key=None)
+    rec = graph.enrich([_ANCHOR], client=keyless, with_context=True)[0]
+    assert rec["degraded"] == ["context", "intent", "is_influential"]
+    assert rec["title"]
+
+
+def test_resolve_corpusid_keyless_is_graceful() -> None:
+    # Keyless S2 may rate-limit; resolve must either succeed or degrade cleanly
+    # (return resolved=False + reason), never raise.
+    keyless = HttpClient(cache_dir=None, mailto=_MAILTO, s2_key=None)
+    rec = graph.resolve(_CMNN_CORPUSID, client=keyless)
+    assert "resolved" in rec
+    if not rec["resolved"]:
+        assert "reason" in rec
+
+
+@_requires_s2
+def test_enrich_with_key_attaches_s2(client: HttpClient) -> None:
+    rec = graph.enrich([_ANCHOR], client=client, with_context=True)[0]
+    assert "degraded" not in rec  # a key was used, so no not-queried marker
+    s2_id = rec["id"]["s2"]
+    assert s2_id
+    assert s2_id.startswith("CorpusId:")
+
+
+@_requires_s2
+def test_resolve_via_corpusid_with_key(client: HttpClient) -> None:
+    # CorpusId → S2 externalIds → OpenAlex (honest-scholar#31 B3).
+    rec = graph.resolve(_CMNN_CORPUSID, client=client)
+    assert rec["resolved"] is True
+    assert "monotonic" in (rec["title"] or "").lower()

--- a/honest-scholar/tests/test_live_retrieval.py
+++ b/honest-scholar/tests/test_live_retrieval.py
@@ -1,0 +1,153 @@
+"""Opt-in live integration tests: real pooch download + real rclone (honest-scholar#30).
+
+Skipped unless ``HONEST_SCHOLAR_LIVE=1``. The Tier-B download runs **real** ``pooch``
+over a localhost HTTP server (deterministic, no external host to flake on); the
+mirror runs the **real** ``rclone`` binary against a local-filesystem *alias*
+remote — exercising the real subprocess arg construction, ``copyto``/``lsf``, and
+the post-transfer re-hash. A real *cloud* remote is a manual check (credentials);
+this validates that the code path shape is correct.
+
+    HONEST_SCHOLAR_LIVE=1 uv run pytest -m live --no-cov
+
+The rclone tests skip automatically when ``rclone`` is not on ``PATH``.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import http.server
+import os
+import shutil
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+
+from honest_scholar.dataset import retrieval as r
+from honest_scholar.dataset.manifest import DatasetEntry, FileRef, Manifest, Retrieval
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        os.environ.get("HONEST_SCHOLAR_LIVE") != "1",
+        reason="live test — set HONEST_SCHOLAR_LIVE=1 (needs network / rclone)",
+    ),
+]
+
+_needs_rclone = pytest.mark.skipif(
+    shutil.which("rclone") is None, reason="rclone not on PATH"
+)
+
+
+class _QuietHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *_args: object) -> None:  # silence per-request logging
+        pass
+
+
+@pytest.fixture
+def http_file(tmp_path: Path) -> Iterator[tuple[str, str]]:
+    """Serve a small payload over localhost; yield ``(url, sha256)``."""
+    served = tmp_path / "served"
+    served.mkdir()
+    payload = b"honest-scholar live-fetch payload\n" * 8
+    (served / "data.bin").write_bytes(payload)
+    handler = functools.partial(_QuietHandler, directory=str(served))
+    srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    sha = hashlib.sha256(payload).hexdigest()
+    try:
+        yield f"http://127.0.0.1:{srv.server_address[1]}/data.bin", sha
+    finally:
+        srv.shutdown()
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def mirror(tmp_path: Path) -> r.Mirror:
+    """Return a real rclone mirror over a local-filesystem alias remote."""
+    root = tmp_path / "mirror-root"
+    root.mkdir()
+    conf = tmp_path / "rclone.conf"
+    conf.write_text(f"[testmirror]\ntype = alias\nremote = {root}\n", encoding="utf-8")
+    return r.Mirror(remote="testmirror", base_path="proj", config_path=str(conf))
+
+
+def _tier_b_entry(url: str, sha256: str) -> DatasetEntry:
+    return DatasetEntry(
+        id="live-b",
+        version="1",
+        tier="B",
+        license="Apache-2.0",
+        redistributable=True,
+        access="open",
+        datasheet="datasheets/x.md",
+        files=[FileRef(path="data.bin", sha256=sha256)],
+        retrieval=Retrieval(kind="http", url=url),
+    )
+
+
+def test_pooch_fetch_and_verify(tmp_path: Path, http_file: tuple[str, str]) -> None:
+    url, sha = http_file
+    paths = r.fetch(_tier_b_entry(url, sha), cache_dir=tmp_path / "cache")
+    assert len(paths) == 1
+    assert r.sha256_file(paths[0]) == sha
+
+
+def test_pooch_fetch_wrong_hash_raises(
+    tmp_path: Path, http_file: tuple[str, str]
+) -> None:
+    url, _ = http_file
+    with pytest.raises(ValueError, match="does not match"):
+        r.fetch(_tier_b_entry(url, "0" * 64), cache_dir=tmp_path / "cache")
+
+
+@_needs_rclone
+def test_rclone_mirror_roundtrip(tmp_path: Path, mirror: r.Mirror) -> None:
+    f = tmp_path / "x.txt"
+    f.write_text("hi\n", encoding="utf-8")
+    sha = r.sha256_file(f)
+    assert mirror.check(sha) is False
+    mirror.put(f, sha)
+    assert mirror.check(sha) is True
+    dst = tmp_path / "back.txt"
+    assert mirror.get(sha, dst) is True
+    assert r.sha256_file(dst) == sha
+
+
+@_needs_rclone
+def test_fetch_populates_then_hits_mirror(
+    tmp_path: Path, http_file: tuple[str, str], mirror: r.Mirror
+) -> None:
+    url, sha = http_file
+    entry = _tier_b_entry(url, sha)
+    cache = tmp_path / "cache"
+    r.fetch(entry, cache_dir=cache, mirror=mirror)
+    assert mirror.check(sha) is True
+
+    # Clear the cache; the second fetch must come from the MIRROR, not the network.
+    r._blob_path(cache, sha).unlink()
+
+    def _no_network(url: str, sha256: str, dest: Path) -> Path:
+        raise AssertionError("second fetch should hit the mirror, not re-download")
+
+    paths = r.fetch(entry, cache_dir=cache, mirror=mirror, tier_b_fetch=_no_network)
+    assert r.sha256_file(paths[0]) == sha
+
+
+@_needs_rclone
+def test_audit_reports_mirror_presence(
+    tmp_path: Path, http_file: tuple[str, str], mirror: r.Mirror
+) -> None:
+    url, sha = http_file
+    entry = _tier_b_entry(url, sha)
+    cache = tmp_path / "cache"
+    r.fetch(entry, cache_dir=cache, mirror=mirror)
+    report = r.audit(Manifest(datasets=[entry]), cache_dir=cache, mirror=mirror)
+    assert report.ok is True
+    assert report.mirror_present[entry.id] is True


### PR DESCRIPTION
## What

Closes the **#30** release gate. `literature` (OpenAlex/S2) and `dataset` retrieval (pooch/rclone) shipped with **mocked-transport tests only** — their real integration paths had never run against real services, the biggest quality risk for a *final* release.

## Result: validated live, no fixes needed

I ran the real code paths against **live OpenAlex, live Semantic Scholar, real `pooch`, and real `rclone`** using the group's ICML'23 paper and a well-connected anchor. **No endpoint / response-shape / argument mismatches were found** — both modules work end-to-end, and the mocked tests matched reality. (Notably, the #31 B3 fixes — versioned-arXiv DOI, S2 `CorpusId` cross-reference, S2 context aggregation — all verified against real S2 data.)

Two real-world behaviours surfaced and are now encoded:
- the arXiv **preprint** OpenAlex record has empty `referenced_works`, so `refs`/coupling need a *published*-work anchor;
- **keyless S2 rate-limits hard** — `resolve(CorpusId)` degrades gracefully to `resolved: False` (never crashes) when throttled.

## The opt-in harness (acceptance criteria)

- `tests/test_live_literature.py` — resolve (incl. arXiv, versioned, and S2 `CorpusId` cross-ref), refs, cites (pagination cap), neighbors, and the keyless `enrich` **degrade** path against **live OpenAlex/S2**. S2-keyed assertions gated on `S2_API_KEY`; the keyless CorpusId resolve is asserted only to degrade *gracefully*.
- `tests/test_live_retrieval.py` — real `pooch` Tier-B download over a **localhost** server (deterministic) + fixity; real `rclone` mirror put/get/check + a **mirror-hit** fetch + `audit`, against a local-filesystem *alias* remote (real subprocess, no cloud creds). rclone tests skip if the binary is absent.
- **Opt-in**: `@pytest.mark.live`, skipped unless `HONEST_SCHOLAR_LIVE=1` (marker registered). The hermetic suite stays **187 passed / 14 skipped at 100% coverage** — the gate is untouched.
- `.github/workflows/live-validation.yml` — manual + weekly job that installs rclone and runs `pytest -m live --no-cov` (optional `S2_API_KEY` secret). **Not** part of the required PR gate.

Local live run: **12 passed, 2 skipped** (S2-keyed, no key) in ~29s.

## Incidental hardening

- Added deterministic `_tool_report` unit tests (monkeypatched `shutil.which`/`subprocess.run`) so the 100% gate no longer silently depends on `uv`/`rclone` being on PATH (it briefly dropped to 99.87% when neither was found).
- `retrieval.py` docstring note now points to the live suite instead of "a follow-up".

Closes #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)