### PR TITLE
fix: honesty-of-failure defects — surface failures, never misreport (#43)

### DIFF
--- a/honest-scholar/honest_scholar/cli.py
+++ b/honest-scholar/honest_scholar/cli.py
@@ -131,6 +131,12 @@ def _lit_client() -> HttpClient:
         typer.echo(f"invalid .honest-scholar/config.yml: {exc}", err=True)
         raise typer.Exit(code=1) from exc
     lit = config.get("literature")
+    if lit is not None and not isinstance(lit, dict):
+        typer.echo(
+            "invalid .honest-scholar/config.yml: 'literature' must be a mapping",
+            err=True,
+        )
+        raise typer.Exit(code=1)
     mailto = lit.get("mailto") if isinstance(lit, dict) else None
     return HttpClient(
         cache_dir=Path(".honest-scholar/cache/http"),
@@ -575,12 +581,14 @@ def record(
     :raises typer.Exit: Code 1 on a guard violation or malformed artifact.
     """
     gap_list = [g.strip() for g in gaps.split("||") if g.strip()]
-    transcript_text: str | None = None
-    if transcript == "-":
-        transcript_text = sys.stdin.read()
-    elif transcript:
-        transcript_text = Path(transcript).read_text(encoding="utf-8")
     try:
+        transcript_text: str | None = None
+        if transcript == "-":
+            transcript_text = sys.stdin.read()
+        elif transcript:
+            # Inside the try so an unreadable transcript exits 1 cleanly rather
+            # than tracebacking (it is an ``OSError`` like the other read paths).
+            transcript_text = Path(transcript).read_text(encoding="utf-8")
         result = record_mod.record(
             artifact,
             target,

--- a/honest-scholar/honest_scholar/core/config.py
+++ b/honest-scholar/honest_scholar/core/config.py
@@ -20,13 +20,18 @@ def load_config(path: str | Path = DEFAULT_CONFIG_PATH) -> dict[str, Any]:
     :param path: Path to the config file; defaults to ``.honest-scholar/config.yml``.
     :returns: The parsed configuration mapping (empty if the file is absent or
         blank).
-    :raises ValueError: If the file exists but does not contain a YAML mapping.
+    :raises ValueError: If the file exists but is not valid YAML, or does not
+        contain a YAML mapping.
     """
     config_path = Path(path)
     if not config_path.is_file():
         return {}
     with config_path.open(encoding="utf-8") as handle:
-        data = yaml.safe_load(handle)
+        try:
+            data = yaml.safe_load(handle)
+        except yaml.YAMLError as exc:
+            msg = f"{config_path}: invalid YAML: {exc}"
+            raise ValueError(msg) from exc
     if data is None:
         return {}
     if not isinstance(data, dict):

--- a/honest-scholar/honest_scholar/core/http.py
+++ b/honest-scholar/honest_scholar/core/http.py
@@ -118,7 +118,12 @@ class HttpClient:
             return None
         path = self.cache_dir / f"{key}.json"
         if path.is_file():
-            data: JsonValue = json.loads(path.read_text(encoding="utf-8"))
+            try:
+                data: JsonValue = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                # A truncated/corrupt entry (e.g. an interrupted ``_store``) is
+                # treated as a cache miss and re-fetched, never a raw traceback.
+                return None
             return data
         return None
 
@@ -126,7 +131,12 @@ class HttpClient:
         if self.cache_dir is None:
             return
         self.cache_dir.mkdir(parents=True, exist_ok=True)
-        (self.cache_dir / f"{key}.json").write_text(json.dumps(value), encoding="utf-8")
+        # Write to a temp file then atomically rename, so an interruption can
+        # never leave a half-written (corrupt) cache entry behind.
+        path = self.cache_dir / f"{key}.json"
+        tmp = self.cache_dir / f"{key}.json.tmp"
+        tmp.write_text(json.dumps(value), encoding="utf-8")
+        tmp.replace(path)
 
     def get_json(
         self,

--- a/honest-scholar/honest_scholar/dataset/manifest.py
+++ b/honest-scholar/honest_scholar/dataset/manifest.py
@@ -196,6 +196,28 @@ def _opt_bool(value: Any) -> bool | None:
     return value if isinstance(value, bool) else None
 
 
+def _int_or_error(value: Any, where: str, fieldname: str) -> int | None:
+    """Coerce an optional integer field, raising :class:`ManifestError`.
+
+    Accepts real ints and numeric strings (``int(value)``); ``None`` passes
+    through. A non-numeric value is a clean error rather than a silent drop.
+
+    :param value: The raw value to coerce.
+    :param where: Location prefix for the error message.
+    :param fieldname: The field name to name in the error message.
+    :returns: The coerced integer, or ``None`` when `value` is ``None``.
+    :raises ManifestError: If `value` is non-``None`` and not integer-coercible.
+    """
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (ValueError, TypeError) as exc:
+        raise ManifestError(
+            f"{where}: '{fieldname}' must be an integer, got {value!r}"
+        ) from exc
+
+
 def _decode_file_ref(raw: Any, where: str) -> FileRef:
     """Decode one ``files[]`` element, raising :class:`ManifestError` on shape."""
     if not isinstance(raw, dict):
@@ -205,14 +227,9 @@ def _decode_file_ref(raw: Any, where: str) -> FileRef:
         sha256 = str(raw["sha256"])
     except KeyError as exc:
         raise ManifestError(f"{where}: file missing required key {exc}") from exc
-    size = raw.get("size")
-    try:
-        size_int = int(size) if size is not None else None
-    except (ValueError, TypeError) as exc:
-        raise ManifestError(
-            f"{where}: 'size' must be an integer, got {size!r}"
-        ) from exc
-    return FileRef(path=path, sha256=sha256, size=size_int)
+    return FileRef(
+        path=path, sha256=sha256, size=_int_or_error(raw.get("size"), where, "size")
+    )
 
 
 def _decode_retrieval(raw: Any, where: str) -> Retrieval:
@@ -230,12 +247,7 @@ def _decode_citation(raw: Any, where: str) -> Citation:
     if not isinstance(raw, dict):
         raise ManifestError(f"{where}: 'citation' must be a mapping")
     year = raw.get("publicationYear", raw.get("publication_year"))
-    try:
-        year_int = int(year) if year is not None else None
-    except (ValueError, TypeError) as exc:
-        raise ManifestError(
-            f"{where}: 'publicationYear' must be an integer, got {year!r}"
-        ) from exc
+    year_int = _int_or_error(year, where, "publicationYear")
     return Citation(
         identifier=_opt_str(raw.get("identifier")),
         creator=_opt_str(raw.get("creator")),
@@ -515,7 +527,10 @@ def entry_from_croissant(json_ld: dict[str, Any]) -> DatasetEntry:
 
     :param json_ld: A parsed Croissant / schema.org ``Dataset`` document.
     :returns: A partial :class:`DatasetEntry` draft.
-    :raises ManifestError: If the document has no usable ``name``.
+    :raises ManifestError: If the document has no usable ``name``, or a
+        ``distribution`` entry is a malformed ``FileObject`` (not a mapping, or
+        missing ``contentUrl`` / ``sha256``). A malformed file is surfaced, never
+        silently dropped — "no distribution" is distinct from "a bad file".
     """
     name = json_ld.get("name")
     if not name:
@@ -526,20 +541,23 @@ def entry_from_croissant(json_ld: dict[str, Any]) -> DatasetEntry:
     title = str(name) if str(name) != entry_id else None
 
     files: list[FileRef] = []
-    for obj in json_ld.get("distribution") or []:
+    for i, obj in enumerate(json_ld.get("distribution") or []):
+        loc = f"croissant: distribution[{i}]"
         if not isinstance(obj, dict):
-            continue
+            raise ManifestError(f"{loc}: FileObject must be a mapping")
         url = obj.get("contentUrl")
         sha = obj.get("sha256")
-        if url and sha:
-            size = obj.get("contentSize")
-            files.append(
-                FileRef(
-                    path=str(url),
-                    sha256=str(sha),
-                    size=size if isinstance(size, int) else None,
-                )
+        if not url or not sha:
+            raise ManifestError(
+                f"{loc}: FileObject missing 'contentUrl' and/or 'sha256'"
             )
+        files.append(
+            FileRef(
+                path=str(url),
+                sha256=str(sha),
+                size=_int_or_error(obj.get("contentSize"), loc, "contentSize"),
+            )
+        )
 
     return DatasetEntry(
         id=entry_id,

--- a/honest-scholar/honest_scholar/dataset/retrieval.py
+++ b/honest-scholar/honest_scholar/dataset/retrieval.py
@@ -152,8 +152,17 @@ def _blob_path(cache_dir: Path, sha256: str) -> Path:
 
 
 def _verified(path: Path, sha256: str) -> bool:
-    """Return whether `path` exists and its SHA-256 matches (else it is absent)."""
-    return path.is_file() and sha256_file(path) == _bare(sha256)
+    """Return whether `path` exists and its SHA-256 matches (else it is absent).
+
+    A present-but-unreadable file (``OSError`` while hashing) is treated as
+    absent, so the resolution chain moves on instead of crashing.
+    """
+    if not path.is_file():
+        return False
+    try:
+        return sha256_file(path) == _bare(sha256)
+    except OSError:
+        return False
 
 
 def _resolve_file(
@@ -262,7 +271,9 @@ def verify(entry: DatasetEntry, *, cache_dir: str | Path) -> VerifyReport:
 
     :param entry: The dataset entry to verify.
     :param cache_dir: The content-addressed cache directory.
-    :returns: A per-file verification report.
+    :returns: A per-file verification report. A present-but-unreadable file
+        (``OSError`` while hashing) is folded into ``corrupt`` rather than
+        crashing the offline report.
     """
     cache = Path(cache_dir)
     report = VerifyReport(entry_id=entry.id)
@@ -270,7 +281,13 @@ def verify(entry: DatasetEntry, *, cache_dir: str | Path) -> VerifyReport:
         path = Path(ref.path) if entry.tier == "A" else _blob_path(cache, ref.sha256)
         if not path.is_file():
             report.missing.append(ref.path)
-        elif sha256_file(path) == _bare(ref.sha256):
+            continue
+        try:
+            digest = sha256_file(path)
+        except OSError:
+            report.corrupt.append(ref.path)
+            continue
+        if digest == _bare(ref.sha256):
             report.verified.append(ref.path)
         else:
             report.corrupt.append(ref.path)

--- a/honest-scholar/honest_scholar/exploration/backlog.py
+++ b/honest-scholar/honest_scholar/exploration/backlog.py
@@ -122,13 +122,20 @@ class Backlog:
         :param text: The markdown document (may contain prose around the table).
         :param level: The backlog level.
         :returns: The parsed backlog.
+        :raises BacklogError: If table-like content is present but never anchored
+            by a GFM separator (a malformed table is not a genuinely empty one),
+            or a data row's cell count does not match the header (a ragged row
+            would otherwise silently pad/drop required columns).
         """
         header: list[str] | None = None
         rows: list[Row] = []
         candidate: list[str] | None = None
+        pending = 0  # consecutive unconfirmed pipe rows (a table shape sans separator)
+        saw_table_shape = False
         for line in text.splitlines():
             if "|" not in line:
                 candidate = None  # prose breaks a pending header candidate
+                pending = 0
                 continue
             cells = _split_cells(line)
             if _is_separator(cells):
@@ -137,15 +144,24 @@ class Backlog:
                 if header is None and candidate is not None:
                     header = candidate
                     candidate = None
+                    pending = 0
                 continue
             if header is None:
                 candidate = cells  # a header only if a separator follows it
+                pending += 1
+                if pending >= 2:  # header + row(s) shape with no separator between
+                    saw_table_shape = True
                 continue
-            rows.append(
-                {
-                    header[i]: (cells[i] if i < len(cells) else "")
-                    for i in range(len(header))
-                }
+            if len(cells) != len(header):
+                raise BacklogError(
+                    f"ragged backlog row: {len(cells)} cells, header has "
+                    f"{len(header)} ({cells!r})"
+                )
+            rows.append({header[i]: cells[i] for i in range(len(header))})
+        if header is None and saw_table_shape:
+            raise BacklogError(
+                "malformed backlog table: table-like rows with no GFM '|---|' "
+                "separator to anchor a header"
             )
         return cls(level=level, rows=rows)
 
@@ -245,9 +261,12 @@ class Backlog:
 
         :param row_id: The row to rank.
         :param scores: Column→value scores (e.g. ``feas``, ``interest``, ``EIG``,
-            ``frame``); unknown columns for this level are ignored.
+            ``frame``). A score key not in this level's columns is a hard error,
+            never silently dropped — a mistyped or level-mismatched score must
+            not vanish while the row is still marked ``ranked``.
         :returns: The updated row.
-        :raises BacklogError: If the row's status is not ``candidate``/``parked``.
+        :raises BacklogError: If the row's status is not ``candidate``/``parked``,
+            or a score key is not a column of this level.
         """
         row = self.get(row_id)
         if row.get("status") not in _RANK_SOURCES:
@@ -255,9 +274,14 @@ class Backlog:
                 f"cannot rank {row_id!r} from status {row.get('status')!r} "
                 f"(must be one of {sorted(_RANK_SOURCES)})"
             )
+        unknown = [key for key in scores if key not in self.columns]
+        if unknown:
+            raise BacklogError(
+                f"unknown score key(s) {sorted(unknown)} for level {self.level!r} "
+                f"(columns: {self.columns})"
+            )
         for key, value in scores.items():
-            if key in self.columns:
-                row[key] = value
+            row[key] = value
         row["status"] = "ranked"
         return row
 

--- a/honest-scholar/honest_scholar/literature/graph.py
+++ b/honest-scholar/honest_scholar/literature/graph.py
@@ -117,9 +117,18 @@ def enrich_work(work: dict[str, Any]) -> dict[str, Any]:
 
 
 def _fetch_work(client: HttpClient, openalex_id: str) -> dict[str, Any]:
-    """Fetch one OpenAlex work by its ``W…`` id."""
-    data = client.get_json(f"{OPENALEX}/works/{openalex_id}")
-    return data if isinstance(data, dict) else {}
+    """Fetch one OpenAlex work by its ``W…`` id.
+
+    :raises HttpError: If the 200 body is not a work object (non-dict or no
+        ``id``); a hollow ``{}`` is never returned in its place.
+    """
+    from honest_scholar.core.http import HttpError
+
+    url = f"{OPENALEX}/works/{openalex_id}"
+    data = client.get_json(url)
+    if not isinstance(data, dict) or not data.get("id"):
+        raise HttpError(f"{url}: response is not an OpenAlex work object")
+    return data
 
 
 def _arxiv_doi(arxiv_id: str) -> str:
@@ -224,7 +233,12 @@ def cites(
     :param client: The HTTP client.
     :param max_results: Cap on rows returned (all citations if ``None``).
     :returns: One record per citing work with provenance ``{via: "openalex"}``.
+    :raises HttpError: If a page mid-pagination is not a JSON object. Stopping
+        silently here would return a truncated frontier as if complete, so it is
+        a hard error (mirroring :meth:`HttpClient.get_json`'s non-JSON path).
     """
+    from honest_scholar.core.http import HttpError
+
     results: list[dict[str, Any]] = []
     cursor: str | None = "*"
     while cursor:
@@ -233,7 +247,7 @@ def cites(
             {"filter": f"cites:{openalex_id}", "per-page": "200", "cursor": cursor},
         )
         if not isinstance(page, dict):
-            break
+            raise HttpError(f"{OPENALEX}/works: citation page is not a JSON object")
         for work in page.get("results", []):
             record = enrich_work(work)
             record["provenance"] = {"source_id": openalex_id, "via": "openalex"}
@@ -434,6 +448,9 @@ def neighbors(
         raise ValueError(f"unknown kind {kind!r} (want cocite | couple | both)")
     out: dict[str, Any] = {}
     citers = cites(openalex_id, client=client, max_results=frontier)
+    # ``cites`` now either paginates to completion or raises on a bad page, so a
+    # short list genuinely means the frontier was exhausted; hitting the cap is
+    # the only way to be incomplete, and that is what ``capped`` reports.
     out["capped"] = len(citers) >= frontier
     if kind in ("cocite", "both"):
         out["cocitation"] = _cocitation(openalex_id, citers, client, top)

--- a/honest-scholar/tests/test_backlog.py
+++ b/honest-scholar/tests/test_backlog.py
@@ -270,10 +270,30 @@ def test_split_cells_without_borders() -> None:
     assert b._split_cells("a | b | c") == ["a", "b", "c"]
 
 
-def test_loads_short_row_pads() -> None:
+def test_loads_ragged_row_raises() -> None:
+    # A short row would silently pad required columns (id/status/provenance).
     text = "| id | one-line | status |\n|---|---|---|\n| h1 |\n"
-    board = b.Backlog.loads(text, "hypothesis")
-    assert board.rows[0]["one-line"] == ""
+    with pytest.raises(b.BacklogError, match="ragged backlog row"):
+        b.Backlog.loads(text, "hypothesis")
+
+
+def test_loads_over_wide_row_raises() -> None:
+    text = "| id | status |\n|---|---|\n| h1 | parked | extra |\n"
+    with pytest.raises(b.BacklogError, match="ragged backlog row"):
+        b.Backlog.loads(text, "hypothesis")
+
+
+def test_loads_malformed_table_without_separator_raises() -> None:
+    # Table-like rows with no GFM separator must not read as a genuinely empty
+    # backlog (which would be indistinguishable from a real one).
+    text = "| id | one-line | status |\n| h1 | an idea | parked |\n"
+    with pytest.raises(b.BacklogError, match="malformed backlog table"):
+        b.Backlog.loads(text, "hypothesis")
+
+
+def test_loads_blank_document_is_empty_not_malformed() -> None:
+    assert b.Backlog.loads("", "hypothesis").rows == []
+    assert b.Backlog.loads("just prose, no table\n", "hypothesis").rows == []
 
 
 def test_get_second_row() -> None:
@@ -283,11 +303,13 @@ def test_get_second_row() -> None:
     assert board.get("z")["one-line"] == "second"
 
 
-def test_rank_ignores_foreign_score() -> None:
+def test_rank_rejects_foreign_score() -> None:
     board = b.Backlog(level="paper")  # paper level has no EIG column
     board.add("p", "own", row_id="p1")
-    board.rank("p1", EIG="high", feas="med")
-    assert "EIG" not in board.get("p1")
+    # A level-mismatched score must not vanish silently while the row is ranked.
+    with pytest.raises(b.BacklogError, match="unknown score key"):
+        board.rank("p1", EIG="high", feas="med")
+    assert board.get("p1")["status"] == "candidate"  # transition did not happen
 
 
 def test_append_registry_without_trailing_newline(tmp_path: Path) -> None:

--- a/honest-scholar/tests/test_config.py
+++ b/honest-scholar/tests/test_config.py
@@ -36,3 +36,11 @@ def test_non_mapping_raises(tmp_path: Path) -> None:
     path.write_text("- just\n- a\n- list\n", encoding="utf-8")
     with pytest.raises(ValueError, match="expected a YAML mapping"):
         load_config(path)
+
+
+def test_malformed_yaml_is_clean_value_error(tmp_path: Path) -> None:
+    path = tmp_path / "config.yml"
+    # Unbalanced flow sequence — a YAMLError, surfaced as a clean ValueError.
+    path.write_text("literature: [unclosed\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid YAML"):
+        load_config(path)

--- a/honest-scholar/tests/test_literature.py
+++ b/honest-scholar/tests/test_literature.py
@@ -109,6 +109,21 @@ def test_http_cache_avoids_second_call(tmp_path: Any) -> None:
     assert len(session.calls) == 1  # second served from cache
 
 
+def test_http_corrupt_cache_is_refetched_not_traceback(tmp_path: Any) -> None:
+    session = FakeSession({"https://x": {"n": 1}})
+    client = http.HttpClient(session=session, cache_dir=tmp_path, sleep=lambda _s: None)
+    key = http._cache_key("https://x", {})
+    (tmp_path / f"{key}.json").write_text("{ not valid json", encoding="utf-8")
+    # A corrupt entry (e.g. an interrupted store) is a cache miss, not a crash.
+    assert client.get_json("https://x") == {"n": 1}
+    assert len(session.calls) == 1
+    # The re-fetch atomically overwrote it: a second call hits the repaired cache
+    # and no temp file is left behind.
+    assert client.get_json("https://x") == {"n": 1}
+    assert len(session.calls) == 1
+    assert not (tmp_path / f"{key}.json.tmp").exists()
+
+
 # --- graph ------------------------------------------------------------------
 
 
@@ -183,6 +198,19 @@ def test_cites_respects_max() -> None:
 def test_refs_reads_referenced_works() -> None:
     client = _client({"https://api.openalex.org/works/W1": _WORK})
     assert graph.refs("W1", client=client) == ["W9", "W8"]
+
+
+def test_fetch_work_non_dict_raises() -> None:
+    # A non-dict 200 body must not be coerced to a hollow {} work.
+    client = _client({"https://api.openalex.org/works/W1": ["not-a-dict"]})
+    with pytest.raises(http.HttpError, match="not an OpenAlex work"):
+        graph.refs("W1", client=client)
+
+
+def test_fetch_work_idless_body_raises() -> None:
+    client = _client({"https://api.openalex.org/works/W1": {}})  # dict but no 'id'
+    with pytest.raises(http.HttpError, match="not an OpenAlex work"):
+        graph.refs("W1", client=client)
 
 
 def test_enrich_with_context_degrades_without_key() -> None:
@@ -267,9 +295,21 @@ def test_resolve_empty_body_is_miss() -> None:
     assert graph.resolve("W1", client=client)["resolved"] is False
 
 
-def test_cites_non_dict_page_stops() -> None:
+def test_cites_non_dict_first_page_raises() -> None:
     client = _client({"https://api.openalex.org/works": ["not-a-dict"]})
-    assert graph.cites("W1", client=client) == []
+    with pytest.raises(http.HttpError, match="not a JSON object"):
+        graph.cites("W1", client=client)
+
+
+def test_cites_non_dict_page_mid_pagination_raises() -> None:
+    # A truncated frontier must never be returned as if complete.
+    page1 = {
+        "results": [{"id": "https://openalex.org/W2"}],
+        "meta": {"next_cursor": "c2"},
+    }
+    client = _client({"https://api.openalex.org/works": [page1, "not-a-dict"]})
+    with pytest.raises(http.HttpError, match="not a JSON object"):
+        graph.cites("W1", client=client)
 
 
 def test_enrich_without_context() -> None:
@@ -747,3 +787,17 @@ def test_cli_generic_http_error_exits_1_cleanly(
     assert not isinstance(result.exception, http.HttpError)  # no traceback
     assert "literature request failed" in result.stderr
     assert "403" in result.stderr
+
+
+def test_lit_client_rejects_non_dict_literature_block(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    cfg = tmp_path / ".honest-scholar"
+    cfg.mkdir()
+    # A present-but-non-dict `literature:` block is a config error, not silently
+    # discarded (which would drop `mailto` without a word).
+    (cfg / "config.yml").write_text("literature: just-a-string\n", encoding="utf-8")
+    with pytest.raises(typer.Exit) as exc:
+        cli._lit_client()
+    assert exc.value.exit_code == 1

--- a/honest-scholar/tests/test_manifest.py
+++ b/honest-scholar/tests/test_manifest.py
@@ -343,14 +343,12 @@ def test_validate_incomplete_citation_warns() -> None:
     assert any("citation" in w for w in report.warnings)
 
 
-def test_entry_from_croissant_mixed_distribution() -> None:
+def test_entry_from_croissant_valid_distribution() -> None:
     draft = m.entry_from_croissant(
         {
             "name": "x",
             "citeAs": "Author (2020). X.",
             "distribution": [
-                "not-a-dict",
-                {"contentUrl": "u1"},  # missing sha256 -> skipped
                 {"contentUrl": "u2", "sha256": _HEX, "contentSize": 5},
             ],
         }
@@ -358,6 +356,44 @@ def test_entry_from_croissant_mixed_distribution() -> None:
     assert [f.path for f in draft.files] == ["u2"]
     assert draft.files[0].size == 5
     assert draft.citation is not None
+
+
+def test_entry_from_croissant_non_dict_file_object_raises() -> None:
+    with pytest.raises(m.ManifestError, match=r"distribution\[0\].*must be a mapping"):
+        m.entry_from_croissant({"name": "x", "distribution": ["not-a-dict"]})
+
+
+def test_entry_from_croissant_file_object_missing_sha_raises() -> None:
+    # A malformed FileObject is surfaced, not silently dropped.
+    with pytest.raises(m.ManifestError, match=r"distribution\[0\].*contentUrl"):
+        m.entry_from_croissant({"name": "x", "distribution": [{"contentUrl": "u1"}]})
+
+
+def test_entry_from_croissant_file_object_missing_url_raises() -> None:
+    with pytest.raises(m.ManifestError, match=r"distribution\[0\]"):
+        m.entry_from_croissant({"name": "x", "distribution": [{"sha256": _HEX}]})
+
+
+def test_entry_from_croissant_numeric_string_content_size_accepted() -> None:
+    draft = m.entry_from_croissant(
+        {
+            "name": "x",
+            "distribution": [{"contentUrl": "u", "sha256": _HEX, "contentSize": "42"}],
+        }
+    )
+    assert draft.files[0].size == 42
+
+
+def test_entry_from_croissant_non_numeric_content_size_raises() -> None:
+    with pytest.raises(m.ManifestError, match="'contentSize' must be an integer"):
+        m.entry_from_croissant(
+            {
+                "name": "x",
+                "distribution": [
+                    {"contentUrl": "u", "sha256": _HEX, "contentSize": "big"}
+                ],
+            }
+        )
 
 
 def test_croissant_minimal_entry_omits_absent_fields() -> None:

--- a/honest-scholar/tests/test_record.py
+++ b/honest-scholar/tests/test_record.py
@@ -290,6 +290,27 @@ def test_cli_record_transcript_from_stdin(tmp_path: Path) -> None:
     assert (tmp_path / "log").exists()
 
 
+def test_cli_record_unreadable_transcript_exits_1_cleanly(tmp_path: Path) -> None:
+    artifact = _artifact(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "defend",
+            "record",
+            "--artifact",
+            str(artifact),
+            "--target",
+            "methodology",
+            "--transcript",
+            str(tmp_path / "missing.md"),  # unreadable transcript
+            "--log-dir",
+            str(tmp_path / "log"),
+        ],
+    )
+    assert result.exit_code == 1  # clean exit, not a traceback
+    assert "defend record failed" in result.stderr
+
+
 def test_patch_blank_line_and_trailing_top_key() -> None:
     text = (
         "---\nstatus:\n\n  understanding: {status: pending, unresolved: []}\n"

--- a/honest-scholar/tests/test_retrieval.py
+++ b/honest-scholar/tests/test_retrieval.py
@@ -94,6 +94,37 @@ def test_verify_flags_missing_and_corrupt(tmp_path: Path) -> None:
     assert r.verify(entry, cache_dir=cache).corrupt == ["data/f.bin"]
 
 
+def test_verify_unreadable_file_is_corrupt_not_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache = tmp_path / "cache"
+    _write(cache / "sha256" / ("a" * 64))  # a present-but-(soon)-unreadable blob
+    entry = _entry("B", "a" * 64, retrieval=m.Retrieval(kind="http", url="https://x"))
+
+    def _boom(_p: object, **_kw: object) -> str:
+        raise PermissionError("unreadable")
+
+    monkeypatch.setattr(r, "sha256_file", _boom)
+    report = r.verify(entry, cache_dir=cache)
+    assert report.corrupt == ["data/f.bin"]  # folded into corrupt, no traceback
+    assert not report.ok
+
+
+def test_verified_unreadable_present_file_treated_as_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write(Path("data/f.bin"))
+
+    def _boom(_p: object, **_kw: object) -> str:
+        raise PermissionError("unreadable")
+
+    monkeypatch.setattr(r, "sha256_file", _boom)
+    # An unreadable Tier-A file is absent to the chain, which then fails cleanly.
+    with pytest.raises(r.RetrievalError, match="missing or corrupt"):
+        r.fetch(_entry("A", "a" * 64), cache_dir="cache")
+
+
 # --- fetch chain ------------------------------------------------------------
 
 


### PR DESCRIPTION
Fixes all 12 confirmed honesty-of-failure defects from #43 — each was a failure/uncertain condition folded into a normal-looking result, or a traceback where a clean report is contracted. Every fix turns that into a clean typed error (`HttpError`/`ManifestError`/`BacklogError`/`ValueError`) or an explicitly-signalled result, matching each module's existing contract, with a deterministic regression test.

Closes #43

## Medium — misreports data

| # | `file` → function | What changed |
|---|---|---|
| 1 | `literature/graph.py` `cites` / `neighbors` | A non-dict page mid-pagination now raises `HttpError` (mirroring `get_json`'s non-JSON path) instead of `break`-ing and returning the citations so far as if complete. With silent truncation gone, `neighbors`' `capped = len(citers) >= frontier` is honest again (short list ⇒ frontier exhausted; only hitting the cap means incomplete). |
| 2 | `dataset/manifest.py` `entry_from_croissant` | A malformed `distribution` FileObject (non-mapping, or missing `contentUrl`/`sha256`) raises `ManifestError` naming `distribution[i]` instead of being silently skipped — "no distribution" is now distinct from "a bad file". |
| 3 | `core/http.py` `_cached` / `_store` | A corrupt/truncated cache entry is caught (`JSONDecodeError`) and treated as a cache miss (re-fetch) instead of a raw traceback; `_store` writes to a temp file then `Path.replace`s atomically, so an interrupted write can't leave a half-written entry. |
| 4 | `dataset/retrieval.py` `verify` / `_verified` | A present-but-unreadable file (`OSError` while hashing) is folded into `corrupt` in `verify`, and treated as absent in `_verified` (chain continues), instead of crashing the offline report / the fetch chain. |
| 5 | `exploration/backlog.py` `loads` | Table-like rows with no GFM `\|---\|` separator now raise `BacklogError` instead of returning an empty `Backlog` indistinguishable from a genuinely empty one. (Blank/prose-only docs still return empty.) |
| 6 | `exploration/backlog.py` `loads` | A ragged data row (cell count != header) raises `BacklogError` instead of silently padding/dropping required columns (`id`/`status`/`provenance`). |
| 7 | `exploration/backlog.py` `rank` | An unknown/level-mismatched score key raises `BacklogError` listing the keys instead of being silently dropped while the row is still marked `ranked`; docstring fixed. |

## Low — clean-error / consistency polish

| # | `file` → function | What changed |
|---|---|---|
| 8 | `core/config.py` `load_config` | Malformed YAML re-raised as `ValueError(f"{path}: invalid YAML: …")`, matching the non-mapping path the CLI already handles. |
| 9 | `literature/graph.py` `_fetch_work` | A non-dict / id-less 200 body raises `HttpError` (mirroring `resolve`) instead of being coerced to a hollow `{}` that propagates into `refs()`/`enrich()`. |
| 10 | `dataset/manifest.py` `entry_from_croissant` | Non-int `contentSize` now goes through the loader's `int()` coercion (shared `_int_or_error` helper, reused by `_decode_file_ref`/`_decode_citation`): numeric strings accepted, non-numeric raises — no more silent drop to `None`. |
| 11 | `cli.py` `record` | The transcript `read_text()` moved inside the `try/except (RecordError, OSError)` so a missing/unreadable transcript exits 1 cleanly instead of tracebacking. |
| 12 | `cli.py` `_lit_client` | A present-but-non-dict `literature` config block now echoes `invalid .honest-scholar/config.yml` and exits 1, instead of being silently discarded (dropping `mailto`). |

## Verification

- `uv run pytest -q` → **204 passed, 14 skipped**, coverage **100.00%** (statement+branch, `fail_under = 100` held).
- `uv run ruff format` · `uv run ruff check` (All checks passed) · `uv run mypy` (Success, 24 files) · `codespell` — all clean.
- No `# pragma: no cover` added.

## Coordination with #41 (rate-limit honesty)

This PR branches from `origin/main`, the same base as #41. Edits are kept localized to the named functions, but the two PRs both touch **`core/http.py`**, **`literature/graph.py`**, and **`cli.py`** — so whichever merges second will likely need a small rebase:

- `core/http.py`: #41 edits `_fetch`/`get_json` (+`RateLimitError`); this PR edits only `_cached`/`_store` — should auto-merge.
- `literature/graph.py`: #41 edits `resolve` + literature error propagation; this PR edits only `_fetch_work` and `cites`/`neighbors`. Note #41 may want to catch the new `HttpError` from `cites`/`_fetch_work` in the literature CLI commands (out of scope here).
- `cli.py`: #41 edits literature command error handling; this PR edits `_lit_client` and `defend record`. `_lit_client` is the most likely overlap point.

Nothing rate-limit-related is implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
