### PR TITLE
feat(core): unified API-key handling — CLI-managed JSON store + keys subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # honest-scholar plugin — consumers create these in THEIR repos, never here
 .honest-scholar/cache/          # http + dataset caches (cli.py writes here)
+.honest-scholar/keys.json       # CLI-owned API-key store (0600; ADR-0029)
 .honest-scholar/rclone.conf
 *.rclone.conf
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -318,7 +318,46 @@ coherent through-line. Never a paper count.
   defend claim <hypothesis-id>          # rehearse before you sign
   ```
 
-## 8. Everyday tips
+## 8. API keys & credentials
+
+Some services the tooling reaches key-gate their *useful* rate limits. Providing
+a key is optional — everything degrades gracefully without one — but it removes
+the throttling that otherwise stalls citation-graph work.
+
+| Key | Service | What it buys | How to obtain |
+|---|---|---|---|
+| `S2_API_KEY` | Semantic Scholar | Raises the rate limit far above the shared keyless pool (which throttles hard). | <https://www.semanticscholar.org/product/api#api-key> |
+| `OPENALEX_MAILTO` | OpenAlex | Joins the "polite pool" (a contact email) for faster, more reliable responses. | <https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication> |
+| `RCLONE_CONFIG_<REMOTE>_*` | Private dataset mirror | rclone remote credentials, handed to rclone as scoped env vars (no config file needed). | Per your rclone remote (see `rclone config`). |
+
+honest-scholar keeps keys in a **CLI-managed JSON store** at
+`.honest-scholar/keys.json` — never a `.env` — and reads them with
+**`os.environ` > store > unset** precedence, so an environment variable always
+wins (CI / secrets injection is unaffected) and an unset key just degrades the
+service. Manage the store with the `keys` command group:
+
+```
+honest-scholar keys set S2_API_KEY        # prompts hidden, or reads piped stdin
+echo "$MY_KEY" | honest-scholar keys set S2_API_KEY
+honest-scholar keys set < keys.json       # a JSON object sets many at once
+honest-scholar keys list                  # metadata + presence + source (never values)
+honest-scholar keys check                 # compact presence/source report
+honest-scholar keys unset S2_API_KEY
+honest-scholar keys path                  # print the resolved store path
+```
+
+The value is **never** taken from the command line — only from stdin or a hidden
+prompt — so a secret never lands in your shell history or the process list.
+`keys list`/`check` and `doctor` report only **presence and source**, never a
+value.
+
+> **Honesty caveat — plaintext at rest.** The store is **not encrypted**.
+> Gitignore (`.honest-scholar/keys.json` is ignored) and `0600` file permissions
+> limit exposure, but anyone who can read the file reads the keys. Treat it as
+> convenience storage, not a secret vault. OS-keychain backing behind the same
+> `keys` interface is a planned follow-up (issue #49).
+
+## 9. Everyday tips
 
 - **What honest-scholar will NOT do.** It will not make a material decision for you
   (confirm/refute, publish/no-go, defensible), will not write your paper

--- a/honest-scholar/README.md
+++ b/honest-scholar/README.md
@@ -39,10 +39,41 @@ honest-scholar dataset    validate|ingest|emit                  # manifest + Cro
 honest-scholar dataset    fetch|verify|mirror|audit             # SHA-256 retrieval + rclone mirror
 honest-scholar defend     record                                # understanding-status record
 honest-scholar backlog    park|add|list|rank|promote|drop       # exploration backlog
+honest-scholar keys       set|list|check|unset|path             # API-key & credential store
 ```
 
 Every command is implemented and emits JSON (the skills parse it). Network- and
 `rclone`-backed commands degrade gracefully when a key or the binary is absent.
+
+## API keys & credentials
+
+Some services throttle hard without a key. Providing one is optional (the tooling
+degrades gracefully) but lifts the ceiling:
+
+| Key | Service | What it buys | How to obtain |
+|---|---|---|---|
+| `S2_API_KEY` | Semantic Scholar | Rate limit well above the shared keyless pool. | <https://www.semanticscholar.org/product/api#api-key> |
+| `OPENALEX_MAILTO` | OpenAlex | The "polite pool" (a contact email) — faster, more reliable. | <https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication> |
+| `RCLONE_CONFIG_<REMOTE>_*` | Private dataset mirror | rclone remote credentials passed as scoped env vars (no config file). | Per your rclone remote. |
+
+Keys live in a **CLI-managed JSON store** at `.honest-scholar/keys.json`
+(gitignored, created `0600`), read with **`os.environ` > store > unset**
+precedence, so an environment variable always wins. Manage it with `keys`:
+
+```bash
+honest-scholar keys set S2_API_KEY        # hidden prompt, or reads piped stdin
+echo "$MY_KEY" | honest-scholar keys set S2_API_KEY
+honest-scholar keys set < keys.json       # a JSON object sets many at once
+honest-scholar keys list                  # presence + source (never the value)
+honest-scholar keys check | unset | path
+```
+
+The value is read only from stdin or a hidden prompt — never `argv` — so it never
+hits your shell history or the process list, and `list`/`check`/`doctor` report
+presence only.
+
+> **Plaintext at rest.** The store is **not encrypted**; gitignore + `0600` limit
+> exposure but are not a vault. OS-keychain backing is a planned follow-up (#49).
 
 ## Learn more
 

--- a/honest-scholar/honest_scholar/cli.py
+++ b/honest-scholar/honest_scholar/cli.py
@@ -9,8 +9,8 @@ ADR-0024 and ``docs/design/proposals/tooling-package.md``.
 from __future__ import annotations
 
 import dataclasses
+import getpass
 import json
-import os
 import platform
 import shutil
 import subprocess  # nosec B404 - used only to read `--version` of trusted tools
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Annotated
 import typer
 
 from honest_scholar import __version__
+from honest_scholar.core import keys as keys_mod
 from honest_scholar.dataset import manifest as manifest_mod
 from honest_scholar.dataset import retrieval as retrieval_mod
 from honest_scholar.defend import record as record_mod
@@ -105,6 +106,13 @@ def doctor() -> None:
     typer.echo(f"  python: {platform.python_version()} ({platform.platform()})")
     typer.echo(f"  {_tool_report('uv')}")
     typer.echo(f"  {_tool_report('rclone')}")
+    typer.echo("  keys:")
+    for known in keys_mod.KNOWN_KEYS.values():
+        source = keys_mod.source_of(known.name)
+        if source is None:
+            typer.echo(f"    {known.name}: not set")
+        else:
+            typer.echo(f"    {known.name}: set (source: {source})")
     raise typer.Exit(code=0)
 
 
@@ -116,11 +124,13 @@ app.add_typer(literature, name="literature")
 
 
 def _lit_client() -> HttpClient:
-    """Build the literature HTTP client from config + environment.
+    """Build the literature HTTP client from config + the key store.
 
-    Reads ``literature.mailto`` from ``.honest-scholar/config.yml`` (polite pool)
-    and ``S2_API_KEY`` from the environment; caches responses under
-    ``.honest-scholar/cache/http``. Tests monkeypatch this to inject a fake client.
+    Reads ``literature.mailto`` from ``.honest-scholar/config.yml`` (polite pool),
+    falling back to ``OPENALEX_MAILTO``, and sources ``S2_API_KEY`` through the
+    key store — both with ``os.environ`` > store precedence (ADR-0029). Caches
+    responses under ``.honest-scholar/cache/http``. Tests monkeypatch this to
+    inject a fake client.
     """
     from honest_scholar.core.config import load_config
     from honest_scholar.core.http import HttpClient
@@ -140,8 +150,8 @@ def _lit_client() -> HttpClient:
     mailto = lit.get("mailto") if isinstance(lit, dict) else None
     return HttpClient(
         cache_dir=Path(".honest-scholar/cache/http"),
-        mailto=mailto or os.environ.get("OPENALEX_MAILTO"),
-        s2_key=os.environ.get("S2_API_KEY"),
+        mailto=mailto or keys_mod.get("OPENALEX_MAILTO"),
+        s2_key=keys_mod.get("S2_API_KEY"),
     )
 
 
@@ -400,14 +410,21 @@ def _entry_or_exit(
 
 
 def _mirror_from(parsed: manifest_mod.Manifest) -> retrieval_mod.Mirror | None:
-    """Build a :class:`Mirror` from the manifest's mirror block, if configured."""
+    """Build a :class:`Mirror` from the manifest's mirror block, if configured.
+
+    Any ``RCLONE_CONFIG_<REMOTE>_*`` credentials in the key store (or environment)
+    for this remote are handed to rclone as a scoped, in-memory ``env`` (ADR-0029);
+    a hand-managed ``.honest-scholar/rclone.conf`` still works as a fallback.
+    """
     mir = parsed.mirror
     if mir is None or not mir.rclone_remote:
         return None
+    scoped = keys_mod.rclone_scoped_env(mir.rclone_remote)
     return retrieval_mod.Mirror(
         remote=mir.rclone_remote,
         base_path=mir.base_path or "",
         config_path=".honest-scholar/rclone.conf",
+        env=scoped or None,
     )
 
 
@@ -803,6 +820,173 @@ def drop(
         raise typer.Exit(code=1) from exc
     board.save(backlog_path)
     _emit_row(row)
+
+
+# --- keys (honest-scholar#42) -----------------------------------------------------
+keys = typer.Typer(
+    help="Store, list and check API keys & credentials (ADR-0029).",
+    no_args_is_help=True,
+)
+app.add_typer(keys, name="keys")
+
+
+def _stdin_is_piped() -> bool:
+    """Return whether stdin is a pipe/redirect rather than an interactive tty."""
+    return not sys.stdin.isatty()
+
+
+def _parse_json_object(raw: str) -> dict[str, object] | None:
+    """Parse `raw` as a JSON object, or ``None`` if it is not one.
+
+    :param raw: The raw stdin text.
+    :returns: The decoded mapping, or ``None`` when `raw` is not valid JSON or is
+        valid JSON but not an object (so it is treated as a single value).
+    """
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _warn_unknown(name: str) -> None:
+    """Warn on stderr when `name` is not a recognised key (but still store it)."""
+    if not keys_mod.is_known(name):
+        typer.echo(f"warning: {name!r} is not a known key; storing it anyway", err=True)
+
+
+def _set_many(blob: dict[str, object]) -> None:
+    """Set every entry of a piped JSON object; never echoes a value.
+
+    :param blob: The decoded ``{name: value}`` mapping.
+    :raises typer.Exit: Code 2 if the object is empty or any value is not a string.
+    """
+    if not blob:
+        typer.echo("keys set: the JSON object is empty", err=True)
+        raise typer.Exit(code=2)
+    for name, value in blob.items():
+        if not isinstance(value, str):
+            typer.echo(f"keys set: value for {name!r} must be a string", err=True)
+            raise typer.Exit(code=2)
+        _warn_unknown(name)
+        keys_mod.set_key(name, value)
+    typer.echo(f"stored {len(blob)} key(s) (source: store)")
+
+
+@keys.command(name="set")
+def set_(
+    name: Annotated[
+        str, typer.Argument(help="Key name; omit only when piping a JSON object.")
+    ] = "",
+) -> None:
+    """Store a key. The value comes from **stdin or a hidden prompt**, never argv.
+
+    Piping a JSON object (``{"NAME": "value", ...}``) sets many at once. Unknown
+    names warn but are still stored. No value is ever echoed.
+
+    :param name: The key name (unused when a JSON object is piped).
+    :raises typer.Exit: Code 2 on a missing name or an empty value; code 0 on
+        success.
+    """
+    if _stdin_is_piped():
+        raw = sys.stdin.read()
+        blob = _parse_json_object(raw)
+        if blob is not None:
+            _set_many(blob)
+            raise typer.Exit(code=0)
+        value: str | None = raw.strip()
+    else:
+        value = None
+    if not name:
+        typer.echo(
+            "keys set: provide NAME (or pipe a JSON object to set many)", err=True
+        )
+        raise typer.Exit(code=2)
+    if value is None:
+        value = getpass.getpass(f"Value for {name} (input hidden): ")
+    if not value:
+        typer.echo(f"keys set: empty value for {name}", err=True)
+        raise typer.Exit(code=2)
+    _warn_unknown(name)
+    keys_mod.set_key(name, value)
+    typer.echo(f"stored {name} (source: store)")
+    raise typer.Exit(code=0)
+
+
+def _key_report() -> list[dict[str, object]]:
+    """Build a presence report for every known + stored key — never a value.
+
+    :returns: One record per key with ``name``, ``service``, ``benefit``,
+        ``how_to_obtain``, ``present`` and ``source`` (``env``/``store``/``None``).
+    """
+    report: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for known in keys_mod.KNOWN_KEYS.values():
+        source = keys_mod.source_of(known.name)
+        report.append(
+            {
+                "name": known.name,
+                "service": known.service,
+                "benefit": known.benefit,
+                "how_to_obtain": known.how_to_obtain,
+                "present": source is not None,
+                "source": source,
+            }
+        )
+        seen.add(known.name)
+    report.extend(
+        {
+            "name": name,
+            "service": None,
+            "benefit": None,
+            "how_to_obtain": None,
+            "present": True,
+            "source": keys_mod.source_of(name),
+        }
+        for name in sorted(keys_mod.load_store())
+        if name not in seen
+    )
+    return report
+
+
+@keys.command(name="list")
+def list_keys() -> None:
+    """List every known + stored key with its metadata and presence (no values)."""
+    typer.echo(json.dumps(_key_report(), indent=2))
+    raise typer.Exit(code=0)
+
+
+@keys.command()
+def check() -> None:
+    """Report presence/absence and source of each key as JSON (never a value)."""
+    compact = [
+        {"name": row["name"], "present": row["present"], "source": row["source"]}
+        for row in _key_report()
+    ]
+    typer.echo(json.dumps(compact, indent=2))
+    raise typer.Exit(code=0)
+
+
+@keys.command()
+def unset(
+    name: Annotated[str, typer.Argument(help="Key name to remove from the store.")],
+) -> None:
+    """Remove a key from the store (a no-op if it was not stored).
+
+    :param name: The key name to remove.
+    """
+    if keys_mod.unset_key(name):
+        typer.echo(f"unset {name}")
+    else:
+        typer.echo(f"{name} was not in the store", err=True)
+    raise typer.Exit(code=0)
+
+
+@keys.command()
+def path() -> None:
+    """Print the resolved key-store path."""
+    typer.echo(str(keys_mod.store_path()))
+    raise typer.Exit(code=0)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/honest-scholar/honest_scholar/core/keys.py
+++ b/honest-scholar/honest_scholar/core/keys.py
@@ -1,0 +1,288 @@
+"""CLI-owned API-key store (ADR-0029).
+
+A single, controlled place to store, read and check the service keys the tooling
+uses — Semantic Scholar (``S2_API_KEY``), the OpenAlex polite pool
+(``OPENALEX_MAILTO``) and private rclone-mirror credentials — without leaking a
+secret through shell history, ``argv`` or an over-broad always-present file.
+
+Design (ADR-0029):
+
+- **Store.** A JSON object ``{name: value}`` at ``.honest-scholar/keys.json`` —
+  gitignored, created ``0600``. JSON (not ``.env``) because the CLI is the sole
+  reader/writer. Per-key *metadata* (service, how-to-obtain link, rate-limit
+  benefit) lives in the :data:`KNOWN_KEYS` registry — the single source of truth —
+  rather than being duplicated into every stored record.
+- **Precedence.** :func:`get` resolves ``os.environ`` **>** the store **>**
+  ``None``, so an injected environment variable always wins (CI / secrets
+  injection) and the service degrades gracefully when a key is unset.
+- **Least privilege.** :func:`scoped_env` / :func:`rclone_scoped_env` build an
+  in-memory ``env`` dict holding *only* the secrets a given child process needs —
+  never the whole store, never a file on the default path.
+- **Honesty.** The store is **plaintext at rest**. ``gitignore`` + ``0600`` limit
+  exposure but are *not* encryption; OS-keychain backing is the follow-up (#49).
+  Nothing in this module logs or echoes a value.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+#: The CLI-owned store path (relative to the project root / current directory).
+STORE_PATH = Path(".honest-scholar/keys.json")
+
+#: Prefix for rclone remote-config credentials handed to the rclone subprocess as
+#: ``RCLONE_CONFIG_<REMOTE>_<PARAM>`` environment variables (no config file).
+RCLONE_ENV_PREFIX = "RCLONE_CONFIG_"
+
+
+@dataclass(frozen=True)
+class KnownKey:
+    """A documented, recognised key the tooling knows how to use.
+
+    :param name: The environment-variable / store name (e.g. ``S2_API_KEY``).
+    :param service: The service the key authenticates or identifies to.
+    :param benefit: What providing it buys (a rate-limit / politeness benefit).
+    :param how_to_obtain: A URL describing how to obtain the key.
+    """
+
+    name: str
+    service: str
+    benefit: str
+    how_to_obtain: str
+
+
+#: The recognised-keys registry — the single source of truth for key metadata.
+KNOWN_KEYS: dict[str, KnownKey] = {
+    "S2_API_KEY": KnownKey(
+        name="S2_API_KEY",
+        service="Semantic Scholar",
+        benefit=(
+            "Raises the Semantic Scholar rate limit well above the shared keyless "
+            "pool, which throttles hard and stalls citation-graph lookups."
+        ),
+        how_to_obtain="https://www.semanticscholar.org/product/api#api-key",
+    ),
+    "OPENALEX_MAILTO": KnownKey(
+        name="OPENALEX_MAILTO",
+        service="OpenAlex",
+        benefit=(
+            "Joins the OpenAlex 'polite pool' (a contact email), giving faster, "
+            "more reliable responses than the anonymous pool."
+        ),
+        how_to_obtain="https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication",
+    ),
+}
+
+
+def is_known(name: str) -> bool:
+    """Return whether `name` is a recognised key.
+
+    Recognised means either a registry entry or an rclone remote-config variable
+    (``RCLONE_CONFIG_<REMOTE>_<PARAM>``), which are accepted by convention.
+
+    :param name: The candidate key name.
+    :returns: ``True`` if the name is documented or an rclone-config variable.
+    """
+    return name in KNOWN_KEYS or name.startswith(RCLONE_ENV_PREFIX)
+
+
+def store_path(path: str | Path | None = None) -> Path:
+    """Resolve the store path, defaulting to :data:`STORE_PATH`.
+
+    :param path: An explicit override; ``None`` uses the default store path.
+    :returns: The path the store is read from / written to.
+    """
+    return Path(path) if path is not None else STORE_PATH
+
+
+def load_store(path: str | Path | None = None) -> dict[str, str]:
+    """Load the key store as a ``{name: value}`` mapping.
+
+    A missing store yields an empty mapping rather than an error, so callers can
+    treat an unconfigured project as "no stored keys".
+
+    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :returns: The stored ``{name: value}`` pairs (empty if the file is absent).
+    :raises ValueError: If the file exists but is not a JSON object of strings.
+    """
+    resolved = store_path(path)
+    if not resolved.is_file():
+        return {}
+    try:
+        data = json.loads(resolved.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        msg = f"{resolved}: invalid JSON: {exc}"
+        raise ValueError(msg) from exc
+    if not isinstance(data, dict):
+        msg = f"{resolved}: expected a JSON object, got {type(data).__name__}"
+        raise ValueError(msg)
+    result: dict[str, str] = {}
+    for name, value in data.items():
+        if not isinstance(value, str):
+            msg = f"{resolved}: value for {name!r} must be a string"
+            raise ValueError(msg)
+        result[str(name)] = value
+    return result
+
+
+def write_store(mapping: Mapping[str, str], path: str | Path | None = None) -> None:
+    """Write `mapping` to the store, creating it ``0600``.
+
+    The parent directory is created if needed; the file mode is tightened to
+    owner-read/write only. Values are written verbatim (plaintext at rest — this
+    is not encryption; see the module docstring).
+
+    :param mapping: The ``{name: value}`` pairs to persist.
+    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    """
+    resolved = store_path(path)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(dict(sorted(mapping.items())), indent=2) + "\n"
+    resolved.write_text(payload, encoding="utf-8")
+    resolved.chmod(0o600)
+
+
+def set_key(name: str, value: str, path: str | Path | None = None) -> None:
+    """Add or update a single key in the store.
+
+    :param name: The key name.
+    :param value: The secret value (never logged or echoed).
+    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    """
+    store = load_store(path)
+    store[name] = value
+    write_store(store, path)
+
+
+def unset_key(name: str, path: str | Path | None = None) -> bool:
+    """Remove a key from the store.
+
+    :param name: The key name to remove.
+    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :returns: ``True`` if the key was present and removed, ``False`` if absent.
+    """
+    store = load_store(path)
+    if name not in store:
+        return False
+    del store[name]
+    write_store(store, path)
+    return True
+
+
+def _environ(environ: Mapping[str, str] | None) -> Mapping[str, str]:
+    """Return the environment mapping to consult (`os.environ` by default)."""
+    return os.environ if environ is None else environ
+
+
+def get(
+    name: str,
+    *,
+    path: str | Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> str | None:
+    """Resolve a key value with ``os.environ`` > store > ``None`` precedence.
+
+    :param name: The key name.
+    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :param environ: Environment mapping override (for tests); defaults to
+        :data:`os.environ`.
+    :returns: The resolved value, or ``None`` if unset in both sources.
+    """
+    env = _environ(environ)
+    if name in env:
+        return env[name]
+    return load_store(path).get(name)
+
+
+def source_of(
+    name: str,
+    *,
+    path: str | Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> str | None:
+    """Report *where* a key would resolve from — without exposing its value.
+
+    :param name: The key name.
+    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :param environ: Environment mapping override; defaults to :data:`os.environ`.
+    :returns: ``"env"`` if an environment variable would win, ``"store"`` if the
+        store would supply it, or ``None`` if it is unset everywhere.
+    """
+    env = _environ(environ)
+    if name in env:
+        return "env"
+    if name in load_store(path):
+        return "store"
+    return None
+
+
+def scoped_env(
+    names: Iterable[str],
+    *,
+    path: str | Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Build a least-privilege ``env`` dict of only the requested, present keys.
+
+    Intended for handing to a child process: it contains *only* the named
+    secrets that actually resolve (via :func:`get` precedence), and nothing else
+    from the store.
+
+    :param names: The key names the job is allowed to see.
+    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :param environ: Environment mapping override; defaults to :data:`os.environ`.
+    :returns: A ``{name: value}`` dict of the present requested secrets.
+    """
+    result: dict[str, str] = {}
+    for name in names:
+        value = get(name, path=path, environ=environ)
+        if value is not None:
+            result[name] = value
+    return result
+
+
+def rclone_config_env(remote: str, params: Mapping[str, str]) -> dict[str, str]:
+    """Translate rclone remote parameters to ``RCLONE_CONFIG_<REMOTE>_<KEY>`` vars.
+
+    rclone reads a remote's configuration from environment variables of this
+    shape, so a mirror can run with no config file on disk.
+
+    :param remote: The rclone remote name (upper-cased in the variable names).
+    :param params: The remote's config parameters (e.g. ``type``, ``token``).
+    :returns: The corresponding ``RCLONE_CONFIG_*`` environment mapping.
+    """
+    prefix = f"{RCLONE_ENV_PREFIX}{remote.upper()}_"
+    return {f"{prefix}{key.upper()}": value for key, value in params.items()}
+
+
+def rclone_scoped_env(
+    remote: str,
+    *,
+    path: str | Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Collect the stored/env ``RCLONE_CONFIG_<REMOTE>_*`` credentials for `remote`.
+
+    Only the variables scoped to this one remote are returned (least privilege),
+    each resolved with :func:`get` precedence. An empty result means no
+    credentials are stored for the remote (a ``rclone.conf`` may still cover it).
+
+    :param remote: The rclone remote name.
+    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :param environ: Environment mapping override; defaults to :data:`os.environ`.
+    :returns: A ``{RCLONE_CONFIG_<REMOTE>_<PARAM>: value}`` dict.
+    """
+    prefix = f"{RCLONE_ENV_PREFIX}{remote.upper()}_"
+    candidates = {
+        name
+        for name in (*load_store(path), *_environ(environ))
+        if name.startswith(prefix)
+    }
+    return scoped_env(sorted(candidates), path=path, environ=environ)

--- a/honest-scholar/honest_scholar/dataset/retrieval.py
+++ b/honest-scholar/honest_scholar/dataset/retrieval.py
@@ -20,6 +20,7 @@ without the network or the binary. Design:
 from __future__ import annotations
 
 import hashlib
+import os
 import subprocess  # nosec B404 - rclone is a trusted, fixed-arg subprocess
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -29,6 +30,8 @@ from typing import TYPE_CHECKING, Protocol
 from honest_scholar.dataset import manifest as manifest_mod
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from honest_scholar.dataset.manifest import DatasetEntry, FileRef, Manifest
 
 #: A fetcher: ``(url, sha256, dest) -> path``; the default uses ``pooch``.
@@ -84,6 +87,10 @@ class Mirror:
     :param config_path: Optional ``--config`` path (untracked ``rclone.conf``).
     :param rclone_bin: The rclone executable name.
     :param run: The subprocess runner (defaults to :func:`subprocess.run`).
+    :param env: Optional scoped secrets (e.g. ``RCLONE_CONFIG_<REMOTE>_*`` from
+        the key store) merged over the process environment for each rclone call,
+        so credentials need not live in a config file (ADR-0029). ``None`` keeps
+        the inherited environment untouched.
     """
 
     remote: str
@@ -91,6 +98,7 @@ class Mirror:
     config_path: str | None = None
     rclone_bin: str = "rclone"
     run: Runner = subprocess.run
+    env: Mapping[str, str] | None = None
 
     def _target(self, sha256: str) -> str:
         key = f"{self.base_path.rstrip('/')}/sha256/{_bare(sha256)}".lstrip("/")
@@ -103,9 +111,12 @@ class Mirror:
         return [*base, *args]
 
     def _run_ok(self, *args: str) -> bool:
+        kwargs: dict[str, object] = {"capture_output": True, "check": False}
+        if self.env is not None:
+            kwargs["env"] = {**os.environ, **self.env}
         try:
             proc = self.run(  # nosec B603 - fixed rclone args, no shell
-                self._cmd(*args), capture_output=True, check=False
+                self._cmd(*args), **kwargs
             )
         except FileNotFoundError as exc:  # rclone not installed
             raise RetrievalError(

--- a/honest-scholar/tests/test_keys.py
+++ b/honest-scholar/tests/test_keys.py
@@ -49,8 +49,10 @@ def test_missing_store_is_empty(tmp_path: Path) -> None:
 
 def test_set_creates_parent_and_0600(tmp_path: Path) -> None:
     store = tmp_path / "nested" / "keys.json"
-    keys_mod.set_key("S2_API_KEY", "secret", store)
-    assert keys_mod.load_store(store) == {"S2_API_KEY": "secret"}
+    keys_mod.set_key("S2_API_KEY", "fake-s2-key", store)
+    assert keys_mod.load_store(store) == {
+        "S2_API_KEY": "fake-s2-key"  # pragma: allowlist secret
+    }
     assert stat.S_IMODE(store.stat().st_mode) == 0o600
 
 
@@ -93,7 +95,11 @@ def test_get_precedence(tmp_path: Path) -> None:
     assert keys_mod.get("S2_API_KEY", path=store, environ={}) == "from-store"
     # a present env var always wins
     assert (
-        keys_mod.get("S2_API_KEY", path=store, environ={"S2_API_KEY": "from-env"})
+        keys_mod.get(
+            "S2_API_KEY",
+            path=store,
+            environ={"S2_API_KEY": "from-env"},  # pragma: allowlist secret
+        )
         == "from-env"
     )
     # unset everywhere
@@ -144,18 +150,26 @@ def test_rclone_config_env_translation() -> None:
 def test_rclone_scoped_env_is_per_remote(tmp_path: Path) -> None:
     store = tmp_path / "keys.json"
     keys_mod.set_key("RCLONE_CONFIG_STORE_TYPE", "s3", store)
-    keys_mod.set_key("RCLONE_CONFIG_STORE_SECRET_ACCESS_KEY", "shh", store)
+    keys_mod.set_key(
+        "RCLONE_CONFIG_STORE_SECRET_ACCESS_KEY",  # pragma: allowlist secret
+        "fake-mirror-secret",
+        store,
+    )
     keys_mod.set_key("RCLONE_CONFIG_OTHER_TYPE", "sftp", store)
     scoped = keys_mod.rclone_scoped_env("store", path=store, environ={})
     assert scoped == {
         "RCLONE_CONFIG_STORE_TYPE": "s3",
-        "RCLONE_CONFIG_STORE_SECRET_ACCESS_KEY": "shh",
+        "RCLONE_CONFIG_STORE_SECRET_ACCESS_KEY": (  # pragma: allowlist secret
+            "fake-mirror-secret"
+        ),
     }
     # a var supplied only via the environment is picked up too
     scoped_env_only = keys_mod.rclone_scoped_env(
-        "store", path=store, environ={"RCLONE_CONFIG_STORE_TOKEN": "t"}
+        "store",
+        path=store,
+        environ={"RCLONE_CONFIG_STORE_TOKEN": "fake-token"},  # pragma: allowlist secret
     )
-    assert scoped_env_only["RCLONE_CONFIG_STORE_TOKEN"] == "t"
+    assert scoped_env_only["RCLONE_CONFIG_STORE_TOKEN"] == "fake-token"
 
 
 # --- keys CLI group ---------------------------------------------------------
@@ -163,10 +177,12 @@ def test_rclone_scoped_env_is_per_remote(tmp_path: Path) -> None:
 
 def test_set_single_via_stdin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
-    result = runner.invoke(app, ["keys", "set", "S2_API_KEY"], input="s3cr3t\n")
+    result = runner.invoke(app, ["keys", "set", "S2_API_KEY"], input="fake-s2-key\n")
     assert result.exit_code == 0
-    assert "s3cr3t" not in result.stdout  # never echoes the value
-    assert keys_mod.load_store() == {"S2_API_KEY": "s3cr3t"}
+    assert "fake-s2-key" not in result.stdout  # never echoes the value
+    assert keys_mod.load_store() == {
+        "S2_API_KEY": "fake-s2-key"  # pragma: allowlist secret
+    }
 
 
 def test_set_numeric_value_is_not_treated_as_json(
@@ -243,12 +259,14 @@ def test_set_interactive_uses_hidden_prompt(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(cli, "_stdin_is_piped", lambda: False)
     monkeypatch.setattr(
-        "honest_scholar.cli.getpass.getpass", lambda prompt: "typed-secret"
+        "honest_scholar.cli.getpass.getpass", lambda prompt: "fake-typed-value"
     )
     result = runner.invoke(app, ["keys", "set", "S2_API_KEY"])
     assert result.exit_code == 0
-    assert "typed-secret" not in result.stdout
-    assert keys_mod.load_store() == {"S2_API_KEY": "typed-secret"}
+    assert "fake-typed-value" not in result.stdout
+    assert keys_mod.load_store() == {
+        "S2_API_KEY": "fake-typed-value"  # pragma: allowlist secret
+    }
 
 
 def test_set_interactive_missing_name_errors(

--- a/honest-scholar/tests/test_keys.py
+++ b/honest-scholar/tests/test_keys.py
@@ -1,0 +1,347 @@
+"""Tests for the CLI-owned API-key store and the ``keys`` command group (#42).
+
+Deterministic throughout: the store path is a ``tmp_path`` (module tests) or the
+CLI's cwd via ``monkeypatch.chdir``; the environment is driven with
+``monkeypatch``; stdin is fed via ``CliRunner(input=...)``. No test ever asserts a
+secret *value* appears in output — only presence/absence and source.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from honest_scholar import cli
+from honest_scholar.cli import app
+from honest_scholar.core import keys as keys_mod
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+
+# --- registry ---------------------------------------------------------------
+
+
+def test_is_known_registry_rclone_and_unknown() -> None:
+    assert keys_mod.is_known("S2_API_KEY") is True
+    assert keys_mod.is_known("RCLONE_CONFIG_STORE_TYPE") is True
+    assert keys_mod.is_known("MYSTERY") is False
+
+
+# --- store round-trip + permissions -----------------------------------------
+
+
+def test_store_path_default_and_override(tmp_path: Path) -> None:
+    assert keys_mod.store_path() == keys_mod.STORE_PATH
+    override = tmp_path / "k.json"
+    assert keys_mod.store_path(override) == override
+
+
+def test_missing_store_is_empty(tmp_path: Path) -> None:
+    assert keys_mod.load_store(tmp_path / "absent.json") == {}
+
+
+def test_set_creates_parent_and_0600(tmp_path: Path) -> None:
+    store = tmp_path / "nested" / "keys.json"
+    keys_mod.set_key("S2_API_KEY", "secret", store)
+    assert keys_mod.load_store(store) == {"S2_API_KEY": "secret"}
+    assert stat.S_IMODE(store.stat().st_mode) == 0o600
+
+
+def test_load_store_rejects_bad_json(tmp_path: Path) -> None:
+    store = tmp_path / "keys.json"
+    store.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid JSON"):
+        keys_mod.load_store(store)
+
+
+def test_load_store_rejects_non_object(tmp_path: Path) -> None:
+    store = tmp_path / "keys.json"
+    store.write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(ValueError, match="expected a JSON object"):
+        keys_mod.load_store(store)
+
+
+def test_load_store_rejects_non_string_value(tmp_path: Path) -> None:
+    store = tmp_path / "keys.json"
+    store.write_text('{"S2_API_KEY": 5}', encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a string"):
+        keys_mod.load_store(store)
+
+
+def test_unset_present_and_absent(tmp_path: Path) -> None:
+    store = tmp_path / "keys.json"
+    keys_mod.set_key("S2_API_KEY", "secret", store)
+    assert keys_mod.unset_key("S2_API_KEY", store) is True
+    assert keys_mod.load_store(store) == {}
+    assert keys_mod.unset_key("S2_API_KEY", store) is False
+
+
+# --- precedence: os.environ > store > None ----------------------------------
+
+
+def test_get_precedence(tmp_path: Path) -> None:
+    store = tmp_path / "keys.json"
+    keys_mod.set_key("S2_API_KEY", "from-store", store)
+    # store wins over unset environment
+    assert keys_mod.get("S2_API_KEY", path=store, environ={}) == "from-store"
+    # a present env var always wins
+    assert (
+        keys_mod.get("S2_API_KEY", path=store, environ={"S2_API_KEY": "from-env"})
+        == "from-env"
+    )
+    # unset everywhere
+    assert keys_mod.get("OPENALEX_MAILTO", path=store, environ={}) is None
+
+
+def test_get_defaults_to_os_environ(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)  # default store path is absent under a fresh cwd
+    monkeypatch.setenv("S2_API_KEY", "env-default")
+    assert keys_mod.get("S2_API_KEY") == "env-default"
+
+
+def test_source_of(tmp_path: Path) -> None:
+    store = tmp_path / "keys.json"
+    keys_mod.set_key("S2_API_KEY", "s", store)
+    assert keys_mod.source_of("S2_API_KEY", path=store, environ={}) == "store"
+    assert (
+        keys_mod.source_of("S2_API_KEY", path=store, environ={"S2_API_KEY": "e"})
+        == "env"
+    )
+    assert keys_mod.source_of("OPENALEX_MAILTO", path=store, environ={}) is None
+
+
+# --- scoped env (least privilege) -------------------------------------------
+
+
+def test_scoped_env_only_present_requested(tmp_path: Path) -> None:
+    store = tmp_path / "keys.json"
+    keys_mod.set_key("S2_API_KEY", "s", store)
+    keys_mod.set_key("OPENALEX_MAILTO", "m", store)
+    scoped = keys_mod.scoped_env(
+        ["S2_API_KEY", "OPENALEX_MAILTO", "MISSING"], path=store, environ={}
+    )
+    assert scoped == {"S2_API_KEY": "s", "OPENALEX_MAILTO": "m"}
+    assert "MISSING" not in scoped
+
+
+def test_rclone_config_env_translation() -> None:
+    env = keys_mod.rclone_config_env("myremote", {"type": "s3", "access_key_id": "AK"})
+    assert env == {
+        "RCLONE_CONFIG_MYREMOTE_TYPE": "s3",
+        "RCLONE_CONFIG_MYREMOTE_ACCESS_KEY_ID": "AK",
+    }
+
+
+def test_rclone_scoped_env_is_per_remote(tmp_path: Path) -> None:
+    store = tmp_path / "keys.json"
+    keys_mod.set_key("RCLONE_CONFIG_STORE_TYPE", "s3", store)
+    keys_mod.set_key("RCLONE_CONFIG_STORE_SECRET_ACCESS_KEY", "shh", store)
+    keys_mod.set_key("RCLONE_CONFIG_OTHER_TYPE", "sftp", store)
+    scoped = keys_mod.rclone_scoped_env("store", path=store, environ={})
+    assert scoped == {
+        "RCLONE_CONFIG_STORE_TYPE": "s3",
+        "RCLONE_CONFIG_STORE_SECRET_ACCESS_KEY": "shh",
+    }
+    # a var supplied only via the environment is picked up too
+    scoped_env_only = keys_mod.rclone_scoped_env(
+        "store", path=store, environ={"RCLONE_CONFIG_STORE_TOKEN": "t"}
+    )
+    assert scoped_env_only["RCLONE_CONFIG_STORE_TOKEN"] == "t"
+
+
+# --- keys CLI group ---------------------------------------------------------
+
+
+def test_set_single_via_stdin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["keys", "set", "S2_API_KEY"], input="s3cr3t\n")
+    assert result.exit_code == 0
+    assert "s3cr3t" not in result.stdout  # never echoes the value
+    assert keys_mod.load_store() == {"S2_API_KEY": "s3cr3t"}
+
+
+def test_set_numeric_value_is_not_treated_as_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # "12345" is valid JSON but not an object → stored as a single value.
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["keys", "set", "S2_API_KEY"], input="12345")
+    assert result.exit_code == 0
+    assert keys_mod.load_store() == {"S2_API_KEY": "12345"}
+
+
+def test_set_json_blob_sets_many(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    blob = json.dumps({"S2_API_KEY": "a", "OPENALEX_MAILTO": "me@x.org"})
+    result = runner.invoke(app, ["keys", "set"], input=blob)
+    assert result.exit_code == 0
+    assert "a" not in result.stdout.split()  # no value echoed
+    assert keys_mod.load_store() == {"S2_API_KEY": "a", "OPENALEX_MAILTO": "me@x.org"}
+
+
+def test_set_json_blob_empty_object_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["keys", "set"], input="{}")
+    assert result.exit_code == 2
+    assert "empty" in result.stderr
+
+
+def test_set_json_blob_non_string_value_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["keys", "set"], input='{"S2_API_KEY": 5}')
+    assert result.exit_code == 2
+    assert "must be a string" in result.stderr
+
+
+def test_set_unknown_name_warns_but_stores(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["keys", "set", "MYSTERY_KEY"], input="v\n")
+    assert result.exit_code == 0
+    assert "not a known key" in result.stderr
+    assert keys_mod.load_store() == {"MYSTERY_KEY": "v"}
+
+
+def test_set_missing_name_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    # A bare token (not a JSON object) piped with no NAME argument.
+    result = runner.invoke(app, ["keys", "set"], input="loose-token\n")
+    assert result.exit_code == 2
+    assert "provide NAME" in result.stderr
+
+
+def test_set_empty_value_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["keys", "set", "S2_API_KEY"], input="   \n")
+    assert result.exit_code == 2
+    assert "empty value" in result.stderr
+
+
+def test_set_interactive_uses_hidden_prompt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "_stdin_is_piped", lambda: False)
+    monkeypatch.setattr(
+        "honest_scholar.cli.getpass.getpass", lambda prompt: "typed-secret"
+    )
+    result = runner.invoke(app, ["keys", "set", "S2_API_KEY"])
+    assert result.exit_code == 0
+    assert "typed-secret" not in result.stdout
+    assert keys_mod.load_store() == {"S2_API_KEY": "typed-secret"}
+
+
+def test_set_interactive_missing_name_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli, "_stdin_is_piped", lambda: False)
+
+    def _never(prompt: str) -> str:  # pragma: no cover - must not be called
+        raise AssertionError("getpass must not run without a name")
+
+    monkeypatch.setattr("honest_scholar.cli.getpass.getpass", _never)
+    result = runner.invoke(app, ["keys", "set"])
+    assert result.exit_code == 2
+    assert "provide NAME" in result.stderr
+
+
+def test_list_reports_presence_and_source_not_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    keys_mod.set_key("S2_API_KEY", "topsecret")
+    keys_mod.set_key("RCLONE_CONFIG_STORE_TOKEN", "mirror-cred")
+    result = runner.invoke(app, ["keys", "list"])
+    assert result.exit_code == 0
+    assert "topsecret" not in result.stdout
+    assert "mirror-cred" not in result.stdout
+    rows = {row["name"]: row for row in json.loads(result.stdout)}
+    assert rows["S2_API_KEY"]["present"] is True
+    assert rows["S2_API_KEY"]["source"] == "store"
+    assert "how_to_obtain" in rows["S2_API_KEY"]
+    # an unset known key is reported absent
+    assert rows["OPENALEX_MAILTO"]["present"] is False
+    assert rows["OPENALEX_MAILTO"]["source"] is None
+    # the stored rclone credential shows up as an extra, metadata-less row
+    assert rows["RCLONE_CONFIG_STORE_TOKEN"]["present"] is True
+    assert rows["RCLONE_CONFIG_STORE_TOKEN"]["service"] is None
+
+
+def test_check_env_source_wins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    keys_mod.set_key("S2_API_KEY", "from-store")
+    monkeypatch.setenv("S2_API_KEY", "from-env")
+    result = runner.invoke(app, ["keys", "check"])
+    assert result.exit_code == 0
+    assert "from-store" not in result.stdout
+    assert "from-env" not in result.stdout
+    rows = {row["name"]: row for row in json.loads(result.stdout)}
+    assert rows["S2_API_KEY"] == {
+        "name": "S2_API_KEY",
+        "present": True,
+        "source": "env",
+    }
+
+
+def test_unset_present_then_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    keys_mod.set_key("S2_API_KEY", "s")
+    ok = runner.invoke(app, ["keys", "unset", "S2_API_KEY"])
+    assert ok.exit_code == 0
+    assert "unset S2_API_KEY" in ok.stdout
+    again = runner.invoke(app, ["keys", "unset", "S2_API_KEY"])
+    assert again.exit_code == 0
+    assert "was not in the store" in again.stderr
+
+
+def test_path_prints_store_path() -> None:
+    result = runner.invoke(app, ["keys", "path"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == str(keys_mod.STORE_PATH)
+
+
+# --- integration: doctor + _lit_client --------------------------------------
+
+
+def test_doctor_reports_key_presence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    keys_mod.set_key("S2_API_KEY", "s")
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0
+    assert "S2_API_KEY: set (source: store)" in result.stdout
+    assert "OPENALEX_MAILTO: not set" in result.stdout
+
+
+def test_lit_client_sources_s2_key_from_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("S2_API_KEY", raising=False)
+    keys_mod.set_key("S2_API_KEY", "store-key")
+    client = cli._lit_client()
+    assert client.s2_key == "store-key"

--- a/honest-scholar/tests/test_retrieval.py
+++ b/honest-scholar/tests/test_retrieval.py
@@ -245,6 +245,41 @@ def test_mirror_missing_binary_is_actionable() -> None:
         mirror.check("a" * 64)
 
 
+def test_mirror_forwards_scoped_env_merged_over_process_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", "/usr/bin")
+    captured: dict[str, object] = {}
+
+    def _runner(args: list[str], **kw: object) -> FakeProc:
+        captured.update(kw)
+        return FakeProc(0)
+
+    mirror = r.Mirror(
+        remote="store",
+        run=_runner,
+        env={"RCLONE_CONFIG_STORE_TYPE": "s3"},
+    )
+    assert mirror.check("a" * 64) is True
+    passed = captured["env"]
+    assert isinstance(passed, dict)
+    # scoped secret is present …
+    assert passed["RCLONE_CONFIG_STORE_TYPE"] == "s3"
+    # … merged over the inherited environment (PATH survives).
+    assert passed["PATH"] == "/usr/bin"
+
+
+def test_mirror_without_env_passes_no_env_kwarg() -> None:
+    captured: dict[str, object] = {}
+
+    def _runner(args: list[str], **kw: object) -> FakeProc:
+        captured.update(kw)
+        return FakeProc(0)
+
+    r.Mirror(remote="store", run=_runner).check("a" * 64)
+    assert "env" not in captured
+
+
 # --- audit ------------------------------------------------------------------
 
 


### PR DESCRIPTION
## What

Implements **ADR-0029** (#42): one controlled way to store, read and check the
service keys the tooling uses — Semantic Scholar (`S2_API_KEY`), the OpenAlex
polite pool (`OPENALEX_MAILTO`) and private rclone-mirror creds — loaded
consistently by the CLI, that never leaks a secret through shell history, `argv`
or an over-broad always-present file, and is honest about what it does not
protect.

## Details

- **Key store** (`honest_scholar/core/keys.py`): a CLI-owned JSON store at
  `.honest-scholar/keys.json` (gitignored, created `0600`). `get()` resolves
  **`os.environ` > store > unset**, so an injected env var always wins (CI /
  secrets injection unaffected). A `KNOWN_KEYS` registry carries each key's
  service, rate-limit benefit and how-to-obtain link — the single source of
  metadata (the store persists values only; see below).
- **Scoped env** (least privilege): `scoped_env` / `rclone_scoped_env` /
  `rclone_config_env` build an in-memory `env` dict with *only* the secrets a
  given job needs, translating rclone creds to `RCLONE_CONFIG_<REMOTE>_*` vars —
  no config file. Nothing logs or echoes a value.
- **`keys` CLI group** — `set|list|check|unset|path`. `set` reads the value from
  piped stdin (a single value, or a JSON object to set many) or a hidden
  `getpass` prompt — **never `argv`** — and validates the name against the
  registry (warns on unknown, still stores). `list`/`check` report **presence +
  source, never values**.
- **Integration**: `_lit_client` sources `S2_API_KEY`/`OPENALEX_MAILTO` through
  the store (env precedence preserved); `doctor` reports key presence; the
  dataset `Mirror` gains an optional scoped `env=` and `_mirror_from` flows
  `RCLONE_CONFIG_*` creds through it while keeping `rclone.conf` working.
- **Honesty caveat**: the store is **plaintext at rest** — gitignore + `0600`
  limit exposure but are *not* encryption. Documented in USER-GUIDE + package
  README; OS-keychain backing behind the same interface is the #49 follow-up.

**Resolved design choice:** per-key *metadata* lives in the `KNOWN_KEYS`
registry (one source of truth) rather than being duplicated into every stored
record; the on-disk store is a plain `{name: value}` object. This keeps the file
simple, the JSON-blob `set` path natural, and satisfies every functional
requirement in ADR-0029/#42 (precedence, presence-not-value reporting,
scoped-env provisioning, `0600`, no-leak). Flagged here rather than diverging
silently.

100% statement+branch coverage maintained (`fail_under = 100`); ruff, ruff
format, mypy (strict) and codespell all pass.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
