### PR TITLE
docs(build): adopt "Honest Scholar" brand, hero, nav logos, coral accent

### DIFF
--- a/DISCLOSURE.md
+++ b/DISCLOSURE.md
@@ -1,4 +1,4 @@
-# Disclosing AI use — and citing honest-scholar
+# Disclosing AI use — and citing Honest Scholar
 
 `honest-scholar` helps you use AI in research **honestly**: you (not the AI) make
 and sign off every material decision, you can defend the work, and evidence is
@@ -6,13 +6,13 @@ provenance-tracked. This page is how you *tell your readers that* — a short,
 truthful **AI-use disclosure** you can put in a paper, plus how to **cite** the
 tool.
 
-This is also, deliberately, how honest-scholar spreads: a disclosure that helps
+This is also, deliberately, how Honest Scholar spreads: a disclosure that helps
 you (venues increasingly require an AI-use statement) and, because it names the
 protocol you followed, points other researchers to it. See ADR-0025.
 
 ## What it is *not*
 
-- **Not a seal of honesty.** honest-scholar does not certify that your research is
+- **Not a seal of honesty.** Honest Scholar does not certify that your research is
   honest — it gives you a *structured, truthful way to disclose* what you and the
   AI each did, backed by your own recorded sign-offs. Readers judge; the statement
   just tells them what happened and links the record.
@@ -28,7 +28,7 @@ which `run-ref`s back which results, what the AI drafted) — so it is evidence-
 not boilerplate. Edit freely.
 
 > **Use of AI.** This work was conducted with AI assistance under the
-> *honest-scholar* protocol (github.com/davorrunje/honest-scholar). Every material
+> *Honest Scholar* protocol (github.com/davorrunje/honest-scholar). Every material
 > scientific decision — the hypotheses, whether results are real, what to publish,
 > and all claims — was made and signed off by the named authors, who understand and
 > can defend the work. AI tools were used for [literature search, bookkeeping and
@@ -38,7 +38,7 @@ not boilerplate. Edit freely.
 Keep it truthful: only claim what the record shows, and cut any line that isn't
 true of your project.
 
-## Citing honest-scholar
+## Citing Honest Scholar
 
 For now, cite the repository (a `CITATION.cff` is included, so GitHub's *"Cite this
 repository"* works):
@@ -52,7 +52,7 @@ repository"* works):
 }
 ```
 
-> **Transition:** a short report on honest-scholar will be posted to **arXiv** and
+> **Transition:** a short report on Honest Scholar will be posted to **arXiv** and
 > then submitted to a venue. When the preprint exists, `CITATION.cff`'s
 > `preferred-citation` will point at it, and this BibTeX will be replaced by the
 > arXiv (then published) reference. (Tracking: the "arXiv report" issue.)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/wordmark-banner.svg" alt="honest-scholar" width="640">
+  <img src="assets/wordmark-banner.svg" alt="Honest Scholar" width="640">
 </p>
 
 <p align="center"><em>Research you can defend.</em></p>
@@ -104,7 +104,7 @@ drafted from your provenance record — who signed off what, which run-refs back
 which results. It is opt-in and author-owned: you review, edit, adopt, or decline.
 
 The growth angle, plainly: every published paper that carries the disclosure points
-other researchers to the tool. But honest-scholar only *supports* honest disclosure
+other researchers to the tool. But Honest Scholar only *supports* honest disclosure
 — it does **not** certify that your research is honest, and there is no seal of
 honesty. The statement says what was done and links the record; readers judge.
 

--- a/assets/docs-hero.svg
+++ b/assets/docs-hero.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="420" viewBox="0 0 1600 420">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1c1240"></stop>
+      <stop offset="100%" stop-color="#33217a"></stop>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="420" fill="url(#bg)"></rect>
+  <circle cx="1360" cy="80" r="180" fill="none" stroke="#ffffff" stroke-opacity="0.06" stroke-width="2"></circle>
+  <circle cx="180" cy="360" r="130" fill="none" stroke="#ffffff" stroke-opacity="0.06" stroke-width="2"></circle>
+  <circle cx="800" cy="150" r="72" fill="#ff6558"></circle>
+  <path d="M764 154 L792 184 L840 122" fill="none" stroke="#ffffff" stroke-width="16" stroke-linecap="round" stroke-linejoin="round"></path>
+  <text x="800" y="290" font-family="Arial, Helvetica, sans-serif" font-weight="700" font-size="80" fill="#ffffff" text-anchor="middle" letter-spacing="-1">Honest Scholar</text>
+  <text x="800" y="340" font-family="Arial, Helvetica, sans-serif" font-weight="600" font-size="32" fill="#ff9b8f" text-anchor="middle">Research you can defend.</text>
+</svg>

--- a/assets/nav-logo-dark.svg
+++ b/assets/nav-logo-dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="340" height="56" viewBox="0 0 340 56">
+  <circle cx="28" cy="28" r="26" fill="#ff6558"></circle>
+  <path d="M16 29 L24 37 L41 18" fill="none" stroke="#ffffff" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"></path>
+  <text x="66" y="37" font-family="Arial, Helvetica, sans-serif" font-weight="700" font-size="30" fill="#ffffff" letter-spacing="-0.5">Honest Scholar</text>
+</svg>

--- a/assets/nav-logo-light.svg
+++ b/assets/nav-logo-light.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="340" height="56" viewBox="0 0 340 56">
+  <circle cx="28" cy="28" r="26" fill="#ff6558"></circle>
+  <path d="M16 29 L24 37 L41 18" fill="none" stroke="#ffffff" stroke-width="5.5" stroke-linecap="round" stroke-linejoin="round"></path>
+  <text x="66" y="37" font-family="Arial, Helvetica, sans-serif" font-weight="700" font-size="30" fill="#241852" letter-spacing="-0.5">Honest Scholar</text>
+</svg>

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="../assets/wordmark-banner.svg" alt="honest-scholar" width="640">
+  <img src="../assets/wordmark-banner.svg" alt="Honest Scholar" width="640">
 </p>
 
 <!-- honest-scholar user guide -->
 
-# honest-scholar — User Guide
+# Honest Scholar — User Guide
 
 A hands-on guide for a researcher meeting `honest-scholar` for the first time. It walks
 you from install to a signed finding to a submitted paper, using one running
@@ -14,7 +14,7 @@ you fill in.
 For the *why* behind the design, read [`README.md`](../README.md) and the specs
 under [`docs/design/`](design/); this guide is the *how*.
 
-## 1. What honest-scholar is (and the two rules it runs on)
+## 1. What Honest Scholar is (and the two rules it runs on)
 
 `honest-scholar` helps you keep research honest — **especially now that AI is in the
 loop**. It is a Claude Code plugin for the **scientific** side of research — idea →
@@ -23,7 +23,7 @@ delegates the *engineering* (design, plans, code) to the bound **engineering
 backend** via the engineering-delegation contract; `honest-scholar` calls out to that
 backend for all of that rather than reimplementing it.
 
-To be clear up front: honest-scholar does **not** certify that your work is honest —
+To be clear up front: Honest Scholar does **not** certify that your work is honest —
 there is no seal of honesty. It gives you the *mechanics* to do honest work and to
 disclose truthfully what you and the AI each did; readers judge the result.
 
@@ -35,7 +35,7 @@ They are not decoration — they change how the skills behave at every step:
    you: whether a hypothesis is confirmed or refuted, whether a result is real,
    whether a paper is worth publishing, whether a thesis is defensible. Each of
    those is recorded in the artifact with a **named human sign-off + date**. You
-   cannot "run" honest-scholar to produce a paper — you drive it. In practice: expect the
+   cannot "run" Honest Scholar to produce a paper — you drive it. In practice: expect the
    skill to stop at every judgement point and ask you. *So the science is honestly
    yours.*
 
@@ -175,7 +175,7 @@ documents, in order, under `docs/research/<paper>/hypotheses/<slug>/`:
    the datasets it needs. **`defend` fires here** on the strategy — expect to
    defend your assumptions and falsifiers before moving on.
 3. **`design.md` / `plan.md`** — *the engineering, delegated to the bound
-   engineering backend* (its `design` → `plan` capabilities). honest-scholar stores the
+   engineering backend* (its `design` → `plan` capabilities). Honest Scholar stores the
    results here but does not design experiments or write code itself. Executing
    the plan produces the runs.
 4. **`findings.md`** — *the verdict:* `confirmed | refuted | inconclusive`, tied
@@ -216,7 +216,7 @@ claim is false is successful science.
 
 ### 4d. How runs become evidence — the experiment-backend contract
 
-honest-scholar defines a **contract**; your repo supplies the implementation (bound in
+Honest Scholar defines a **contract**; your repo supplies the implementation (bound in
 `.honest-scholar/config.yml`, named per paper in `papers.md`). The contract has four
 capabilities:
 
@@ -272,7 +272,7 @@ which decisions, which run-refs back which results) — so it is evidence-based,
 boilerplate. It is opt-in and author-owned: you review, edit, adopt, or decline.
 
 Plainly: every published paper that carries the disclosure points other researchers
-to the tool. But honest-scholar only *supports* honest disclosure — it does **not**
+to the tool. But Honest Scholar only *supports* honest disclosure — it does **not**
 certify that your research is honest, and there is no seal of honesty. The statement
 says what was done and links the record; readers judge.
 
@@ -334,7 +334,7 @@ the throttling that otherwise stalls citation-graph work.
 | `OPENALEX_MAILTO` | OpenAlex | Joins the "polite pool" (a contact email) for faster, more reliable responses. | <https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication> |
 | `RCLONE_CONFIG_<REMOTE>_*` | Private dataset mirror | rclone remote credentials, handed to rclone as scoped env vars (no config file needed). | Per your rclone remote (see `rclone config`). |
 
-honest-scholar keeps keys in a **CLI-managed JSON store** at
+Honest Scholar keeps keys in a **CLI-managed JSON store** at
 `.honest-scholar/keys.json` — never a `.env` — and reads them with
 **`os.environ` > store > unset** precedence, so an environment variable always
 wins (CI / secrets injection is unaffected) and an unset key just degrades the
@@ -363,15 +363,15 @@ value.
 
 ## 9. Everyday tips
 
-- **What honest-scholar will NOT do.** It will not make a material decision for you
+- **What Honest Scholar will NOT do.** It will not make a material decision for you
   (confirm/refute, publish/no-go, defensible), will not write your paper
   unattended, will not hand-copy result numbers, and will not produce a
   productivity score. Every judgement point stops and asks.
 - **Trust the firewall.** If a skill refuses to test a claim it also generated, or
   refuses to adjudicate its own decision, that is by design — use the paired
   skill.
-- **Commits are attributed.** Commits made via honest-scholar skills carry a discovery
-  trailer, so provenance of an automated change is visible in `git log`. honest-scholar
+- **Commits are attributed.** Commits made via Honest Scholar skills carry a discovery
+  trailer, so provenance of an automated change is visible in `git log`. Honest Scholar
   never auto-commits `research-init` scaffolding — you review and commit.
 - **Evidence is run-refs, not numbers.** If a number can't be traced to a run-ref,
   it doesn't go in a findings doc or a paper section.
@@ -388,5 +388,5 @@ value.
 **The shortest possible path:** `research-init` → `hypothesis-exploration
 promote` → `hypothesis-testing` (strategy, examined → delegate design/plan →
 sign findings) → `paper-exploration promote` → `paper-synthesis` (positioning →
-sign decision → sections) → `progress dashboard`. You drive every arrow; honest-scholar
+sign decision → sections) → `progress dashboard`. You drive every arrow; Honest Scholar
 keeps the accounts and makes sure you can defend each signature.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -4,7 +4,7 @@
 
 <!-- honest-scholar user guide -->
 
-# Honest Scholar — User Guide
+# User Guide
 
 A hands-on guide for a researcher meeting `honest-scholar` for the first time. It walks
 you from install to a signed finding to a submitted paper, using one running

--- a/honest-scholar/README.md
+++ b/honest-scholar/README.md
@@ -1,8 +1,8 @@
-# honest-scholar
+# Honest Scholar
 
 *Research you can defend.*
 
-**honest-scholar** helps you keep research honest — especially now that AI is in
+**Honest Scholar** helps you keep research honest — especially now that AI is in
 the loop. You (not the AI) make and sign off every material decision, and you must
 be able to explain and defend the work; the tool keeps the accounts, advises, and
 probes. It **supports** honest, disclosable AI-assisted research — it does **not**
@@ -79,7 +79,7 @@ presence only.
 
 - **Plugin, docs, and full design record:** <https://github.com/davorrunje/honest-scholar>
 - **User guide:** <https://github.com/davorrunje/honest-scholar/blob/main/docs/USER-GUIDE.md>
-- **Disclose your AI use & cite honest-scholar:** <https://github.com/davorrunje/honest-scholar/blob/main/DISCLOSURE.md>
+- **Disclose your AI use & cite Honest Scholar:** <https://github.com/davorrunje/honest-scholar/blob/main/DISCLOSURE.md>
 
 ## Status
 

--- a/tools/build_docs_site.py
+++ b/tools/build_docs_site.py
@@ -14,8 +14,9 @@ Mintlify site into an output directory:
   so it never drifts from the released CLI),
 * the design record — specs, proposals, the ADR log, reference digests, disclosure,
 * a ``docs.json`` with grouped navigation, brand colours, logo and social links,
-* the brand assets (the icon mark, the light/dark wordmark lockups, the social
-  preview) copied verbatim into the site root.
+* the brand assets (the icon mark, the light/dark navigation logos, the home-page
+  hero, the social preview, and the wordmark lockups still embedded by the
+  visual-identity page) copied verbatim into the site root.
 
 Intra-repo relative markdown links are rewritten to site routes; links that point
 at repo files *not* in the site become absolute ``github.com`` URLs. A link that
@@ -51,23 +52,41 @@ GH_REPO = "https://github.com/davorrunje/honest-scholar"
 GH_BLOB = f"{GH_REPO}/blob/main/"
 GH_TREE = f"{GH_REPO}/tree/main/"
 
-SITE_NAME = "honest-scholar"
+SITE_NAME = "Honest Scholar"
 SITE_DESCRIPTION = (
     "Research you can defend — keep your research honest, "
     "especially now that AI is in the loop."
 )
-# Brand palette (see assets/visual-identity.md): indigo primary, with a lighter
-# indigo for dark-mode chrome and a deeper indigo for light-mode hovers.
-PRIMARY = "#241852"
-COLOR_LIGHT = "#4a3a8f"
-COLOR_DARK = "#160f33"
+# Brand palette (see assets/visual-identity.md). Indigo (#241852) is the *ground*
+# — carried by the nav logos, dark surfaces, and the assets — so it stays out of
+# `colors`. Mintlify's `colors.primary` drives links/buttons/active states, so the
+# interactive accent is the brand coral: "a single coral accent carries every call
+# to action". `light` is a brighter coral for dark-mode chrome; `dark` (which
+# Mintlify uses as the primary in light mode) is a deeper coral that clears WCAG AA
+# (~4.9:1) for link text on white.
+PRIMARY = "#ff6558"
+COLOR_LIGHT = "#ff8a7d"
+COLOR_DARK = "#c9402e"
 
 # Brand assets copied verbatim into the site root and referenced by absolute path.
 FAVICON = "icon-mark.svg"
-LOGO_LIGHT = "wordmark-lockup-light.svg"  # indigo lockup — for light surfaces
-LOGO_DARK = "wordmark-lockup-dark.svg"  # white/coral lockup — for dark surfaces
+NAV_LOGO_LIGHT = "nav-logo-light.svg"  # navigation logo — light mode
+NAV_LOGO_DARK = "nav-logo-dark.svg"  # navigation logo — dark mode
+HERO = "docs-hero.svg"  # full-width home-page hero banner
 SOCIAL_PREVIEW = "social-preview.svg"
-SITE_ASSETS = (FAVICON, LOGO_LIGHT, LOGO_DARK, SOCIAL_PREVIEW)
+# The wordmark lockups are still embedded by the visual-identity design page, so
+# they are copied into the site even though the nav now uses the dedicated logos.
+WORDMARK_LIGHT = "wordmark-lockup-light.svg"
+WORDMARK_DARK = "wordmark-lockup-dark.svg"
+SITE_ASSETS = (
+    FAVICON,
+    NAV_LOGO_LIGHT,
+    NAV_LOGO_DARK,
+    HERO,
+    SOCIAL_PREVIEW,
+    WORDMARK_LIGHT,
+    WORDMARK_DARK,
+)
 ASSET_ROUTES = frozenset(f"/{name}" for name in SITE_ASSETS)
 
 # Directory links that have no page of their own map to a representative route.
@@ -616,6 +635,10 @@ def build_page(
         if "---" in lines:
             body = "\n".join(lines[lines.index("---") + 1 :])
         title, description = SITE_NAME, SITE_DESCRIPTION
+        # Full-width home-page hero above the intro text. A Markdown image is the
+        # MDX-safe construct here (no raw JSX for the sanitizer to mangle); the
+        # target is a copied site asset, so rewrite_links leaves it untouched.
+        body = f"![{SITE_NAME}](/{HERO})\n\n{body.lstrip()}"
     elif skill_name:  # a SKILL.md
         title = skill_name
         description = truncate(skill_desc or title, 200)
@@ -643,7 +666,7 @@ def build_docs_json(navigation: dict[str, object]) -> dict[str, object]:
         "description": SITE_DESCRIPTION,
         "colors": {"primary": PRIMARY, "light": COLOR_LIGHT, "dark": COLOR_DARK},
         "favicon": f"/{FAVICON}",
-        "logo": {"light": f"/{LOGO_LIGHT}", "dark": f"/{LOGO_DARK}"},
+        "logo": {"light": f"/{NAV_LOGO_LIGHT}", "dark": f"/{NAV_LOGO_DARK}"},
         "seo": {"metatags": {"og:image": f"/{SOCIAL_PREVIEW}"}},
         "navigation": navigation,
         "navbar": {"links": [{"label": "GitHub", "href": GH_REPO}]},


### PR DESCRIPTION
## What

Visual polish for the docs portal and the communication surfaces: adopt the
**Honest Scholar** product name in prose/titles, add a home-page hero, switch
the nav to the new light/dark logos, and make **coral the interactive accent**
(links/buttons/active states) so the site is no longer monochromatic indigo.

## Details

**Naming — "Honest Scholar" in communication (code slugs kept).** Judgment-based,
per occurrence:

- Changed to `Honest Scholar` (title case, plain text) — the brand in running
  prose, headings, taglines, and generated titles. Examples:
  - `honest-scholar/README.md`: `# honest-scholar` → `# Honest Scholar`;
    `**honest-scholar** helps you…` → `**Honest Scholar** helps you…`
  - `docs/USER-GUIDE.md`: `# honest-scholar — User Guide` →
    `# Honest Scholar — User Guide` (drives the generated page title); and
    bare-prose lines like `honest-scholar defines a contract` → `Honest Scholar
    defines a contract`.
  - `DISCLOSURE.md`: `## Citing honest-scholar` → `## Citing Honest Scholar`;
    the disclosure-template `*honest-scholar* protocol` → `*Honest Scholar*
    protocol`.
  - `README.md`: `But honest-scholar only supports…` → `But Honest Scholar only
    supports…`; masthead `alt` text.
  - Builder: `docs.json` `name` and the generated `index` page title →
    `Honest Scholar` (both driven by `SITE_NAME`).
- **Deliberately kept verbatim as `honest-scholar`** (literal identifiers):
  the PyPI/package name and install commands (`pip install honest-scholar`,
  `uv tool install honest-scholar`), the CLI command + subcommands, the
  plugin/marketplace id (`honest-scholar@honest-scholar`), all github URLs, the
  `.honest-scholar/` config dir, the `honest_scholar` module, the BibTeX
  `honest_scholar` key, and everything inside code fences / inline code. Every
  occurrence in the `skills/*/SKILL.md` **bodies** turned out to be a code-font
  identifier, path, CLI command, or the literal `Generated-with:` trailer — so
  no skill body changed, and no skill frontmatter was touched.
- **Not in scope (later follow-up):** the design record —
  `docs/design/`, `decisions/`, `resources/` — left as-is.

**Hero.** The generated `index` page now opens with a full-width Markdown image
above the intro text: `![Honest Scholar](/docs-hero.svg)`. Markdown image (not
raw JSX) so the MDX sanitizer leaves it intact; the target is a copied site
asset, so the link rewriter treats it as an asset route.

**Nav logos.** `docs.json` `logo` = `{ "light": "/nav-logo-light.svg", "dark":
"/nav-logo-dark.svg" }` (340×56). The wordmark lockups are still copied into the
site because the visual-identity design page embeds them. Favicon unchanged
(`/icon-mark.svg`).

**Coral accent.** Indigo (`#241852`) stays the ground (nav logos, dark
surfaces, assets) and is out of `colors`. `colors.primary` = `#ff6558`;
`colors.light` = `#ff8a7d` (brighter coral for dark-mode chrome, ~8:1 on the
dark surfaces); `colors.dark` = `#c9402e` (Mintlify uses this as the primary in
light mode — coral link text at ~4.9:1 on white, clears WCAG AA).

**Gates.** Real local `mint validate` + `mint broken-links` both pass on the
67-page generated site; `pre-commit run --all-files` all-green; `honest-scholar`
`pytest` holds 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
