### PR TITLE
docs: docs-site build + publish pipeline (Mintlify)

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,107 @@
+name: Docs publish
+
+# Builds the Mintlify docs site from this repo's markdown + the honest-scholar
+# Typer CLI (tools/build_docs_site.py) and publishes it to the generated docs repo
+# davorrunje/honest-scholar-docs, which Mintlify renders at honest-scholar.science.
+# See docs/design/proposals/docs-site.md and ADR-0030.
+#
+#   * pull_request      → strict build check (fails on any build error / broken
+#                         link); never pushes.
+#   * release published → build + push to the docs repo (release-gated, ADR-0027).
+#   * workflow_dispatch → build + push (the first / manual publish).
+#
+# Maintainer prerequisite: create a repo Actions secret DOCS_DEPLOY_TOKEN — a
+# fine-grained PAT with Contents: read and write on davorrunje/honest-scholar-docs
+# (only). Without it the publish job fails fast with an explanatory message.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "README.md"
+      - "DISCLOSURE.md"
+      - "docs/**"
+      - "skills/**"
+      - "decisions/**"
+      - "resources/references/**"
+      - "assets/wordmark.svg"
+      - "honest-scholar/**"
+      - "tools/build_docs_site.py"
+      - ".github/workflows/docs-publish.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-check:
+    # Strict build on every relevant PR — fails on a broken link or missing page,
+    # but does not push anywhere.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8.3.1
+      - name: Sync honest-scholar
+        run: uv sync --project honest-scholar
+      - name: Build the docs site (strict)
+        run: |
+          uv run --project honest-scholar python tools/build_docs_site.py \
+            --out "$RUNNER_TEMP/docs-site"
+
+  publish:
+    # Release or manual dispatch → build and push to the generated docs repo.
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8.3.1
+      - name: Guard — DOCS_DEPLOY_TOKEN must be configured
+        env:
+          DOCS_DEPLOY_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+        run: |
+          if [ -z "$DOCS_DEPLOY_TOKEN" ]; then
+            echo "::error::DOCS_DEPLOY_TOKEN is not set. Create a fine-grained PAT with Contents:write on davorrunje/honest-scholar-docs and add it as a repo Actions secret named DOCS_DEPLOY_TOKEN."
+            exit 1
+          fi
+      - name: Sync honest-scholar
+        run: uv sync --project honest-scholar
+      - name: Build the docs site (strict)
+        run: |
+          uv run --project honest-scholar python tools/build_docs_site.py \
+            --out "$RUNNER_TEMP/docs-site"
+      - name: Checkout the docs repo
+        uses: actions/checkout@v7
+        with:
+          repository: davorrunje/honest-scholar-docs
+          token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+          path: docs-repo
+      - name: Replace generated content (preserve LICENSE + README.md)
+        run: |
+          cd docs-repo
+          # Remove every tracked file except the docs repo's own LICENSE + README.md.
+          git ls-files -z \
+            | grep -zvE '^(LICENSE|README\.md)$' \
+            | xargs -0 -r git rm -q --cached --
+          find . -mindepth 1 -not -path './.git*' \
+            -not -name LICENSE -not -name README.md -delete
+          # Copy the freshly built site in.
+          cp -R "$RUNNER_TEMP/docs-site/." .
+      - name: Commit and push
+        run: |
+          cd docs-repo
+          git config user.name "honest-scholar docs bot"
+          git config user.email "davor@synthpop.ai"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Docs site unchanged — nothing to publish."
+            exit 0
+          fi
+          git commit --no-gpg-sign \
+            -m "docs: publish site from davorrunje/honest-scholar@${GITHUB_SHA}"
+          git push

--- a/tools/build_docs_site.py
+++ b/tools/build_docs_site.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+"""Build the ``honest-scholar`` Mintlify docs site from the in-repo markdown.
+
+This is a **standalone build tool**, not part of the shipped package (it lives in
+``tools/`` and is outside the package's coverage/lint gate). It assembles the
+"one portal" documented in ``docs/design/proposals/docs-site.md`` / ADR-0030 from
+the repository's own markdown — nothing is hand-duplicated — and emits a complete
+Mintlify site into an output directory:
+
+* an ``index.mdx`` landing page (from ``README.md``),
+* a Get-started page (from ``docs/USER-GUIDE.md``),
+* one page per ``skills/*/SKILL.md``,
+* a **generated** CLI reference (walked live from the ``honest_scholar`` Typer app,
+  so it never drifts from the released CLI),
+* the design record — specs, proposals, the ADR log, reference digests, disclosure,
+* a ``docs.json`` with grouped navigation, brand colours, logo and social links,
+* the ``wordmark.svg`` asset.
+
+Intra-repo relative markdown links are rewritten to site routes; links that point
+at repo files *not* in the site become absolute ``github.com`` URLs. A link that
+points at a file which does not exist is a **hard error** — the build fails loudly
+rather than silently dropping content (the repo's failure-honesty rule).
+
+Run it from the ``honest-scholar/`` package directory (so the Typer app imports)::
+
+    cd honest-scholar
+    uv run python ../tools/build_docs_site.py --out ../dist/docs-site
+
+or from the repo root under the package project::
+
+    uv run --project honest-scholar python tools/build_docs_site.py --out dist/docs-site
+
+The output directory is created (and, if it already exists, emptied) by the build.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import posixpath
+import re
+import shutil
+import sys
+from pathlib import Path
+
+# --- constants -------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GH_REPO = "https://github.com/davorrunje/honest-scholar"
+GH_BLOB = f"{GH_REPO}/blob/main/"
+GH_TREE = f"{GH_REPO}/tree/main/"
+
+SITE_NAME = "honest-scholar"
+SITE_DESCRIPTION = (
+    "Research you can defend — keep your research honest, "
+    "especially now that AI is in the loop."
+)
+PRIMARY = "#4338CA"
+COLOR_LIGHT = "#818CF8"
+COLOR_DARK = "#3730A3"
+WORDMARK = "wordmark.svg"
+
+# Directory links that have no page of their own map to a representative route.
+DIR_ALIASES = {
+    "decisions": "decisions/index",
+    "docs/design": "design/00-meta-spec",
+}
+# Asset links rewritten to the copied site asset.
+ASSET_ALIASES = {
+    "assets/wordmark.svg": f"/{WORDMARK}",
+}
+
+
+class BuildError(Exception):
+    """Raised to abort the build with an explicit, actionable message."""
+
+
+# --- the site plan ----------------------------------------------------------------
+
+
+def plan() -> tuple[dict[str, str | None], dict[str, object]]:
+    """Enumerate the site's pages and navigation from the repository layout.
+
+    :returns: ``(sources, navigation)`` where ``sources`` maps every site route to
+        the repo-relative source markdown path (or ``None`` for a generated page),
+        and ``navigation`` is the Mintlify ``navigation`` object referencing exactly
+        those routes.
+    :raises BuildError: If an expected source directory is missing.
+    """
+    sources: dict[str, str | None] = {}
+
+    def reg(route: str, source: str | None) -> str:
+        sources[route] = source
+        return route
+
+    reg("index", "README.md")
+    reg("get-started/user-guide", "docs/USER-GUIDE.md")
+
+    skills_dir = REPO_ROOT / "skills"
+    skills_pages = [
+        reg(f"skills/{d.name}", f"skills/{d.name}/SKILL.md")
+        for d in sorted(skills_dir.iterdir())
+        if (d / "SKILL.md").is_file()
+    ]
+    if not skills_pages:
+        raise BuildError(f"no skills found under {skills_dir}")
+
+    reg("cli-reference", None)
+
+    spec_pages = [
+        reg(f"design/{f.stem}", f"docs/design/{f.name}")
+        for f in sorted((REPO_ROOT / "docs/design").glob("*.md"))
+    ]
+    proposal_pages = [
+        reg(f"design/proposals/{f.stem}", f"docs/design/proposals/{f.name}")
+        for f in sorted((REPO_ROOT / "docs/design/proposals").glob("*.md"))
+    ]
+    adr_pages = [reg("decisions/index", "decisions/README.md")]
+    adr_pages += [
+        reg(f"decisions/{f.stem}", f"decisions/{f.name}")
+        for f in sorted((REPO_ROOT / "decisions").glob("[0-9]*.md"))
+    ]
+    ref_pages = [
+        reg(f"references/{f.stem}", f"resources/references/{f.name}")
+        for f in sorted((REPO_ROOT / "resources/references").glob("*.md"))
+    ]
+    reg("disclosure", "DISCLOSURE.md")
+
+    navigation = {
+        "groups": [
+            {"group": "Overview", "pages": ["index"]},
+            {"group": "Get started", "pages": ["get-started/user-guide"]},
+            {"group": "Skills & methodology", "pages": skills_pages},
+            {"group": "CLI reference", "pages": ["cli-reference"]},
+            {
+                "group": "Design & reasoning",
+                "pages": [
+                    {"group": "Specs", "pages": spec_pages},
+                    {"group": "Proposals", "pages": proposal_pages},
+                    {"group": "Decisions (ADRs)", "pages": adr_pages},
+                    {"group": "Reference digests", "pages": ref_pages},
+                    {"group": "Disclosure", "pages": ["disclosure"]},
+                ],
+            },
+        ]
+    }
+    return sources, navigation
+
+
+def _routes_in_nav(navigation: dict[str, object]) -> list[str]:
+    """Flatten every page route referenced by the navigation tree, in order."""
+    out: list[str] = []
+
+    def walk(pages: list[object]) -> None:
+        for entry in pages:
+            if isinstance(entry, str):
+                out.append(entry)
+            elif isinstance(entry, dict):
+                walk(entry["pages"])  # type: ignore[arg-type]
+
+    for group in navigation["groups"]:  # type: ignore[index]
+        walk(group["pages"])  # type: ignore[index]
+    return out
+
+
+# --- markdown helpers -------------------------------------------------------------
+
+_MD_INLINE = [
+    (re.compile(r"`([^`]*)`"), r"\1"),
+    (re.compile(r"\*\*([^*]+)\*\*"), r"\1"),
+    (re.compile(r"\*([^*]+)\*"), r"\1"),
+    (re.compile(r"\[([^\]]*)\]\([^)]*\)"), r"\1"),
+]
+
+
+def strip_inline_markdown(text: str) -> str:
+    """Reduce inline markdown (code, emphasis, links) to its plain text."""
+    for pattern, repl in _MD_INLINE:
+        text = pattern.sub(repl, text)
+    return text
+
+
+def split_frontmatter(text: str) -> tuple[str | None, str]:
+    """Split a leading ``---`` frontmatter block (raw text) from the body."""
+    match = re.match(r"^---\n(.*?)\n---\n?(.*)$", text, re.S)
+    if not match:
+        return None, text
+    return match.group(1), match.group(2)
+
+
+def parse_skill_meta(frontmatter_text: str) -> tuple[str | None, str | None]:
+    """Extract ``name`` and ``description`` from a SKILL.md frontmatter block.
+
+    Parsed leniently (not via a strict YAML loader): the plugin's SKILL
+    descriptions are single scalars that legitimately contain ``: `` and span
+    folded lines, which a strict YAML parser rejects.
+    """
+    name_match = re.search(r"^name:[ \t]*(.+?)[ \t]*$", frontmatter_text, re.M)
+    name = name_match.group(1).strip("\"'") if name_match else None
+
+    desc_match = re.search(r"^description:[ \t]*(.*)$", frontmatter_text, re.M | re.S)
+    description = None
+    if desc_match:
+        raw = re.split(r"\n(?=[A-Za-z_][\w-]*:)", desc_match.group(1), maxsplit=1)[0]
+        raw = re.sub(r"^[>|][-+]?[ \t]*", "", raw.strip())
+        description = " ".join(raw.split()).strip("\"'") or None
+    return name, description
+
+
+def extract_title(body: str, fallback: str) -> str:
+    """Take the first ``# H1`` as the title, else derive one from `fallback`."""
+    match = re.search(r"^#\s+(.+)$", body, re.M)
+    if match:
+        return strip_inline_markdown(match.group(1)).strip()
+    return fallback.replace("-", " ").replace("_", " ").strip().capitalize()
+
+
+def strip_leading_h1(body: str) -> str:
+    """Remove the first top-level ``# H1`` line (Mintlify renders the title)."""
+    return re.sub(r"^\s*#\s+.+?(\n+)", "", body, count=1)
+
+
+def first_paragraph_description(body: str) -> str | None:
+    """Derive a one-line description from the first prose paragraph of `body`."""
+    for block in re.split(r"\n\s*\n", body.strip()):
+        block = block.strip()
+        if not block:
+            continue
+        head = block.splitlines()[0].lstrip()
+        if not head or head[0] in "-*>|#<!:" or head.startswith("```"):
+            continue
+        text = strip_inline_markdown(" ".join(block.split())).strip()
+        if text:
+            return truncate(text, 160)
+    return None
+
+
+def truncate(text: str, limit: int) -> str:
+    """Truncate `text` to at most `limit` characters on a word boundary."""
+    if len(text) <= limit:
+        return text
+    cut = text[: limit + 1].rsplit(" ", 1)[0].rstrip(" ,.;:—-")
+    return f"{cut}…"
+
+
+def yaml_quote(value: str) -> str:
+    """Return `value` as a double-quoted YAML scalar."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def frontmatter(title: str, description: str | None) -> str:
+    """Render a Mintlify page frontmatter block."""
+    lines = ["---", f"title: {yaml_quote(title)}"]
+    if description:
+        lines.append(f"description: {yaml_quote(description)}")
+    lines.append("---")
+    return "\n".join(lines) + "\n"
+
+
+# --- MDX safety -------------------------------------------------------------------
+
+
+def _escape_prose(segment: str) -> str:
+    """Escape MDX-hostile characters in a non-code text segment.
+
+    ``{`` / ``}`` (JSX expression delimiters) and tag-like ``<`` are neutralised;
+    autolinks (``<https://…>``, ``<mailto:…>``) are preserved.
+    """
+    segment = segment.replace("{", "&#123;").replace("}", "&#125;")
+    return re.sub(r"<(?!https?://|mailto:)(?=[A-Za-z/!])", "&lt;", segment)
+
+
+def _escape_prose_region(region: str) -> str:
+    """Escape a non-fenced region, preserving inline code spans (even multi-line).
+
+    ``[^`]*?`` spans newlines, so a backtick code span that wraps across a soft
+    line break is matched as one token and left intact — its ``{`` / ``<`` are not
+    touched.
+    """
+    parts = re.split(r"(`+[^`]*?`+)", region)
+    return "".join(p if p.startswith("`") else _escape_prose(p) for p in parts)
+
+
+def mdx_safe(text: str) -> str:
+    """Make `text` safe to embed in an MDX page, leaving fenced code untouched."""
+    out: list[str] = []
+    prose: list[str] = []
+    code: list[str] = []
+    fence: str | None = None
+
+    def flush_prose() -> None:
+        if prose:
+            out.append(_escape_prose_region("\n".join(prose)))
+            prose.clear()
+
+    for line in text.split("\n"):
+        stripped = line.lstrip()
+        marker = stripped[:3] if stripped[:3] in ("```", "~~~") else None
+        if fence is None and marker:
+            flush_prose()
+            fence = marker
+            code = [line]
+        elif fence is not None and stripped.startswith(fence):
+            code.append(line)
+            out.append("\n".join(code))
+            fence = None
+        elif fence is not None:
+            code.append(line)
+        else:
+            prose.append(line)
+    flush_prose()
+    if fence is not None:  # an unterminated fence — emit verbatim
+        out.append("\n".join(code))
+    return "\n".join(out)
+
+
+# --- link rewriting ---------------------------------------------------------------
+
+_LINK_RE = re.compile(r"(!?)\[([^\]]*)\]\(\s*<?([^)\s>]+)>?(\s+\"[^\"]*\")?\s*\)")
+
+
+def _resolve_target(
+    target: str, source: str, route_map: dict[str, str], routes: set[str]
+) -> tuple[str, str | None]:
+    """Resolve one markdown link target for the page generated from `source`.
+
+    :returns: ``(new_target, error)`` — `error` is set only for a link that points
+        at a repository path which does not exist.
+    """
+    if (
+        target.startswith(("#", "/", "//", "mailto:"))
+        or re.match(r"^[a-z][a-z0-9+.-]*://", target)
+    ):
+        return target, None
+
+    path_part, sep, anchor = target.partition("#")
+    anchor = f"#{anchor}" if sep else ""
+    if not path_part:
+        return target, None
+
+    resolved = posixpath.normpath(
+        posixpath.join(posixpath.dirname(source), path_part)
+    )
+    key = resolved.rstrip("/")
+
+    if key in route_map:
+        route = route_map[key]
+        if f"/{route}" not in {f"/{r}" for r in routes}:  # pragma: no cover
+            return target, f"{source}: link {target!r} maps to unknown route {route!r}"
+        return f"/{route}{anchor}", None
+    if key in ASSET_ALIASES:
+        return f"{ASSET_ALIASES[key]}{anchor}", None
+    if key in DIR_ALIASES:
+        return f"/{DIR_ALIASES[key]}{anchor}", None
+
+    abspath = REPO_ROOT / resolved
+    if abspath.is_dir():
+        return f"{GH_TREE}{resolved}{anchor}", None
+    if abspath.exists():
+        return f"{GH_BLOB}{resolved}{anchor}", None
+    return target, f"{source}: broken link {target!r} → {resolved!r} does not exist"
+
+
+def rewrite_links(
+    body: str,
+    source: str,
+    route_map: dict[str, str],
+    routes: set[str],
+    errors: list[str],
+    site_links: set[str],
+) -> str:
+    """Rewrite every intra-repo link in `body`; collect errors and site links."""
+
+    def repl(match: re.Match[str]) -> str:
+        bang, textseg, target, title = match.groups()
+        new_target, error = _resolve_target(target, source, route_map, routes)
+        if error:
+            errors.append(error)
+            return match.group(0)
+        if new_target.startswith("/") and not new_target.startswith(f"/{WORDMARK}"):
+            site_links.add(new_target.split("#", 1)[0])
+        return f"{bang}[{textseg}]({new_target}{title or ''})"
+
+    return _LINK_RE.sub(repl, body)
+
+
+# --- CLI reference generation -----------------------------------------------------
+
+
+def _clean_command_help(help_text: str | None) -> str:
+    """Return the prose part of a command docstring (drop RST field lists)."""
+    if not help_text:
+        return ""
+    kept: list[str] = []
+    for line in help_text.strip("\n").split("\n"):
+        if re.match(r"\s*:(param|arg|returns?|raises|type|rtype|yields?)\b", line):
+            break
+        kept.append(line)
+    return re.sub(r"\n{3,}", "\n\n", "\n".join(kept).strip())
+
+
+def _cell(text: str) -> str:
+    """Escape a value for use inside a markdown table cell."""
+    return " ".join((text or "").split()).replace("|", "\\|") or "—"
+
+
+def _default_cell(param: object) -> str:
+    """Render an option's default value for a table cell."""
+    default = getattr(param, "default", None)
+    if getattr(param, "is_flag", False):
+        return f"`{str(bool(default)).lower()}`"
+    if default in (None, ""):
+        return "—"
+    return f"`{default}`"
+
+
+def _render_command(cmd: object, ctx_cls: type, parent_ctx: object, path: list[str]) -> str:
+    """Render one Typer/Click command (or group) to a markdown section."""
+    ctx = ctx_cls(cmd, info_name=path[-1], parent=parent_ctx)
+    is_group = hasattr(cmd, "list_commands") and hasattr(cmd, "get_command")
+    params = [p for p in cmd.get_params(ctx) if getattr(p, "name", None) != "help"]
+    arguments = [p for p in params if getattr(p, "param_type_name", "") == "argument"]
+    options = [p for p in params if getattr(p, "param_type_name", "") == "option"]
+
+    level = "##" if len(path) == 2 else "###"
+    parts = [f"{level} `{' '.join(path)}`", ""]
+    prose = _clean_command_help(getattr(cmd, "help", None))
+    if prose:
+        parts += [prose, ""]
+
+    if not is_group:
+        usage = list(path)
+        if options:
+            usage.append("[OPTIONS]")
+        for arg in arguments:
+            name = (getattr(arg, "name", "") or "").upper()
+            usage.append(name if getattr(arg, "required", False) else f"[{name}]")
+        parts += ["```text", " ".join(usage), "```", ""]
+
+    if arguments:
+        parts += ["| Argument | Required | Description |", "|---|---|---|"]
+        for arg in arguments:
+            name = (getattr(arg, "name", "") or "").upper()
+            required = "yes" if getattr(arg, "required", False) else "no"
+            parts.append(
+                f"| `{name}` | {required} | {_cell(getattr(arg, 'help', '') or '')} |"
+            )
+        parts.append("")
+
+    if options:
+        parts += ["| Option | Default | Description |", "|---|---|---|"]
+        for opt in options:
+            flags = ", ".join(f"`{o}`" for o in getattr(opt, "opts", []))
+            parts.append(
+                f"| {flags} | {_default_cell(opt)} "
+                f"| {_cell(getattr(opt, 'help', '') or '')} |"
+            )
+        parts.append("")
+
+    if is_group:
+        for name in cmd.list_commands(ctx):
+            sub = cmd.get_command(ctx, name)
+            parts.append(_render_command(sub, ctx_cls, ctx, [*path, name]))
+
+    return "\n".join(parts)
+
+
+def generate_cli_reference() -> str:
+    """Render the ``honest-scholar`` Typer command tree to markdown."""
+    import typer
+    from typer._click.core import Context
+
+    from honest_scholar.cli import app
+
+    root = typer.main.get_command(app)
+    root_ctx = Context(root, info_name="honest-scholar")
+    intro = _clean_command_help(getattr(root, "help", None))
+
+    body = [
+        intro,
+        "",
+        "Every command emits JSON on success and a clear, non-zero exit with an "
+        "actionable message on failure. Run `honest-scholar --version` to print the "
+        "installed version. This page is generated from the Typer app on every "
+        "build, so it always matches the released CLI.",
+        "",
+    ]
+    for name in root.list_commands(root_ctx):
+        sub = root.get_command(root_ctx, name)
+        body.append(_render_command(sub, Context, root_ctx, ["honest-scholar", name]))
+    return "\n".join(body)
+
+
+# --- page assembly ----------------------------------------------------------------
+
+
+def build_page(
+    route: str,
+    source: str | None,
+    route_map: dict[str, str],
+    routes: set[str],
+    errors: list[str],
+    site_links: set[str],
+) -> str:
+    """Assemble one MDX page (frontmatter + transformed body)."""
+    if source is None:  # the generated CLI reference
+        title = "CLI reference"
+        description = "The honest-scholar command tree, generated from the Typer app."
+        raw = generate_cli_reference()
+        body = rewrite_links(raw, "docs/USER-GUIDE.md", route_map, routes, errors, site_links)
+        return frontmatter(title, description) + "\n" + mdx_safe(body).strip() + "\n"
+
+    text = (REPO_ROOT / source).read_text(encoding="utf-8")
+    fm_text, body = split_frontmatter(text)
+    skill_name, skill_desc = parse_skill_meta(fm_text) if fm_text else (None, None)
+
+    if route == "index":
+        # README opens with a centred HTML masthead + badges, then a `---` rule;
+        # drop everything through that rule and use the canonical site identity.
+        lines = body.split("\n")
+        if "---" in lines:
+            body = "\n".join(lines[lines.index("---") + 1 :])
+        title, description = SITE_NAME, SITE_DESCRIPTION
+    elif skill_name:  # a SKILL.md
+        title = skill_name
+        description = truncate(skill_desc or title, 200)
+        body = strip_leading_h1(body)
+    else:
+        fallback = Path(source).stem
+        title = extract_title(body, fallback)
+        description = first_paragraph_description(strip_leading_h1(body)) or title
+        body = strip_leading_h1(body)
+
+    body = rewrite_links(body, source, route_map, routes, errors, site_links)
+    return frontmatter(title, description or None) + "\n" + mdx_safe(body).strip() + "\n"
+
+
+def build_docs_json(navigation: dict[str, object]) -> dict[str, object]:
+    """Assemble the Mintlify ``docs.json`` configuration."""
+    return {
+        "$schema": "https://mintlify.com/docs.json",
+        "theme": "mint",
+        "name": SITE_NAME,
+        "description": SITE_DESCRIPTION,
+        "colors": {"primary": PRIMARY, "light": COLOR_LIGHT, "dark": COLOR_DARK},
+        "favicon": f"/{WORDMARK}",
+        "logo": {"light": f"/{WORDMARK}", "dark": f"/{WORDMARK}"},
+        "navigation": navigation,
+        "navbar": {"links": [{"label": "GitHub", "href": GH_REPO}]},
+        "footer": {"socials": {"github": GH_REPO}},
+    }
+
+
+# --- driver -----------------------------------------------------------------------
+
+
+def build(out: Path) -> dict[str, int]:
+    """Build the whole site into `out`. Raises :class:`BuildError` on any problem."""
+    sources, navigation = plan()
+    nav_routes = _routes_in_nav(navigation)
+
+    # nav and the source table must describe exactly the same set of pages.
+    if set(nav_routes) != set(sources):
+        missing = set(sources) - set(nav_routes)
+        extra = set(nav_routes) - set(sources)
+        raise BuildError(f"navigation/pages mismatch (missing={missing}, extra={extra})")
+
+    route_map = {src: route for route, src in sources.items() if src}
+    routes = set(sources)
+    errors: list[str] = []
+    site_links: set[str] = set()
+
+    if out.exists():
+        shutil.rmtree(out)
+    out.mkdir(parents=True)
+
+    for route, source in sources.items():
+        page = build_page(route, source, route_map, routes, errors, site_links)
+        dest = out / f"{route}.mdx"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(page, encoding="utf-8")
+
+    # Every intra-site link must resolve to a real page.
+    for link in sorted(site_links):
+        if link.lstrip("/") not in routes:
+            errors.append(f"intra-site link {link!r} resolves to no page")
+
+    # Copy assets.
+    wordmark_src = REPO_ROOT / "assets" / WORDMARK
+    if not wordmark_src.is_file():
+        raise BuildError(f"missing asset {wordmark_src}")
+    shutil.copy2(wordmark_src, out / WORDMARK)
+
+    # Emit and re-parse docs.json to guarantee validity.
+    docs_json = build_docs_json(navigation)
+    docs_text = json.dumps(docs_json, indent=2) + "\n"
+    json.loads(docs_text)
+    (out / "docs.json").write_text(docs_text, encoding="utf-8")
+
+    if errors:
+        raise BuildError(
+            "build failed with "
+            f"{len(errors)} link error(s):\n  - " + "\n  - ".join(sorted(errors))
+        )
+
+    return {
+        "pages": len(sources),
+        "groups": len(navigation["groups"]),  # type: ignore[arg-type]
+        "site_links": len(site_links),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Build the honest-scholar docs site.")
+    parser.add_argument(
+        "--out", required=True, type=Path, help="Output directory for the site."
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        stats = build(args.out.resolve())
+    except BuildError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"built honest-scholar docs site → {args.out}")
+    print(
+        f"  {stats['pages']} pages across {stats['groups']} top-level nav groups; "
+        f"{stats['site_links']} intra-site links verified; docs.json valid; "
+        f"{WORDMARK} copied."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements the rendered docs site (**Mintlify**) per **ADR-0030** and
`docs/design/proposals/docs-site.md`. This repo stays the single source of truth
and free of Mintlify config; CI generates the site and pushes it to the separate
`davorrunje/honest-scholar-docs` repo, which Mintlify renders at
`honest-scholar.science`.

## What lands

**`tools/build_docs_site.py`** — a standalone builder (not part of the shipped
package; lives in `tools/`, outside the coverage/lint gate). Run it from the
package dir: `cd honest-scholar && uv run python ../tools/build_docs_site.py --out ../dist/docs-site`
(or from the root under the project: `uv run --project honest-scholar python tools/build_docs_site.py --out dist/docs-site`).
It:

- **Assembles the one portal** from the in-repo markdown — Overview (README,
  masthead trimmed), Get started (USER-GUIDE), one page per `skills/*/SKILL.md`,
  and Design & reasoning (specs, proposals, the ADR log incl. its index, the
  reference digests, DISCLOSURE). Nothing is hand-duplicated.
- **Generates the CLI reference** live from the `honest_scholar` Typer app by
  walking the command tree (`typer.main.get_command(app)`, then Typer's vendored
  Click groups/commands/params) into markdown — description, usage, and
  argument/option tables per command. Regenerated every build, so it never drifts.
- **Front-matter**: every page gets `title` + `description`, derived from each
  SKILL's YAML `name`/`description` (parsed leniently — the descriptions contain
  `: ` and folded lines that strict YAML rejects) and from each doc's H1 / first
  prose paragraph.
- **`docs.json`**: valid Mintlify config matching the existing placeholder (`mint`
  theme, `name`, primary `#4338CA`, `/wordmark.svg` favicon+logo, navbar GitHub
  link, footer github social) with **grouped navigation** (`navigation.groups`,
  nested under Design & reasoning).
- **Link rewriting**: intra-repo relative links → site routes; repo files *not*
  in the site → absolute `github.com/.../blob|tree/main/...` URLs; `assets/wordmark.svg`
  → `/wordmark.svg`. Copies the wordmark asset.
- **Fails loudly** (non-zero exit) on a broken intra-repo link or a missing page,
  and self-validates `docs.json` (JSON round-trip) + every intra-site link — no
  silent content drops. MDX-hostile chars (`{`/`}`, tag-like `<`) in prose are
  escaped; fenced and inline code (incl. multi-line spans) and autolinks are
  preserved.

**`.github/workflows/docs-publish.yml`** — pins `actions/checkout@v7` +
`astral-sh/setup-uv@v8.3.1`:

- `pull_request` → **strict build-check** (fails on any build error / broken link),
  **no push**.
- `release: published` (release-gated, ADR-0027) **and** `workflow_dispatch` →
  build, then push the generated site to `davorrunje/honest-scholar-docs`
  (`main`) via the `DOCS_DEPLOY_TOKEN` secret, **preserving that repo's `LICENSE`
  and `README.md`** and replacing the rest. Mintlify redeploys on push.

## Local verification

- Builder runs clean end-to-end against the real content: **67 pages** across
  **5 top-level nav groups** (Overview · Get started · Skills & methodology · CLI
  reference · Design & reasoning{Specs, Proposals, Decisions, Reference digests,
  Disclosure}); **58 intra-site links verified**; `docs.json` valid; `wordmark.svg`
  copied. (Node/`mint` unavailable in-container, so link + JSON integrity is
  asserted by the builder itself, as the design allows.)
- `pre-commit run --all-files` (ruff, ruff-format, mypy, codespell,
  detect-secrets, plugin-validate, yaml/whitespace) — **all green**.

## Maintainer prerequisite to go live

1. Create a repo Actions secret **`DOCS_DEPLOY_TOKEN`** — a fine-grained PAT with
   **Contents: read and write** scoped to **`davorrunje/honest-scholar-docs`** only.
2. Run the **Docs publish** workflow via **workflow_dispatch** for the first
   publish (replaces the single-page placeholder); thereafter it publishes on each
   `release: published`. The publish job fails fast with an explanatory message if
   the secret is absent.

## Design ambiguity resolved

- SKILL front-matter descriptions are not strict-YAML-parseable (they contain
  `: ` and folded scalars), so `name`/`description` are extracted with a tolerant
  parser rather than a YAML loader — matches how the plugin loader tolerates them.
- Directory links with no page of their own map to a representative route
  (`decisions/` → the ADR index, `docs/design/` → the meta-spec); other repo
  directories become `github.com/.../tree/main/...` URLs.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
