### PR TITLE
fix(docs): compile every Mintlify page + gate CI on the MDX compile

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -41,26 +41,44 @@ concurrency:
 jobs:
   build-check:
     # Strict build on every relevant PR — fails on a broken link or missing page,
-    # but does not push anywhere.
+    # then compiles the generated MDX with Mintlify so a page that would silently
+    # drop on the live site fails the check here instead. Does not push anywhere.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v8.3.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
       - name: Sync honest-scholar
         run: uv sync --project honest-scholar
       - name: Build the docs site (strict)
         run: |
           uv run --project honest-scholar python tools/build_docs_site.py \
             --out "$RUNNER_TEMP/docs-site"
+      - name: Validate MDX compilation + internal links (Mintlify)
+        run: |
+          npm i -g mint
+          cd "$RUNNER_TEMP/docs-site"
+          # `mint validate` fails on any MDX compile error or missing nav page —
+          # this is the gate that closes the silent-drop hole. `broken-links`
+          # fails on any broken internal link in the generated output.
+          mint validate
+          mint broken-links
 
   publish:
     # Release or manual dispatch → build and push to the generated docs repo.
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    outputs:
+      pages: ${{ steps.count.outputs.pages }}
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v8.3.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
       - name: Guard — DOCS_DEPLOY_TOKEN must be configured
         env:
           DOCS_DEPLOY_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}
@@ -75,6 +93,19 @@ jobs:
         run: |
           uv run --project honest-scholar python tools/build_docs_site.py \
             --out "$RUNNER_TEMP/docs-site"
+      - name: Validate MDX compilation + internal links (Mintlify)
+        run: |
+          npm i -g mint
+          cd "$RUNNER_TEMP/docs-site"
+          # Never publish content Mintlify cannot compile, and never publish a
+          # broken internal link.
+          mint validate
+          mint broken-links
+      - name: Count built pages (for the live check)
+        id: count
+        run: |
+          echo "pages=$(find "$RUNNER_TEMP/docs-site" -name '*.mdx' | wc -l)" \
+            >> "$GITHUB_OUTPUT"
       - name: Checkout the docs repo
         uses: actions/checkout@v7
         with:
@@ -105,3 +136,96 @@ jobs:
           git commit --no-gpg-sign \
             -m "docs: publish site from davorrunje/honest-scholar@${GITHUB_SHA}"
           git push
+
+  live-link-check:
+    # After the push, Mintlify rebuilds honest-scholar.science asynchronously.
+    # Wait for that deploy to land, then check the *live* site for broken
+    # internal links. Internal 404s (e.g. a page that failed to compile and was
+    # silently dropped) fail the job; external links are excluded so a
+    # third-party outage cannot make this flaky.
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    needs: publish
+    runs-on: ubuntu-latest
+    env:
+      SITE: https://honest-scholar.science
+      EXPECTED_PAGES: ${{ needs.publish.outputs.pages }}
+    steps:
+      - name: Wait for Mintlify to reflect the new deploy
+        run: |
+          # Poll the auto-generated llms.txt until it lists at least as many
+          # pages as we just published (or a marker times out). Mintlify rebuilds
+          # can take a minute or two; give it up to 15 with an initial settle.
+          sleep 30
+          deadline=$((SECONDS + 900))
+          while :; do
+            live=$(curl -fsSL --max-time 20 "$SITE/llms.txt" 2>/dev/null \
+              | grep -coE 'https?://[^)[:space:]]*honest-scholar\.science' || true)
+            live=${live:-0}
+            echo "live llms.txt page links: $live / expected >= ${EXPECTED_PAGES:-?}"
+            if [ -n "$EXPECTED_PAGES" ] && [ "$live" -ge "$EXPECTED_PAGES" ]; then
+              echo "Deploy reflects the new build."
+              break
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::warning::Timed out waiting for the Mintlify deploy to fully" \
+                "reflect the new build; running the link check anyway."
+              break
+            fi
+            sleep 15
+          done
+          # Small extra settle so the CDN serves the new pages consistently.
+          sleep 30
+      - name: Enumerate the expected live page URLs
+        run: |
+          # Fetch the published nav (docs.json) and turn every page route into an
+          # absolute site URL — this catches a silently-dropped page directly,
+          # even if it never made it into the sitemap/llms.txt.
+          curl -fsSL --max-time 30 \
+            "https://raw.githubusercontent.com/davorrunje/honest-scholar-docs/main/docs.json" \
+            -o docs.json
+          python3 - <<'PY' > expected-urls.txt
+          import json, os
+          site = os.environ["SITE"].rstrip("/")
+          nav = json.load(open("docs.json"))["navigation"]
+          out = []
+          def walk(pages):
+              for p in pages:
+                  if isinstance(p, str):
+                      out.append("" if p == "index" else p)
+                  elif isinstance(p, dict):
+                      walk(p["pages"])
+          for g in nav["groups"]:
+              walk(g["pages"])
+          print("\n".join(f"{site}/{r}" for r in out))
+          PY
+          echo "Will verify $(wc -l < expected-urls.txt) live page URLs."
+          cat expected-urls.txt
+      - name: Verify every published page is reachable (no silent 404s)
+        run: |
+          # Directly closes the silent-drop hole on the live site: a page that
+          # Mintlify failed to render 404s here and fails the job.
+          fail=0
+          while IFS= read -r url; do
+            [ -n "$url" ] || continue
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "$url" \
+              || echo 000)
+            printf '%s  %s\n' "$code" "$url"
+            case "$code" in 200 | 206) ;; *) fail=1 ;; esac
+          done < expected-urls.txt
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::One or more published pages are not reachable on" \
+              "$SITE (silently dropped or deploy incomplete)."
+            exit 1
+          fi
+      - name: Check live internal links (lychee)
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # Fetch every published page and check the links found on it, but only
+          # for the honest-scholar.science host — external links are ignored so
+          # CI never flakes on a third-party outage. Any internal 404 fails.
+          args: >-
+            --no-progress
+            --include 'honest-scholar\.science'
+            --accept 200,206,429
+            expected-urls.txt
+          fail: true

--- a/tools/build_docs_site.py
+++ b/tools/build_docs_site.py
@@ -261,14 +261,40 @@ def frontmatter(title: str, description: str | None) -> str:
 # --- MDX safety -------------------------------------------------------------------
 
 
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.S)
+_AUTOLINK_RE = re.compile(r"<((?:https?://|mailto:)[^>\s]+)>")
+
+
+def _autolink_to_markdown(match: re.Match[str]) -> str:
+    """Convert a Markdown autolink to an explicit ``[text](url)`` link.
+
+    Mintlify's MDX parser reads a raw ``<https://…>`` autolink as a JSX tag and
+    fails on the ``//``. Rewriting it to an ordinary Markdown link keeps it
+    clickable while being MDX-safe. A ``mailto:`` link shows the bare address.
+    """
+    url = match.group(1)
+    text = url[len("mailto:") :] if url.startswith("mailto:") else url
+    return f"[{text}]({url})"
+
+
 def _escape_prose(segment: str) -> str:
     """Escape MDX-hostile characters in a non-code text segment.
 
-    ``{`` / ``}`` (JSX expression delimiters) and tag-like ``<`` are neutralised;
-    autolinks (``<https://…>``, ``<mailto:…>``) are preserved.
+    The generated site carries no intentional JSX, so anything tag- or
+    expression-like in prose must be neutralised or MDX compilation fails:
+
+    * HTML comments (``<!-- … -->``) are dropped — they are not valid MDX.
+    * Markdown autolinks (``<https://…>``, ``<mailto:…>``) are rewritten to
+      explicit ``[text](url)`` links so they still render (a raw autolink is
+      parsed as JSX and breaks the build).
+    * every remaining ``<`` becomes ``&lt;`` (a bare ``<foo>``, ``<0.05``, or
+      ``</x>`` in prose is otherwise read as a JSX tag), and ``{`` / ``}`` (JSX
+      expression delimiters) become HTML entities.
     """
+    segment = _HTML_COMMENT_RE.sub("", segment)
+    segment = _AUTOLINK_RE.sub(_autolink_to_markdown, segment)
     segment = segment.replace("{", "&#123;").replace("}", "&#125;")
-    return re.sub(r"<(?!https?://|mailto:)(?=[A-Za-z/!])", "&lt;", segment)
+    return segment.replace("<", "&lt;")
 
 
 def _escape_prose_region(region: str) -> str:
@@ -313,6 +339,52 @@ def mdx_safe(text: str) -> str:
     if fence is not None:  # an unterminated fence — emit verbatim
         out.append("\n".join(code))
     return "\n".join(out)
+
+
+def mdx_hazards(text: str) -> list[str]:
+    """Report residual MDX-hostile constructs in a *finished* page's prose.
+
+    A best-effort, deliberately independent sanity check (it does not reuse
+    :func:`_escape_prose`, so a bug there is caught): after fenced and inline code
+    are removed, a literal ``<`` (JSX tag) or ``{`` / ``}`` (JSX expression) in
+    prose is something Mintlify's MDX parser would reject — the sanitizer should
+    have turned it into an entity. Returned strings are ``"line:col message"``
+    describing each hazard; an empty list means clean.
+    """
+    # The YAML frontmatter is not MDX — its `{ }` / `<` are harmless. Skip it,
+    # keeping a line offset so reported positions match the file.
+    fm_text, body = split_frontmatter(text)
+    offset = text.count("\n", 0, len(text) - len(body)) if fm_text is not None else 0
+
+    # Blank fenced-code lines (keep length so line/col stay accurate).
+    masked: list[str] = []
+    fence: str | None = None
+    for line in body.split("\n"):
+        stripped = line.lstrip()
+        marker = stripped[:3] if stripped[:3] in ("```", "~~~") else None
+        if fence is None and marker:
+            fence = marker
+            masked.append(" " * len(line))
+        elif fence is not None:
+            if stripped.startswith(fence):
+                fence = None
+            masked.append(" " * len(line))
+        else:
+            masked.append(line)
+
+    # Blank inline code spans (which may wrap across a soft line break),
+    # preserving newlines so reported positions stay correct.
+    def _blank(match: re.Match[str]) -> str:
+        return "".join("\n" if ch == "\n" else " " for ch in match.group(0))
+
+    blob = re.sub(r"`+[^`]*?`+", _blank, "\n".join(masked))
+
+    hazards: list[str] = []
+    for lineno, line in enumerate(blob.split("\n"), start=1 + offset):
+        for col, ch in enumerate(line, start=1):
+            if ch in "<{}":
+                hazards.append(f"{lineno}:{col} unescaped {ch!r} (JSX-hostile)")
+    return hazards
 
 
 # --- link rewriting ---------------------------------------------------------------
@@ -580,6 +652,10 @@ def build(out: Path) -> dict[str, int]:
         dest = out / f"{route}.mdx"
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(page, encoding="utf-8")
+        # Local MDX sanity — surface obvious breakage without a Node/Mintlify
+        # toolchain. The authoritative gate is `mint validate` in CI.
+        for hazard in mdx_hazards(page):
+            errors.append(f"{route}.mdx:{hazard}")
 
     # Every intra-site link must resolve to a real page.
     for link in sorted(site_links):


### PR DESCRIPTION
## What

The docs-publish pipeline generated 67 pages, but **3 failed Mintlify's MDX
compilation and were silently dropped** — they 404'd on the live site and were
absent from `llms.txt` (64/67 live). This hardens the Markdown->MDX sanitizer so
every page compiles, and makes CI actually run Mintlify's MDX compile + link
checks so a page that cannot render **fails the check instead of vanishing**.

The dropped pages were `get-started/user-guide` (`docs/USER-GUIDE.md`),
`references/agency-principle`, and `references/understanding-and-defense`. The
old CI `build-check` only validated links + JSON, so it stayed green while
Mintlify quietly discarded the pages.

## Details

**1. Harden the MDX sanitizer (`tools/build_docs_site.py`)**

The confirmed compile errors were: raw `<https://...>` autolinks (Mintlify
parses `<https:` as a JSX tag and chokes on `//`), a bare `<` before a digit
(`"Beyond p<0.05"`), and a top-of-file HTML comment. The prose escaper now:

- **drops HTML comments** (`<!-- ... -->`) — not valid MDX;
- **rewrites autolinks** `<https://...>` / `<mailto:...>` to explicit
  `[text](url)` links, so they still render as links instead of breaking the
  build;
- **escapes every remaining bare `<`** (`&lt;`) and `{`/`}` (entities) in prose.
  The generated site carries **no intentional JSX** (all `<TAG>`-looking tokens
  live inside code spans, which are preserved), so a blanket escape is safe —
  this replaces the old `<`-before-`[A-Za-z/!]`-only rule that missed digits and
  autolinks. Fenced code, inline code (incl. multi-line spans), and Markdown
  autolink semantics are preserved.
- Adds a **code-aware local MDX hazard check** that fails the build on any
  residual `<`/`{`/`}` in prose — independent of the escaper, so a future
  sanitizer regression is caught even without a Node toolchain.

**2. Close the silent-drop gap in CI (`.github/workflows/docs-publish.yml`)**

- `build-check` (PR) and `publish` now install Node + the Mintlify CLI and run
  **`mint validate`** (a real MDX compile — fails on any compile error or
  missing nav page) and **`mint broken-links`** on the generated output. Zero
  MDX errors and zero broken internal links are now a hard gate.
- New **`live-link-check`** job (release / manual dispatch): after the push, it
  **waits for the Mintlify deploy** — polling `honest-scholar.science/llms.txt`
  page count against the number of pages just published, with a 15-min timeout
  and a settle delay — then verifies **every published page is reachable** (no
  404s) and runs **lychee** scoped to the internal host. Internal broken links
  fail the job; external links are excluded so a third-party outage can't flake
  CI.

**Verification:** built locally (67 pages, 5 nav groups); `mint validate` and
`mint broken-links` both pass on the full output; the 3 formerly-broken pages
now compile. `pre-commit run --all-files` is green and the package's 100%
coverage gate holds (changes are in `tools/` + workflow; `pytest` still passes,
252 passed).

**After merge:** the maintainer re-runs the `docs-publish` workflow
(`workflow_dispatch`) to republish; the new `live-link-check` job then confirms
all 67 pages are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
