### PR TITLE
release: honest-scholar v0.1.0 (first final)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "honest-scholar",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "The scientist's research-workflow plugin for Claude Code — from hypothesis to thesis. Assistants, not researchers: you drive, and you must be able to defend it.",
   "author": {
     "name": "Davor Runje"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-07-19
+
+First public release — a Claude Code plugin for the scientific research workflow,
+plus the `honest-scholar` CLI it calls. The two artifacts are versioned
+independently (ADR-0026); this is `0.1.0` for both.
+
 ### Added
 
-- Engineering scaffold for the `honest-scholar` Python package (`honest-scholar/`
-  subdirectory): hatchling build, `honest-scholar` Typer CLI with an implemented
-  `doctor` command and typed stub sub-commands (`literature`, `dataset`,
-  `defend`, `backlog`), a typed `core.config` loader, module stubs, and tests.
-- Repo-root hygiene: `.pre-commit-config.yaml` (pre-commit-hooks, pyupgrade,
-  codespell, detect-secrets, plus local `lint`/`typecheck`/`plugin-validate`
-  hooks), `tools/*.sh`, `.codespell-whitelist.txt`, `.secrets.baseline`, and a
-  GitHub Actions CI workflow (`pre-commit`, `test` matrix on 3.11–3.14,
-  `plugin-validate`, alls-green `check` gate).
+- **Plugin — 10 skills** across the nested generate/resolve lifecycle:
+  `hypothesis-exploration` / `hypothesis-testing`, `paper-exploration` /
+  `paper-synthesis`, `thesis`, the shared `literature` and `dataset` capabilities,
+  cross-cutting `progress` and `defend`, and `research-init` onboarding — behind
+  the exploration→resolution firewall and the agency + understanding principles.
+  Distributed via the repo's git self-marketplace.
+- **`honest-scholar` package** (PyPI, installed isolated) — a Typer CLI with fully
+  implemented groups: `literature` (OpenAlex + Semantic Scholar citation graph),
+  `dataset` (manifest / Croissant / SHA-256 retrieval / rclone mirror / audit),
+  `defend record`, `backlog`, `doctor`, `keys`, and `--version`. Strict mypy;
+  **100% statement + branch test coverage** gate.
+- Honest failure handling: rate-limit / transient errors are distinct from a
+  genuine not-found and never surface as tracebacks; unified, gitignored API-key
+  store (`keys`) with env-var precedence and least-privilege scoped env for child
+  processes.
+- **Rendered docs site** at [honest-scholar.science](https://honest-scholar.science)
+  (Mintlify) — generated from the repo's markdown on release (user guide, skills,
+  CLI reference, and the full design record), gated in CI by a real MDX compile +
+  build-time and post-publish broken-link checks.
+- **Design record**: the meta-spec + four sub-specs, 30 MADR ADRs, verified-source
+  reference digests, and the visual identity.
+- **Release & CI engineering**: independent plugin/package versioning with a
+  compatibility pin (ADR-0026), GitHub-Release-driven PyPI publishing via Trusted
+  Publishing / OIDC (ADR-0027), the 100% coverage gate (ADR-0028), a repo `CLAUDE.md`,
+  and local `create-issue` / `create-pr` skills.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,7 +16,7 @@ authors:
     email: davor@synthpop.ai
 repository-code: "https://github.com/davorrunje/honest-scholar"
 url: "https://github.com/davorrunje/honest-scholar"
-version: 0.0.0b0
+version: 0.1.0
 license: Apache-2.0
 keywords:
   - research integrity

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ consuming repo's `.claude/settings.json`:
 }
 ```
 
-By default this tracks the plugin's `main`. Once a plugin release is tagged you can
-pin it by adding a `"ref": "<tag>"` inside the marketplace `source` for a fixed
-version. See [`STATUS.md`](STATUS.md) for the current state.
+To pin a fixed release, add `"ref": "v0.1.0"` inside the marketplace `source`;
+omit it to track the plugin's `main`. See [`STATUS.md`](STATUS.md) for the current
+state.
 
 ## Design & reasoning
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -80,9 +80,9 @@ consuming repo's `.claude/settings.json`:
 }
 ```
 
-Commit that file and every collaborator gets the same skills auto-enabled. This
-tracks the plugin's `main`; once a plugin release is tagged you can pin it with a
-`"ref": "<tag>"` inside the marketplace `source` for a fixed version. Skills are
+Commit that file and every collaborator gets the same skills auto-enabled. To pin
+a fixed release, add `"ref": "v0.1.0"` inside the marketplace `source`; omit it to
+track the plugin's `main`. Skills are
 invoked by name (`research-init`, `hypothesis-testing`, …) in your Claude Code
 session.
 

--- a/honest-scholar/pyproject.toml
+++ b/honest-scholar/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "honest-scholar"
-version = "0.0.0b0"
+version = "0.1.0"
 description = "honest-scholar — a CLI for honest, defensible AI-assisted research (tooling for the honest-scholar plugin)"
 authors = [{ name = "Davor Runje", email = "davor@synthpop.ai" }]
 maintainers = [{ name = "Davor Runje", email = "davor@synthpop.ai" }]

--- a/resources/ensure-tooling.md
+++ b/resources/ensure-tooling.md
@@ -22,8 +22,9 @@ environment changes** (installing `uv`/Python is the user's call), **honest stop
    - else `python3` (with `venv` + `pip`).
 3. **Install, isolated** — **PyPI-first**. The primary source is the published
    package `honest-scholar` on PyPI, pinned to a **compatible range**
-   (`honest-scholar>=<min>,<<next>`, where `<min>` is the minimum package version
-   this plugin release requires — see the *Version pinning* note):
+   (`honest-scholar>=0.1.0,<0.2.0` — the minimum package version this plugin
+   release requires, up to the next incompatible boundary; see the *Version
+   pinning* note):
    - `uv tool install honest-scholar` — installs Python + deps in an isolated tool
      env; or run ad hoc with `uvx honest-scholar …` (no persistent install).
    - else `pipx install honest-scholar`.
@@ -58,11 +59,12 @@ environment changes** (installing `uv`/Python is the user's call), **honest stop
   anyone's torch/jax install.
 - **Idempotency:** step 1 must be cheap; only steps 2–3 touch the network.
 - **Version pinning:** the plugin and the `honest-scholar` package are versioned
-  **independently**. The plugin pins a *compatible range* (`>=<min>,<<next>`), not an
-  exact string-lock — `<min>` is the minimum package version the plugin's skills
-  need (declared by the plugin; bump it deliberately when a skill starts using a new
-  CLI capability), `<next>` the next incompatible boundary. The package's own
-  releases (PEP 440, `v*` tags → PyPI) proceed on their own cadence.
+  **independently** (ADR-0026). The plugin pins a *compatible range* (currently
+  `>=0.1.0,<0.2.0`), not an exact string-lock — the lower bound is the minimum
+  package version the plugin's skills need (bump it deliberately when a skill
+  starts using a new CLI capability), the upper bound the next incompatible
+  boundary. The package's own releases (PEP 440, `v*` tags → PyPI) proceed on
+  their own cadence.
 - **rclone** (the private-mirror engine) is a separate single static binary — **not
   a Python dependency**; `honest-scholar` shells out to it. It is **optional**: only
   private-mirror operations need it (Tier-A git/LFS and Tier-B `pooch` fetch do


### PR DESCRIPTION
## What

Version-finalization prep for the **first final release**. Feature work is complete (v0.1.0 milestone has no open issues), CI is green, and the docs site is live — this bumps the version files and finalizes the release-facing docs so you can cut the release.

Both artifacts → **0.1.0** (independent versioning, ADR-0026):
- `honest-scholar/pyproject.toml` `0.0.0b0` → `0.1.0`
- `.claude-plugin/plugin.json` `0.0.0` → `0.1.0`
- `CITATION.cff` `0.0.0b0` → `0.1.0`

Plus:
- **`resources/ensure-tooling.md`** — concretized the compat-pin placeholder (`>=<min>,<<next>`) → **`honest-scholar>=0.1.0,<0.2.0`**.
- **`CHANGELOG.md`** — rewrote the stale `[Unreleased]` (it still described "typed stub sub-commands") into an accurate **`[0.1.0]`** entry.
- **README / USER-GUIDE** — marketplace pin example → `ref: "v0.1.0"`.

Verified: `honest-scholar --version` → `0.1.0`; `pytest` 252 passed, **100% coverage**; ruff / mypy / codespell / detect-secrets / plugin-validate all green.

> `STATUS.md`'s "Released" line is **deliberately not** flipped here — it gets updated once the Release is actually cut, to avoid a premature release claim (the B2 lesson from #31).

## After merging — cutting the release
1. **TestPyPI dry-run**: Actions → *Publish* → run with `target: testpypi`; smoke-test `uv tool install --index-url .../test... --extra-index-url .../simple --prerelease=allow honest-scholar==0.1.0`.
2. **PyPI**: create a **GitHub Release `v0.1.0`** → `publish.yml` publishes (tag↔version guard checks the tag matches `pyproject`). The `v0.1.0` tag is also the plugin's marketplace pin.
3. I'll then flip `STATUS.md` to "Released v0.1.0" and verify the PyPI + plugin installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)