### PR TITLE
docs(design): #6 docs-site design — Mintlify + ADR-0030

### DIFF
--- a/decisions/0030-docs-site-mintlify.md
+++ b/decisions/0030-docs-site-mintlify.md
@@ -1,0 +1,91 @@
+# ADR-0030: Docs site on Mintlify, published from a generated docs repo
+
+- Status: accepted · Date: 2026-07-19 · Deciders: Davor Runje
+
+## Context
+
+`honest-scholar` had no rendered docs site (#6) — the design record, `README.md`,
+`docs/USER-GUIDE.md`, and the CLI `--help` were the docs, all as in-repo markdown.
+A single navigable "one portal" site (users **and** the design record) is now
+wanted. The choice must fit the project's posture: it targets the **whole research
+community** (not ML-only, so mononet's Sphinx is not a default), prefers
+**single-binary / light dependencies over heavy toolchains**, keeps a **git-native
+source of truth** ("no hosted services as source of truth"), and has a separate
+future arXiv paper (#7).
+
+## Decision drivers
+
+- Wide, non-ML research audience; professional, navigable result.
+- Source of truth stays as markdown in git.
+- Low maintenance; minimal toolchain weight.
+- Ecosystem fit (a Claude-ecosystem tool) is a plus.
+- The arXiv paper (#7) is **decoupled** — no need for a docs→paper publishing
+  pipeline.
+- Deploy should be release-gated (#6: "on tag").
+
+## Considered options
+
+1. **Quarto** — single binary (pandoc-based), language-agnostic, one source →
+   site + book + arXiv PDF.
+2. **Sphinx + MyST** (PyData/Furo) — the Python-docs incumbent; heavier config;
+   closest to mononet.
+3. **MyST-MD** — scientific-markdown engine (JATS/PDF export); Node-based, young.
+4. **Docusaurus / Astro Starlight** — modern web-docs; full Node toolchain;
+   product- not research-oriented.
+5. **Mintlify** — hosted docs-as-code platform; markdown/MDX in git; AI-native.
+   *(chosen)*
+
+## Decision
+
+**Mintlify**, sourced from the in-repo markdown, published by CI to a **dedicated,
+generated docs repo** (`honest-scholar-docs`) that Mintlify renders at the custom
+domain **`honest-scholar.science`**.
+
+- **Ecosystem-native + proven**: Anthropic's own docs (claude.com/docs) run on
+  Mintlify — well-supported, fitting for a Claude-ecosystem tool.
+- **Docs-as-code**: pages are markdown in git → source of truth stays in the repo;
+  the "no hosted services as source of truth" clause is about provenance/data, not
+  docs rendering, so it is not violated.
+- **AI-native**: auto `llms.txt` + markdown export + MCP — apt for an
+  AI-in-the-loop research tool.
+- **Cost**: the free **Starter** tier includes a **custom domain**, AI search,
+  analytics, web editor, auth, and MCP; usage is metered by **AI credits (5,000/mo
+  included)**.
+- **Topology**: this repo stays the single source of truth and free of Mintlify
+  config; a CI build (on `release: published` + manual dispatch, per ADR-0027)
+  assembles the one-portal content, **generates the CLI reference from the Typer
+  app**, writes `docs.json`, rewrites links, and pushes to the generated docs repo.
+  The docs repo is a **build artifact, never hand-edited** — so #6's "no content
+  duplication" holds.
+
+## Consequences
+
+- A polished, ecosystem-native site at `honest-scholar.science`, release-gated, on
+  the free tier, with the markdown source owned in-repo.
+- One-time maintainer setup: register the domain + DNS, create the docs repo,
+  connect Mintlify, add a least-privilege deploy secret to CI.
+- **AI-credit metering** is the cost/usage dimension to monitor (throttle or
+  disable AI search if it nears the cap).
+- **Lock-in is bounded**: the rendered site is Mintlify's, but content is portable
+  markdown — switching SSG later is a build-target swap, not a content rewrite.
+- No scientific-publishing pipeline; acceptable because #7 is decoupled.
+
+## Rejected alternatives
+
+- **Quarto** — the strongest self-owned/single-binary option and would single-
+  source #7, but that synergy is unneeded (paper decoupled), and it is less
+  ecosystem-native and more setup than Mintlify for a pure markdown portal.
+- **Sphinx + MyST** — most mature, but heaviest config, Python-flavored, and
+  optically anchored to mononet (explicitly not the target audience).
+- **MyST-MD** — most ethos-aligned for scientific records, but Node-based and the
+  youngest/least-settled ecosystem.
+- **Docusaurus / Starlight** — slick but a full Node toolchain (against the light-
+  dependency posture) and product- rather than research-oriented, with MDX lock-in.
+- **Self-hosted vs Mintlify**: hosting lock-in was judged acceptable given the
+  portable markdown source and the ecosystem/effort benefits.
+
+## Links
+
+`docs/design/proposals/docs-site.md` (the design); #6 (implements); #7 (decoupled
+paper); ADR-0027 (release-driven CI pattern); ADR-0024 (light-dependency posture).
+Mintlify pricing + Anthropic case study consulted 2026-07-19.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -41,5 +41,6 @@ Migrates to the plugin's `decisions/` alongside `resources/references/`.
 | [0027](0027-release-driven-oidc-publish.md) | Publish via GitHub Releases + PyPI Trusted Publishing (OIDC, no tokens) | accepted |
 | [0028](0028-100-percent-coverage-gate.md) | 100% statement + branch coverage gate on the package | accepted |
 | [0029](0029-api-key-handling.md) | Unified API-key handling — a CLI-managed JSON store (not `.env`), stdin writes, scoped in-memory env for children | accepted |
+| [0030](0030-docs-site-mintlify.md) | Docs site on Mintlify, published from a generated docs repo to `honest-scholar.science` | accepted |
 
 Format: MADR (Markdown Any Decision Records). Deciders: Davor Runje (with Claude).

--- a/docs/design/proposals/docs-site.md
+++ b/docs/design/proposals/docs-site.md
@@ -1,0 +1,123 @@
+# Proposal: rendered docs site (Mintlify)
+
+`Status: designed 2026-07-19 · Skill: — (project infra) · Implements #6 · Decision ADR-0030`
+
+## Context
+
+For the pre-releases we shipped **no rendered docs site** (#6): the design record,
+`README.md`, `docs/USER-GUIDE.md`, and the `honest-scholar` CLI `--help` were the
+documentation, all as in-repo markdown. As the plugin + package mature, a single
+navigable site helps users and contributors. This proposes the site's tooling,
+topology, and publish flow. (#6's body predates a rename and says
+`scholar`/`scholar-tools`; the repo/package/CLI are all **`honest-scholar`** —
+reconciled here.)
+
+## Decision (see ADR-0030)
+
+Build the site with **Mintlify**, sourced from the in-repo markdown, published by
+CI to a **dedicated docs repo** that Mintlify renders and serves at the custom
+domain **`honest-scholar.science`**.
+
+Why Mintlify (full rationale + rejected alternatives — Quarto, Sphinx+MyST,
+MyST-MD, Docusaurus/Starlight — in ADR-0030):
+
+- **Ecosystem-native + proven**: Anthropic's own docs (claude.com/docs) run on
+  Mintlify — a fitting, well-supported choice for a Claude-ecosystem tool.
+- **Docs-as-code**: pages are markdown in git, so the **source of truth stays in
+  the repo** (no hosted-provenance concern).
+- **AI-native**: auto-served `llms.txt` + markdown export + MCP — apt for an
+  AI-in-the-loop research tool.
+- **Low maintenance / lowest lift**, and the scientific-publishing pipeline we'd
+  get from Quarto/MyST-MD is **not needed** — the arXiv paper (#7) is a separate
+  artifact with its own tooling.
+- **Cost**: the free **Starter** tier includes a **custom domain**, AI search,
+  analytics, web editor, auth, MCP; usage is metered by **AI credits (5,000/mo
+  included)** — the one dimension to monitor (see Risks).
+
+## Topology & publish flow
+
+```
+honest-scholar (this repo)            honest-scholar-docs (new, generated)      Mintlify
+  README, USER-GUIDE, docs/design/,     docs.json + generated .mdx pages   ──▶  renders + serves
+  decisions/, resources/, skills/,      (BUILD ARTIFACT — never hand-edited)     honest-scholar.science
+  honest_scholar Typer CLI
+        │  (source of truth)                     ▲
+        └── CI build on Release ─── push ────────┘
+```
+
+- **Source of truth**: unchanged, in this repo. Nothing is authored in the docs
+  repo by hand.
+- **Docs repo** (e.g. `davorrunje/honest-scholar-docs`): holds only the generated
+  Mintlify site (`docs.json` navigation + `.mdx`/`.md` pages + assets). Mintlify
+  connects to it and auto-redeploys on push.
+- **Build**: a `docs-publish` workflow in *this* repo, triggered on
+  **`release: published`** (reusing the release-driven pattern of ADR-0027) plus a
+  manual `workflow_dispatch`, runs a builder script that:
+  1. assembles the one-portal content from the source markdown,
+  2. **generates the CLI reference** from the Typer app,
+  3. writes `docs.json` (navigation),
+  4. rewrites intra-repo relative links → site routes,
+  5. pushes the result to the docs repo (deploy key / fine-grained PAT).
+  Mintlify then redeploys → satisfies #6's "deploy on tag".
+
+This gives release-gated, snapshot-able docs, keeps this repo free of Mintlify
+config, and lets the builder transform content (link rewriting, CLI ref) before
+publish. Because the docs repo is a **generated artifact**, #6's "no content
+duplication" holds: one hand-maintained source, one generated render.
+
+## Site scope (one portal)
+
+Per the agreed scope — users **and** the design record:
+
+- **Overview / landing** — from `README.md` (trimmed to the site).
+- **Get started** — install (plugin marketplace + `honest-scholar` CLI) + the full
+  `docs/USER-GUIDE.md`.
+- **Skills / methodology** (the star) — the nested generate/resolve lifecycle,
+  the agency + understanding principles, the firewall, and per-skill pages sourced
+  from `skills/*/SKILL.md`.
+- **CLI reference** — `honest-scholar` command tree, generated from the Typer app.
+- **Design & reasoning** — the meta-spec + sub-specs (`docs/design/`), the ADRs
+  (`decisions/`), the reference digests (`resources/references/`), `DISCLOSURE.md`.
+
+## CLI reference generation
+
+Generated from the Typer app so it never drifts: a build step renders the
+`honest-scholar` command tree to markdown (Typer's docs generation, or a small
+script walking the Typer app) → included as the CLI-reference pages each build.
+Regenerated on every publish, so it always matches the released CLI.
+
+## Prerequisites (one-time, maintainer)
+
+- Register **`honest-scholar.science`** and point DNS at Mintlify per their custom-
+  domain setup.
+- Create the **`honest-scholar-docs`** repo; connect it to Mintlify (Starter/free).
+- Add a **deploy secret** (deploy key or fine-grained PAT scoped to the docs repo)
+  to this repo's Actions secrets for the publish workflow.
+
+## Acceptance criteria
+
+- [ ] The site builds from the existing in-repo markdown with **no hand-maintained
+      duplication** (the docs repo is a generated build artifact).
+- [ ] The **CLI reference is generated from the `honest-scholar` Typer app**.
+- [ ] A publish workflow pushes to the docs repo on **`release: published`** (+
+      manual dispatch); Mintlify redeploys.
+- [ ] The site is served at **`honest-scholar.science`**.
+- [ ] `#6`'s stale `scholar`/`scholar-tools` naming is reconciled to `honest-scholar`.
+
+## Risks / open items
+
+- **AI-credit metering** (5,000/mo on free Starter): the AI-search feature consumes
+  credits; monitor usage, and disable AI search or budget if it approaches the cap.
+- **Lock-in**: the *rendered* site lives on Mintlify (content is portable markdown,
+  so migration to another SSG later is a build-target swap, not a content rewrite).
+- **Builder details** to settle at plan time: exact Typer→markdown mechanism, the
+  link-rewriting rules, and how skill pages are transformed for Mintlify front-matter.
+- Deploy-secret handling in CI (least-privilege PAT/deploy key).
+
+## Links
+
+- Implements #6 · Decision: `decisions/0030-docs-site-mintlify.md` (ADR-0030).
+- Source content: `README.md`, `docs/USER-GUIDE.md`, `docs/design/`, `decisions/`,
+  `resources/`, `skills/`, `honest-scholar/honest_scholar/cli.py`.
+- Release-driven CI pattern: ADR-0027. Light-dependency posture: ADR-0024.
+- Decoupled from #7 (the arXiv paper has its own tooling).


### PR DESCRIPTION
## What

The **design** for #6 (rendered docs site), for your review before implementation — a proposal (`docs/design/proposals/docs-site.md`) + **ADR-0030**.

**Decision: Mintlify**, sourced from the in-repo markdown, published by CI to a generated docs repo that Mintlify serves at the custom domain **`honest-scholar.science`**.

Rationale (full trade-offs + rejected alternatives — Quarto, Sphinx+MyST, MyST-MD, Docusaurus/Starlight — in ADR-0030):
- **Ecosystem-native + proven** — Anthropic's own docs (claude.com/docs) run on Mintlify.
- **Docs-as-code** — markdown source of truth stays in this repo.
- **AI-native** — auto `llms.txt` / markdown export / MCP, fitting for an AI-in-the-loop tool.
- **Free Starter tier includes a custom domain** (verified 2026-07-19); usage metered by AI credits (5,000/mo) — the one dimension to monitor.
- Scientific-publishing pipeline deliberately **not** a factor — #7 (arXiv paper) is decoupled with its own tooling.

**Topology:** this repo stays the single source of truth; a CI build on `release: published` (+ manual dispatch) assembles the one-portal content (users + design record), **generates the CLI reference from the Typer app**, writes `docs.json`, rewrites links, and pushes to `honest-scholar-docs` (a build artifact, never hand-edited → #6's "no content duplication" holds). Mintlify redeploys.

Also reconciles #6's stale `scholar`/`scholar-tools` naming → `honest-scholar`.

**One-time prerequisites** (noted in the proposal): register `honest-scholar.science` + DNS, create the docs repo, connect Mintlify, add a least-privilege deploy secret.

This PR records the design only. On approval, implementation (builder script + `docs-publish` workflow + the one-time setup) is the follow-up — happy to drive it.

Part of #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)