### PR TITLE
docs(branding): integrate new visual identity + fix docs-publish build

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -26,7 +26,7 @@ on:
       - "skills/**"
       - "decisions/**"
       - "resources/references/**"
-      - "assets/wordmark.svg"
+      - "assets/**"
       - "honest-scholar/**"
       - "tools/build_docs_site.py"
       - ".github/workflows/docs-publish.yml"

--- a/DISCLOSURE.md
+++ b/DISCLOSURE.md
@@ -63,7 +63,7 @@ If you keep your research in a public repo, you can add a discovery badge (this
 describes the *disclosure*, it does not certify honesty):
 
 ```markdown
-[![AI use: disclosed with honest-scholar](https://img.shields.io/badge/AI%20use-disclosed%20with%20honest--scholar-4338CA)](https://github.com/davorrunje/honest-scholar)
+[![AI use: disclosed with honest-scholar](https://img.shields.io/badge/AI%20use-disclosed%20with%20honest--scholar-ff6558?style=flat-square&labelColor=241852)](https://github.com/davorrunje/honest-scholar)
 ```
 
 ## How it reaches you (the automatic step)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/wordmark.svg" alt="honest-scholar" width="360">
+  <img src="assets/wordmark-banner.svg" alt="honest-scholar" width="640">
 </p>
 
 <p align="center"><em>Research you can defend.</em></p>
@@ -7,8 +7,8 @@
 <p align="center">Keep your research honest — <strong>especially now that AI is in the loop</strong>.</p>
 
 <p align="center">
-  <a href="https://github.com/davorrunje/honest-scholar/actions/workflows/ci.yml"><img src="https://github.com/davorrunje/honest-scholar/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://codecov.io/gh/davorrunje/honest-scholar"><img src="https://codecov.io/gh/davorrunje/honest-scholar/branch/main/graph/badge.svg" alt="coverage"></a>
+  <a href="https://github.com/davorrunje/honest-scholar/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/davorrunje/honest-scholar/ci.yml?branch=main&style=flat-square&labelColor=241852&label=CI" alt="CI"></a>
+  <a href="https://codecov.io/gh/davorrunje/honest-scholar"><img src="https://img.shields.io/codecov/c/github/davorrunje/honest-scholar?style=flat-square&labelColor=241852&label=coverage" alt="coverage"></a>
 </p>
 
 ---

--- a/assets/visual-identity.md
+++ b/assets/visual-identity.md
@@ -9,9 +9,9 @@ new tool, not for a landing page.
 ## Logo
 
 <p align="center">
-  <img src="../../assets/wordmark-lockup-dark.svg" alt="Lockup on dark" width="380">
+  <img src="wordmark-lockup-dark.svg" alt="Lockup on dark" width="380">
   &nbsp;&nbsp;
-  <img src="../../assets/wordmark-lockup-light.svg" alt="Lockup on light" width="380">
+  <img src="wordmark-lockup-light.svg" alt="Lockup on light" width="380">
 </p>
 
 The icon mark (`assets/icon-mark.svg`) is a coral circle with a white
@@ -48,13 +48,13 @@ below 16px.
 
 **README header:**
 
-<p align="center"><img src="../../assets/wordmark-banner.svg" alt="README header" width="640"></p>
+<p align="center"><img src="wordmark-banner.svg" alt="README header" width="640"></p>
 
 **Badges** use `labelColor=241852` (indigo) and `color=ff6558` (coral), flat-square style — see the shields.io URLs in the root `README.md`.
 
 **Social preview** (GitHub repo social image, 1280×640):
 
-<p align="center"><img src="../../assets/social-preview.svg" alt="Social preview" width="640"></p>
+<p align="center"><img src="social-preview.svg" alt="Social preview" width="640"></p>
 
 ## Voice
 
@@ -65,7 +65,7 @@ not "seamlessly" or "powerful."
 
 ## Assets
 
-All source files live in [`assets/`](../../assets):
+All source files live in [`assets/`](../assets):
 
 - `icon-mark.svg` — app icon / favicon source (512×512)
 - `wordmark-banner.svg` — README header (1200×300)

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="../assets/wordmark-banner.svg" alt="honest-scholar" width="640">
+</p>
+
 <!-- honest-scholar user guide -->
 
 # honest-scholar — User Guide

--- a/docs/design/visual-identity.md
+++ b/docs/design/visual-identity.md
@@ -1,85 +1,74 @@
-# honest-scholar — Visual Identity (v1, text)
+# Visual identity
 
-**Date:** 2026-07-17 · **Status:** first proposal (text/SVG). A browser-companion
-pass (`/design consent`) can later render mockups; this establishes the direction.
+Honest Scholar's identity is built to read as rigorous, not decorative: a deep
+indigo grounds the system in credibility, a single coral accent carries every
+call to action and moment of confirmation — the checkmark, the sign-off, the
+"verified." Quietly confident and understated, it is built for researchers
+evaluating a new tool, not for a landing page.
 
-`honest-scholar` covers the *scientific* workflow (engineering is delegated to a bound
-engineering backend via the engineering-delegation contract). Its identity should
-read **scholarly, rigorous, and calm** — a trusted mentor/colleague, not a flashy
-product. Lowercase, understated, typographic; the opposite of hype.
+This page is the design-record narrative. The **canonical asset spec** — exact
+roles, sizes, clearspace, and the source SVGs — lives alongside the assets in
+[`assets/visual-identity.md`](../../assets/visual-identity.md); keep the two in
+sync (palette and asset roles here must match it).
 
-## Name & wordmark
+## Logo
 
-- **Name:** `honest-scholar` (always lowercase).
-- **Wordmark:** the word set in a humanist **serif** (scholarship, print, the
-  paper), lowercase. Optional bracket motif around it — `[ honest-scholar ]` — nodding to
-  citations. See `assets/wordmark.svg`.
-- **Skill names** render in **monospace** (`defend`, `literature`, `hypothesis-
-  testing`) — they are commands.
+![Wordmark lockup on a light surface](../../assets/wordmark-lockup-light.svg)
 
-## Logo mark
+The icon mark ([`assets/icon-mark.svg`](../../assets/icon-mark.svg)) is a coral
+circle with a white checkmark, used standalone as the favicon and app icon at
+32/24/16px, and paired with the wordmark in the lockups:
 
-Recommended concept — **"citation & through-line"** (`assets/logo-concept.svg`):
-two citation brackets `[ ]` embracing an upward stroke with a dot above it. Reads
-as: *scholarship (brackets/citations) enclosing a claim (dot) and its rising
-through-line (understanding/argument)*. Abstract, geometric, works at favicon size,
-pairs with a code aesthetic.
+- [`wordmark-lockup-light.svg`](../../assets/wordmark-lockup-light.svg) — indigo
+  wordmark, for **light** surfaces (docs in light mode, README body).
+- [`wordmark-lockup-dark.svg`](../../assets/wordmark-lockup-dark.svg) — white
+  wordmark with the coral mark, for **dark** surfaces (docs in dark mode).
 
-Alternatives considered (not chosen for v1):
-- **Owl** — the classic scholar/wisdom symbol; warm but common and harder to keep
-  distinctive at small sizes.
-- **Mortarboard** — too narrowly "graduation/degree"; undersells the research-
-  program and colleague framing.
-- **Compass/through-line** — nice for "coherent narrative" but less legible as a
-  mark.
+**Clearspace & minimum size.** Keep clearspace equal to the icon's radius on
+every side. Never render the lockup narrower than 120px, or the icon alone below
+16px. Don't recolor the mark, stretch or skew the lockup, add shadows or
+outlines, or place it on busy imagery.
 
-## Color palette
+## Color
 
-Academic and quiet, with one warm accent for *insight*.
+| Name | Hex | Usage |
+|---|---|---|
+| Indigo | `#241852` | Primary — headers, dark surfaces, wordmark text on white |
+| Coral | `#ff6558` | Accent — the mark, CTAs, confirmations. Never for large fills |
+| White | `#ffffff` | Base for docs, README body, light surfaces |
+| Ink | `#3a3350` | Body text on white |
+| Muted | `#8b7fae` | Captions, secondary labels |
 
-| Role | Name | Hex | Use |
-|---|---|---|---|
-| Primary text / dark | Ink | `#16181D` | body text, dark UI |
-| Brand | Indigo | `#4338CA` | logo brackets, links, primary accents |
-| Accent | Amber | `#F59E0B` | the "insight"/through-line, highlights (sparingly) |
-| Positive | Honest-Scholar Green | `#059669` | **"refuted = done"** states, passed checks |
-| Secondary text | Slate | `#4B5563` | captions, metadata |
-| Light background | Parchment | `#FAF7F0` | page background, cards |
-
-Note the deliberate choice to give **refuted/negative-result** states a *positive*
-green — reinforcing the principle that a refuted hypothesis is successful science
-(anti-Goodhart, ADR-0014).
+Coral is deliberately reserved for **confirmation** — the checkmark, the signed
+sign-off, the "verified" — reinforcing the principle that a decision is real only
+once a human signs it (agency; ADR-0016). It is an accent, never a fill: one
+coral moment per view.
 
 ## Typography
 
-- **Display / headings:** a scholarly serif — **Source Serif 4** (or Charter /
-  Lora). Evokes the paper.
-- **Body / UI:** a humanist sans — **Inter** (or IBM Plex Sans).
-- **Code / skill names / registries:** **JetBrains Mono** (or IBM Plex Mono).
+- **Display — Space Grotesk** (500–700): headlines, wordmark, section labels.
+- **Body — Source Sans 3** (400–700): docs, README prose, UI copy.
+- **Mono — JetBrains Mono**: code, CLI commands, badges, skill names, run-refs —
+  the machine parts.
 
-Pairing rationale: serif headings signal *scholarship*; sans body keeps docs
-readable; mono marks the *machine* parts (skills, YAML, run-refs).
+## Applications
 
-## Voice & tone
+- **README header** — the banner ([`assets/wordmark-banner.svg`](../../assets/wordmark-banner.svg)),
+  centred at ~640px.
+- **Docs site** — `docs.json` uses the indigo primary, the light-surface lockup
+  in light mode and the dark-surface lockup in dark mode, and the icon mark as
+  the favicon. The build tool ([`tools/build_docs_site.py`](../../tools/build_docs_site.py))
+  copies these assets into the generated site.
+- **Badges** — flat-square style, `labelColor=241852` (indigo). Status/metric
+  badges (CI, coverage) keep their signal color; static badges use `color=ff6558`
+  (coral). See the shields.io URLs in the root [`README.md`](../../README.md).
+- **Social preview** — [`assets/social-preview.svg`](../../assets/social-preview.svg)
+  (1280×640), the GitHub repo social image / OG card.
 
-Mentor-and-colleague: rigorous but supportive; asks more than it asserts; never
-grandiose. Directly reflects the mentor personas (ADR-0016) and the two
-principles — it advises and examines, but *you* decide and *you* author.
+## Voice
 
-- **Primary tagline:** *Research you can defend.*
-- **Secondary lines:** *You drive.* · *Understand your work.*
-
-## Usage notes
-
-- Prefer the wordmark alone in docs; use the mark for favicon/social/avatar.
-- Amber is an accent, not a fill — one highlight per view.
-- Keep whitespace generous; the identity is calm, not busy.
-- On dark backgrounds, Parchment text on Ink; Indigo lightens to `#818CF8`.
-
-## Assets
-
-- `assets/wordmark.svg` — the lowercase serif wordmark with bracket motif.
-- `assets/logo-concept.svg` — the citation & through-line mark.
-
-*(These are v1 concepts to react to; a browser-companion pass can iterate on real
-mockups, favicons, and social cards.)*
+Rigorous, plain, anti-hype. Say what the tool does, not how exciting it is.
+Quietly confident: no exclamation points, no "revolutionize," no unearned
+superlatives. Precise verbs over adjectives — "traces," "retires," "verifies,"
+not "seamlessly" or "powerful." This is the mentor-and-colleague register: it
+advises and examines, but *you* decide and *you* author.

--- a/tools/build_docs_site.py
+++ b/tools/build_docs_site.py
@@ -14,7 +14,8 @@ Mintlify site into an output directory:
   so it never drifts from the released CLI),
 * the design record — specs, proposals, the ADR log, reference digests, disclosure,
 * a ``docs.json`` with grouped navigation, brand colours, logo and social links,
-* the ``wordmark.svg`` asset.
+* the brand assets (the icon mark, the light/dark wordmark lockups, the social
+  preview) copied verbatim into the site root.
 
 Intra-repo relative markdown links are rewritten to site routes; links that point
 at repo files *not* in the site become absolute ``github.com`` URLs. A link that
@@ -55,10 +56,19 @@ SITE_DESCRIPTION = (
     "Research you can defend — keep your research honest, "
     "especially now that AI is in the loop."
 )
-PRIMARY = "#4338CA"
-COLOR_LIGHT = "#818CF8"
-COLOR_DARK = "#3730A3"
-WORDMARK = "wordmark.svg"
+# Brand palette (see assets/visual-identity.md): indigo primary, with a lighter
+# indigo for dark-mode chrome and a deeper indigo for light-mode hovers.
+PRIMARY = "#241852"
+COLOR_LIGHT = "#4a3a8f"
+COLOR_DARK = "#160f33"
+
+# Brand assets copied verbatim into the site root and referenced by absolute path.
+FAVICON = "icon-mark.svg"
+LOGO_LIGHT = "wordmark-lockup-light.svg"  # indigo lockup — for light surfaces
+LOGO_DARK = "wordmark-lockup-dark.svg"  # white/coral lockup — for dark surfaces
+SOCIAL_PREVIEW = "social-preview.svg"
+SITE_ASSETS = (FAVICON, LOGO_LIGHT, LOGO_DARK, SOCIAL_PREVIEW)
+ASSET_ROUTES = frozenset(f"/{name}" for name in SITE_ASSETS)
 
 # Directory links that have no page of their own map to a representative route.
 DIR_ALIASES = {
@@ -66,9 +76,7 @@ DIR_ALIASES = {
     "docs/design": "design/00-meta-spec",
 }
 # Asset links rewritten to the copied site asset.
-ASSET_ALIASES = {
-    "assets/wordmark.svg": f"/{WORDMARK}",
-}
+ASSET_ALIASES = {f"assets/{name}": f"/{name}" for name in SITE_ASSETS}
 
 
 class BuildError(Exception):
@@ -218,6 +226,19 @@ def extract_title(body: str, fallback: str) -> str:
 def strip_leading_h1(body: str) -> str:
     """Remove the first top-level ``# H1`` line (Mintlify renders the title)."""
     return re.sub(r"^\s*#\s+.+?(\n+)", "", body, count=1)
+
+
+_MASTHEAD_RE = re.compile(r'\A\s*<p align="center">.*?</p>\s*', re.S)
+
+
+def strip_leading_masthead(body: str) -> str:
+    """Drop a leading centred ``<p align="center">…</p>`` banner block.
+
+    Both ``README.md`` and ``docs/USER-GUIDE.md`` open with a raw-HTML wordmark
+    masthead for GitHub. The site has its own logo/chrome, and MDX would escape
+    that raw ``<img>`` block into literal text — so it is trimmed here.
+    """
+    return _MASTHEAD_RE.sub("", body, count=1)
 
 
 def first_paragraph_description(body: str) -> str | None:
@@ -450,8 +471,9 @@ def rewrite_links(
         if error:
             errors.append(error)
             return match.group(0)
-        if new_target.startswith("/") and not new_target.startswith(f"/{WORDMARK}"):
-            site_links.add(new_target.split("#", 1)[0])
+        stem = new_target.split("#", 1)[0]
+        if new_target.startswith("/") and stem not in ASSET_ROUTES:
+            site_links.add(stem)
         return f"{bang}[{textseg}]({new_target}{title or ''})"
 
     return _LINK_RE.sub(repl, body)
@@ -599,6 +621,10 @@ def build_page(
         description = truncate(skill_desc or title, 200)
         body = strip_leading_h1(body)
     else:
+        # docs/USER-GUIDE.md opens with the same centred wordmark masthead as the
+        # README; strip it before deriving the title/description (the site has its
+        # own chrome, and the raw <img> block is not valid MDX).
+        body = strip_leading_masthead(body)
         fallback = Path(source).stem
         title = extract_title(body, fallback)
         description = first_paragraph_description(strip_leading_h1(body)) or title
@@ -616,8 +642,9 @@ def build_docs_json(navigation: dict[str, object]) -> dict[str, object]:
         "name": SITE_NAME,
         "description": SITE_DESCRIPTION,
         "colors": {"primary": PRIMARY, "light": COLOR_LIGHT, "dark": COLOR_DARK},
-        "favicon": f"/{WORDMARK}",
-        "logo": {"light": f"/{WORDMARK}", "dark": f"/{WORDMARK}"},
+        "favicon": f"/{FAVICON}",
+        "logo": {"light": f"/{LOGO_LIGHT}", "dark": f"/{LOGO_DARK}"},
+        "seo": {"metatags": {"og:image": f"/{SOCIAL_PREVIEW}"}},
         "navigation": navigation,
         "navbar": {"links": [{"label": "GitHub", "href": GH_REPO}]},
         "footer": {"socials": {"github": GH_REPO}},
@@ -662,11 +689,12 @@ def build(out: Path) -> dict[str, int]:
         if link.lstrip("/") not in routes:
             errors.append(f"intra-site link {link!r} resolves to no page")
 
-    # Copy assets.
-    wordmark_src = REPO_ROOT / "assets" / WORDMARK
-    if not wordmark_src.is_file():
-        raise BuildError(f"missing asset {wordmark_src}")
-    shutil.copy2(wordmark_src, out / WORDMARK)
+    # Copy the brand assets into the site root (favicon, logo lockups, social).
+    for name in SITE_ASSETS:
+        asset_src = REPO_ROOT / "assets" / name
+        if not asset_src.is_file():
+            raise BuildError(f"missing asset {asset_src}")
+        shutil.copy2(asset_src, out / name)
 
     # Emit and re-parse docs.json to guarantee validity.
     docs_json = build_docs_json(navigation)
@@ -705,7 +733,7 @@ def main(argv: list[str] | None = None) -> int:
     print(
         f"  {stats['pages']} pages across {stats['groups']} top-level nav groups; "
         f"{stats['site_links']} intra-site links verified; docs.json valid; "
-        f"{WORDMARK} copied."
+        f"{len(SITE_ASSETS)} brand assets copied."
     )
     return 0
 


### PR DESCRIPTION
## What

Integrates the new visual identity from #54 across the docs and **fixes the
`docs-publish` build**, which broke when #54 deleted `assets/wordmark.svg`
(the builder + README still referenced it → `missing asset .../wordmark.svg`).

## Details

- **`README.md`** — header uses `assets/wordmark-banner.svg` (centred, 640px).
  CI + coverage badges restyled to flat-square with `labelColor=241852`
  (indigo) via shields.io; message color left as the pass/fail + coverage
  signal (not forced to coral, per the "don't force it where it can't" rule).
- **`docs/USER-GUIDE.md`** — adds the centred `wordmark-banner` masthead
  (`../assets/…`), GitHub-renderable HTML.
- **`tools/build_docs_site.py`** (the fix) — copies the new assets
  (`icon-mark`, both lockups, `social-preview`) into the site root; `docs.json`
  now sets `logo = {light: /wordmark-lockup-light.svg, dark:
  /wordmark-lockup-dark.svg}`, `favicon = /icon-mark.svg`, `colors.primary =
  #241852` (+ indigo light/dark shades), and `seo.metatags.og:image =
  /social-preview.svg`. The leading-masthead strip is extended to USER-GUIDE so
  the raw `<img>` banner isn't escaped into literal text / broken MDX.
- **Identity-doc reconcile** — the stale `docs/design/visual-identity.md` (old
  `#4338CA`/amber) is rewritten to the new indigo/coral brand and points at the
  canonical `assets/visual-identity.md`; that file's broken `../../assets/`
  image paths (it lives *in* `assets/`) are fixed to siblings.
- **`DISCLOSURE.md`** — the static AI-use badge recolored to brand
  (coral/indigo, flat-square).
- **`docs-publish.yml`** — path trigger broadened from the deleted
  `assets/wordmark.svg` to `assets/**`.

Verified with a real local Mintlify compile: `mint validate` + `mint
broken-links` both pass on the generated site (67 pages, zero MDX errors, zero
broken internal links). `pre-commit run --all-files` and the 100% `pytest`
coverage gate are green.

Refs #54, #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
