### PR TITLE
fix: honest rate-limit / transient-error handling (#41)

### DIFF
--- a/honest-scholar/honest_scholar/cli.py
+++ b/honest-scholar/honest_scholar/cli.py
@@ -15,6 +15,7 @@ import platform
 import shutil
 import subprocess  # nosec B404 - used only to read `--version` of trusted tools
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
@@ -28,6 +29,8 @@ from honest_scholar.exploration import backlog as backlog_mod
 from honest_scholar.literature import graph as graph_mod
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from honest_scholar.core.http import HttpClient
 
 app = typer.Typer(
@@ -136,6 +139,33 @@ def _lit_client() -> HttpClient:
     )
 
 
+@contextmanager
+def _http_guard(client: HttpClient) -> Iterator[None]:
+    """Translate an HTTP failure into a clean, actionable non-zero exit.
+
+    A rate-limit (``RateLimitError``) is distinguished from other transport
+    failures so the researcher is told *why* the lookup stopped — never a
+    traceback, and never silently folded into an empty result.
+
+    :param client: The client whose retry budget informs the message.
+    :raises typer.Exit: Code 1 on any :class:`HttpError` (message on stderr).
+    """
+    from honest_scholar.core.http import HttpError, RateLimitError
+
+    try:
+        yield
+    except RateLimitError as exc:
+        typer.echo(
+            f"rate-limited by Semantic Scholar after {client.max_retries} retries "
+            "— set S2_API_KEY for higher limits, or retry later",
+            err=True,
+        )
+        raise typer.Exit(code=1) from exc
+    except HttpError as exc:
+        typer.echo(f"literature request failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
 def _openalex_id(client: HttpClient, identifier: str) -> str:
     """Resolve `identifier` to an OpenAlex id, or exit 1 if it cannot resolve."""
     record = graph_mod.resolve(identifier, client=client)
@@ -153,10 +183,10 @@ def resolve(identifier: str) -> None:
 
     :param identifier: The identifier to resolve.
     """
-    typer.echo(
-        json.dumps(graph_mod.resolve(identifier, client=_lit_client()), indent=2)
-    )
-    raise typer.Exit(code=0)
+    client = _lit_client()
+    with _http_guard(client):
+        typer.echo(json.dumps(graph_mod.resolve(identifier, client=client), indent=2))
+        raise typer.Exit(code=0)
 
 
 @literature.command()
@@ -170,13 +200,14 @@ def cites(
     :param max_results: Optional cap on the number of rows (0 = all).
     """
     client = _lit_client()
-    rows = graph_mod.cites(
-        _openalex_id(client, identifier),
-        client=client,
-        max_results=max_results or None,
-    )
-    typer.echo(json.dumps(rows, indent=2))
-    raise typer.Exit(code=0)
+    with _http_guard(client):
+        rows = graph_mod.cites(
+            _openalex_id(client, identifier),
+            client=client,
+            max_results=max_results or None,
+        )
+        typer.echo(json.dumps(rows, indent=2))
+        raise typer.Exit(code=0)
 
 
 @literature.command()
@@ -186,10 +217,11 @@ def refs(identifier: str) -> None:
     :param identifier: The work identifier.
     """
     client = _lit_client()
-    typer.echo(
-        json.dumps(graph_mod.refs(_openalex_id(client, identifier), client=client))
-    )
-    raise typer.Exit(code=0)
+    with _http_guard(client):
+        typer.echo(
+            json.dumps(graph_mod.refs(_openalex_id(client, identifier), client=client))
+        )
+        raise typer.Exit(code=0)
 
 
 @literature.command()
@@ -203,10 +235,11 @@ def enrich(
     :param with_context: Request S2 citation-context fields (degrades w/o a key).
     """
     client = _lit_client()
-    ids = [_openalex_id(client, ident) for ident in identifiers]
-    rows = graph_mod.enrich(ids, client=client, with_context=with_context)
-    typer.echo(json.dumps(rows, indent=2))
-    raise typer.Exit(code=0)
+    with _http_guard(client):
+        ids = [_openalex_id(client, ident) for ident in identifiers]
+        rows = graph_mod.enrich(ids, client=client, with_context=with_context)
+        typer.echo(json.dumps(rows, indent=2))
+        raise typer.Exit(code=0)
 
 
 @literature.command()
@@ -224,14 +257,15 @@ def neighbors(
     :param top: Number of neighbours per set.
     """
     client = _lit_client()
-    resolved = _openalex_id(client, identifier)
-    try:
-        result = graph_mod.neighbors(resolved, client=client, kind=kind, top=top)
-    except ValueError as exc:
-        typer.echo(str(exc), err=True)
-        raise typer.Exit(code=1) from exc
-    typer.echo(json.dumps(result, indent=2))
-    raise typer.Exit(code=0)
+    with _http_guard(client):
+        resolved = _openalex_id(client, identifier)
+        try:
+            result = graph_mod.neighbors(resolved, client=client, kind=kind, top=top)
+        except ValueError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=1) from exc
+        typer.echo(json.dumps(result, indent=2))
+        raise typer.Exit(code=0)
 
 
 # --- dataset (honest-scholar#2 manifest / #3 retrieval) ---------------------------

--- a/honest-scholar/honest_scholar/core/http.py
+++ b/honest-scholar/honest_scholar/core/http.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import random
 import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
@@ -21,6 +22,7 @@ from urllib.parse import urlencode
 import requests
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
 JsonValue = dict[str, Any] | list[Any]
@@ -30,10 +32,23 @@ class HttpError(RuntimeError):
     """Raised when a request ultimately fails (after retries) or returns non-JSON."""
 
 
+class RateLimitError(HttpError):
+    """Raised when retries are exhausted on a rate-limit signal.
+
+    The signal is a ``429``, or a ``503`` carrying ``Retry-After``. A distinct
+    type so callers can tell a *transient throttle* apart from a permanent miss
+    (``404``): a throttle must never be recorded as "not found".
+    """
+
+
 class Response(Protocol):
     """The minimal response shape the client needs (``requests``-compatible)."""
 
     status_code: int
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        """Response headers (read for ``Retry-After``)."""
 
     def json(self) -> Any:
         """Decode the response body as JSON."""
@@ -57,6 +72,24 @@ def _cache_key(url: str, params: dict[str, str] | None) -> str:
     """Return a stable content-addressed cache key for a URL + params."""
     query = urlencode(sorted((params or {}).items()))
     return hashlib.sha256(f"{url}?{query}".encode()).hexdigest()
+
+
+def _retry_after_seconds(headers: Mapping[str, str]) -> int | None:
+    """Parse a ``Retry-After`` header value as integer seconds, else ``None``.
+
+    :param headers: The response headers.
+    :returns: The delay in seconds, or ``None`` when the header is absent or is
+        an HTTP-date / otherwise unparsable (in which case the caller falls back
+        to exponential backoff).
+    """
+    value = headers.get("Retry-After")
+    if value is None:
+        return None
+    try:
+        return int(value.strip())
+    except ValueError:
+        # An HTTP-date (or garbage) — ignore it and fall back to backoff.
+        return None
 
 
 @dataclass
@@ -110,7 +143,9 @@ class HttpClient:
         :param headers: Extra headers (``x-api-key`` is added when `s2` + a key).
         :param s2: Whether this is a Semantic Scholar call (key/header handling).
         :returns: The decoded JSON document (served from cache when present).
-        :raises HttpError: On repeated failure or a non-JSON body.
+        :raises HttpError: On a non-retryable status, a non-JSON body, or a
+            non-rate-limit exhaustion.
+        :raises RateLimitError: When retries are exhausted on a rate-limit signal.
         """
         query = dict(params or {})
         if not s2 and self.mailto:
@@ -130,15 +165,24 @@ class HttpClient:
     def _fetch(
         self, url: str, query: dict[str, str], headers: dict[str, str]
     ) -> JsonValue:
-        """Issue the request with retries; the network side of :meth:`get_json`."""
+        """Issue the request with retries; the network side of :meth:`get_json`.
+
+        Honors ``Retry-After`` on ``429`` / ``503`` (integer seconds); otherwise
+        backs off exponentially with jitter. A rate-limit signal (``429``, or a
+        ``503`` carrying ``Retry-After``) that survives every retry surfaces as a
+        :class:`RateLimitError` so it is never mistaken for a permanent miss.
+        """
         last_error = "no attempt made"
+        rate_limited = False
         for attempt in range(self.max_retries):
+            retry_after: int | None = None
             try:
                 resp = self.session.get(
                     url, params=query, headers=headers, timeout=self.timeout
                 )
             except requests.RequestException as exc:  # pragma: no cover - network
                 last_error = str(exc)
+                rate_limited = False
             else:
                 if resp.status_code == 200:
                     try:
@@ -149,8 +193,25 @@ class HttpClient:
                 if resp.status_code not in (429, 500, 502, 503, 504):
                     raise HttpError(f"{url}: HTTP {resp.status_code}")
                 last_error = f"HTTP {resp.status_code}"
-            backoff = 2.0**attempt
-            self.sleep(backoff)  # type: ignore[operator]
-        raise HttpError(
-            f"{url}: giving up after {self.max_retries} attempts ({last_error})"
-        )
+                retry_after = _retry_after_seconds(resp.headers)
+                rate_limited = resp.status_code == 429 or (
+                    resp.status_code == 503 and retry_after is not None
+                )
+            self.sleep(self._backoff(attempt, retry_after))  # type: ignore[operator]
+        detail = f"{url}: giving up after {self.max_retries} attempts ({last_error})"
+        if rate_limited:
+            raise RateLimitError(detail)
+        raise HttpError(detail)
+
+    @staticmethod
+    def _backoff(attempt: int, retry_after: int | None) -> float:
+        """Return the seconds to sleep before the next attempt.
+
+        :param attempt: The zero-based attempt index.
+        :param retry_after: A server-supplied ``Retry-After`` delay, if any.
+        :returns: `retry_after` when the server asked for one, else exponential
+            backoff (``2**attempt``) with additive jitter to avoid thundering herds.
+        """
+        if retry_after is not None:
+            return float(retry_after)
+        return 2.0**attempt + random.uniform(0.0, 1.0)

--- a/honest-scholar/honest_scholar/literature/graph.py
+++ b/honest-scholar/honest_scholar/literature/graph.py
@@ -150,13 +150,16 @@ def _s2_crossref(client: HttpClient, s2_id: str) -> tuple[str, str] | None:
 
     :returns: ``("doi", …)`` / ``("arxiv", …)``, or ``None`` if S2 misses or the
         paper carries no DOI/arXiv cross-reference.
+    :raises RateLimitError: If S2 rate-limits — a throttle is not a "no such paper".
     """
-    from honest_scholar.core.http import HttpError
+    from honest_scholar.core.http import HttpError, RateLimitError
 
     try:
         paper = client.get_json(
             f"{S2}/paper/{s2_id}", {"fields": "externalIds"}, s2=True
         )
+    except RateLimitError:
+        raise
     except HttpError:
         return None
     ext = (paper.get("externalIds") or {}) if isinstance(paper, dict) else {}
@@ -172,10 +175,13 @@ def resolve(identifier: str, *, client: HttpClient) -> dict[str, Any]:
 
     :param identifier: DOI / arXiv id / OpenAlex ``W…`` / S2 id.
     :param client: The HTTP client.
-    :returns: ``{resolved, openalex, doi, s2, arxiv, title, year}``; on a miss,
-        ``{resolved: False, reason: …}`` — never raises for a not-found id.
+    :returns: ``{resolved, openalex, doi, s2, arxiv, title, year}``; on a genuine
+        miss (``404`` / empty body / no cross-reference), ``{resolved: False,
+        reason: …}``.
+    :raises RateLimitError: If a provider rate-limits — a throttle must propagate,
+        never be recorded as a "not found".
     """
-    from honest_scholar.core.http import HttpError
+    from honest_scholar.core.http import HttpError, RateLimitError
 
     kind, norm = _classify(identifier)
     if kind == "s2":
@@ -191,6 +197,8 @@ def resolve(identifier: str, *, client: HttpClient) -> dict[str, Any]:
         return {"resolved": False, "reason": f"unsupported identifier kind: {kind}"}
     try:
         work = client.get_json(lookup)
+    except RateLimitError:
+        raise
     except HttpError as exc:
         return {"resolved": False, "reason": str(exc)}
     if not isinstance(work, dict) or not work.get("id"):
@@ -265,9 +273,13 @@ def _s2_context(client: HttpClient, s2_paper_id: str) -> dict[str, Any]:
     (``/paper/{id}/citations``); for a work in isolation we surface a representative
     citing sentence and intent plus whether *any* citation is influential. Returns
     ``{s2, context_snippet, intent, is_influential}`` (each ``None`` when absent);
-    an S2 miss/error yields all-``None`` (best effort — the key was still used).
+    an S2 miss/error yields all-``None`` (best effort — the key was still used). A
+    rate-limit is *not* best-effort: it propagates rather than masquerading as "S2
+    had no data".
+
+    :raises RateLimitError: If S2 rate-limits during either sub-request.
     """
-    from honest_scholar.core.http import HttpError
+    from honest_scholar.core.http import HttpError, RateLimitError
 
     out: dict[str, Any] = {
         "s2": None,
@@ -279,6 +291,8 @@ def _s2_context(client: HttpClient, s2_paper_id: str) -> dict[str, Any]:
         meta = client.get_json(
             f"{S2}/paper/{s2_paper_id}", {"fields": "externalIds"}, s2=True
         )
+    except RateLimitError:
+        raise
     except HttpError:
         meta = {}
     corpus = (
@@ -294,9 +308,21 @@ def _s2_context(client: HttpClient, s2_paper_id: str) -> dict[str, Any]:
             {"fields": "contexts,intents,isInfluential", "limit": "100"},
             s2=True,
         )
+    except RateLimitError:
+        raise
     except HttpError:
         return out
     edges = page.get("data", []) if isinstance(page, dict) else []
+    _aggregate_s2_edges(edges, out)
+    return out
+
+
+def _aggregate_s2_edges(edges: list[Any], out: dict[str, Any]) -> None:
+    """Fold S2 citation edges into `out` (representative snippet / intent / flag).
+
+    :param edges: The raw ``/citations`` edge list (non-dict entries are ignored).
+    :param out: The context bundle mutated in place.
+    """
     for edge in edges:
         if not isinstance(edge, dict):
             continue
@@ -308,7 +334,6 @@ def _s2_context(client: HttpClient, s2_paper_id: str) -> dict[str, Any]:
             out["is_influential"] = True
     if out["is_influential"] is None and edges:
         out["is_influential"] = False
-    return out
 
 
 def enrich(

--- a/honest-scholar/tests/test_literature.py
+++ b/honest-scholar/tests/test_literature.py
@@ -18,9 +18,12 @@ runner = CliRunner()
 
 
 class FakeResponse:
-    def __init__(self, status_code: int, payload: Any) -> None:
+    def __init__(
+        self, status_code: int, payload: Any, headers: dict[str, str] | None = None
+    ) -> None:
         self.status_code = status_code
         self._payload = payload
+        self.headers: dict[str, str] = headers or {}
 
     def json(self) -> Any:
         return self._payload
@@ -593,3 +596,154 @@ def test_lit_client_rejects_non_mapping_config(
     with pytest.raises(typer.Exit) as exc:
         cli._lit_client()
     assert exc.value.exit_code == 1
+
+
+# --- rate-limit / transient-error honesty (honest-scholar#41) ----------------
+
+
+def test_http_honors_retry_after_header() -> None:
+    sleeps: list[float] = []
+    session = FakeSession(
+        {
+            "https://x": [
+                FakeResponse(429, {}, {"Retry-After": "7"}),
+                FakeResponse(200, {"ok": 1}),
+            ]
+        }
+    )
+    client = http.HttpClient(session=session, sleep=sleeps.append, cache_dir=None)
+    assert client.get_json("https://x") == {"ok": 1}
+    assert sleeps == [7.0]  # honored the header, not the blind 2**0 backoff
+
+
+def test_http_retry_after_http_date_falls_back_to_backoff() -> None:
+    sleeps: list[float] = []
+    session = FakeSession(
+        {
+            "https://x": [
+                FakeResponse(429, {}, {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}),
+                FakeResponse(200, {"ok": 1}),
+            ]
+        }
+    )
+    client = http.HttpClient(session=session, sleep=sleeps.append, cache_dir=None)
+    assert client.get_json("https://x") == {"ok": 1}
+    # An HTTP-date is unparsable → ignored → exponential backoff (2**0) + jitter.
+    assert len(sleeps) == 1
+    assert 1.0 <= sleeps[0] < 2.0
+
+
+def test_http_429_exhaustion_raises_rate_limit_error() -> None:
+    session = FakeSession({"https://x": FakeResponse(429, {})})
+    client = http.HttpClient(
+        session=session, sleep=lambda _s: None, cache_dir=None, max_retries=2
+    )
+    with pytest.raises(http.RateLimitError, match="giving up"):
+        client.get_json("https://x")
+
+
+def test_http_503_with_retry_after_raises_rate_limit_error() -> None:
+    session = FakeSession({"https://x": FakeResponse(503, {}, {"Retry-After": "1"})})
+    client = http.HttpClient(
+        session=session, sleep=lambda _s: None, cache_dir=None, max_retries=2
+    )
+    with pytest.raises(http.RateLimitError):
+        client.get_json("https://x")
+
+
+def test_http_503_without_retry_after_is_plain_http_error() -> None:
+    session = FakeSession({"https://x": FakeResponse(503, {})})
+    client = http.HttpClient(
+        session=session, sleep=lambda _s: None, cache_dir=None, max_retries=2
+    )
+    with pytest.raises(http.HttpError) as exc:
+        client.get_json("https://x")
+    assert not isinstance(exc.value, http.RateLimitError)  # 503 sans header is not RL
+
+
+def test_resolve_rate_limit_propagates_not_miss() -> None:
+    # A throttle must never be recorded as {resolved: False} ("no such work").
+    client = _client(
+        {"https://api.openalex.org/works/W1": FakeResponse(429, {})}, max_retries=2
+    )
+    with pytest.raises(http.RateLimitError):
+        graph.resolve("W1", client=client)
+
+
+def test_resolve_404_still_returns_genuine_miss() -> None:
+    # The genuine not-found path is preserved: 404 → resolved False, not a raise.
+    rec = graph.resolve("W404", client=_client({}))
+    assert rec["resolved"] is False
+
+
+def test_resolve_s2_crossref_rate_limit_propagates() -> None:
+    client = _client({f"{_S2}/paper/CorpusId:9": FakeResponse(429, {})}, max_retries=2)
+    with pytest.raises(http.RateLimitError):
+        graph.resolve("CorpusId:9", client=client)
+
+
+def test_enrich_s2_context_meta_rate_limit_propagates() -> None:
+    client = _client(
+        {
+            "https://api.openalex.org/works/W1": _WORK,
+            f"{_S2}/paper/DOI:10.1234/abc": FakeResponse(429, {}),
+        },
+        s2_key="k",
+        max_retries=2,
+    )
+    with pytest.raises(http.RateLimitError):
+        graph.enrich(["W1"], client=client, with_context=True)
+
+
+def test_enrich_s2_context_citations_rate_limit_propagates() -> None:
+    client = _client(
+        {
+            "https://api.openalex.org/works/W1": _WORK,
+            f"{_S2}/paper/DOI:10.1234/abc": {"externalIds": {"CorpusId": 5}},
+            f"{_S2}/paper/DOI:10.1234/abc/citations": FakeResponse(429, {}),
+        },
+        s2_key="k",
+        max_retries=2,
+    )
+    with pytest.raises(http.RateLimitError):
+        graph.enrich(["W1"], client=client, with_context=True)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["literature", "resolve", "W1"],
+        ["literature", "cites", "W1"],
+        ["literature", "refs", "W1"],
+        ["literature", "enrich", "W1"],
+        ["literature", "neighbors", "W1"],
+    ],
+)
+def test_cli_rate_limit_exits_1_with_actionable_message(
+    argv: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(
+        {"https://api.openalex.org/works/W1": FakeResponse(429, {})}, max_retries=2
+    )
+    monkeypatch.setattr(cli, "_lit_client", lambda: client)
+    result = runner.invoke(app, argv)
+    assert result.exit_code == 1
+    assert not isinstance(result.exception, http.RateLimitError)  # no traceback
+    assert "rate-limited" in result.stderr
+    assert "S2_API_KEY" in result.stderr
+
+
+def test_cli_generic_http_error_exits_1_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A non-rate-limit transport failure exits cleanly with a generic message.
+    routes = {
+        "https://api.openalex.org/works/W1": _WORK,
+        "https://api.openalex.org/works": FakeResponse(403, {}),
+    }
+    monkeypatch.setattr(cli, "_lit_client", lambda: _client(routes))
+    result = runner.invoke(app, ["literature", "cites", "W1"])
+    assert result.exit_code == 1
+    assert not isinstance(result.exception, http.HttpError)  # no traceback
+    assert "literature request failed" in result.stderr
+    assert "403" in result.stderr


### PR DESCRIPTION
## Why

Fixes #41. The HTTP layer had one rate-limit mechanism (blind exponential backoff) and callers folded exhaustion into a semantic "miss". For an honesty-branded tool, reporting "we were throttled" as "this paper does not exist" is a correctness bug. Surfaced during #30 live validation: keyless Semantic Scholar throttling made `resolve(CorpusId:…)` return `resolved: False`, indistinguishable from a genuine not-found.

## Behavior change

- **A throttle is no longer reported as a miss.** `resolve`, `_s2_crossref`, and `_s2_context` now let a rate-limit propagate instead of returning `{resolved: False}` / all-`None`. A genuine not-found (`404` / empty body) still returns `resolved: False`.
- **No tracebacks.** `literature resolve/cites/refs/enrich/neighbors` catch `HttpError`/`RateLimitError` and exit `1` with an actionable message — for a rate-limit: `rate-limited by Semantic Scholar after N retries — set S2_API_KEY for higher limits, or retry later`; otherwise a generic clean message.
- **`Retry-After` is honored** on `429`/`503` (integer seconds; an HTTP-date or unparsable value is ignored and falls back to backoff). The exponential fallback now adds jitter.

## How

- `core/http.py`: new `RateLimitError(HttpError)`. Exhaustion on a rate-limit signal (`429`, or `503` carrying `Retry-After`) raises `RateLimitError`; other exhaustion stays `HttpError`. `_fetch` parses `Retry-After` and computes backoff via a small `_backoff` helper. The `Response` `Protocol` gains a read-only `headers` mapping.
- `literature/graph.py`: re-raise `RateLimitError` in `resolve` / `_s2_crossref` / `_s2_context`; extracted the S2 edge-aggregation loop into a helper.
- `cli.py`: a `_http_guard` context manager wraps each literature command.
- `tests/test_literature.py`: mocked, deterministic regressions (Retry-After honored, HTTP-date fallback, exhaustion → `RateLimitError`, propagation vs genuine miss, clean CLI exits). `FakeResponse` now carries `headers`.

## Scope note

Only the issue's **Core** checklist. The proactive per-host token-bucket/throttle is left as the issue's follow-up. Key handling is unchanged (`S2_API_KEY` from `os.environ`), consistent with the separately-tracked #42.

## Verification

`uv run pytest -q` → `203 passed, 14 skipped`, **100.00% coverage** (`fail_under = 100`). `ruff format`, `ruff check`, `mypy`, and `codespell` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
