### PR TITLE
docs(pypi): homepage/docs → honest-scholar.science; sync 0.1.0 lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 <p align="center">
   <a href="https://github.com/davorrunje/honest-scholar/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/davorrunje/honest-scholar/ci.yml?branch=main&style=flat-square&labelColor=241852&label=CI" alt="CI"></a>
   <a href="https://codecov.io/gh/davorrunje/honest-scholar"><img src="https://img.shields.io/codecov/c/github/davorrunje/honest-scholar?style=flat-square&labelColor=241852&label=coverage" alt="coverage"></a>
+  <a href="https://honest-scholar.science/"><img src="https://img.shields.io/badge/docs-honest--scholar.science-241852?style=flat-square&labelColor=241852" alt="docs"></a>
 </p>
 
 ---
@@ -34,7 +35,7 @@ and never re-derive the workflow, or its rigor, per project. Concretely, it:
 Because AI is in the loop, it is also built so the science stays honestly *yours*
 and defensible (see [The mechanics of honesty](#the-mechanics-of-honesty)).
 
-> **New here?** Start with the **[User Guide](docs/USER-GUIDE.md)**.
+> **New here?** Read the docs at **[honest-scholar.science](https://honest-scholar.science/)** — start with the **[User Guide](docs/USER-GUIDE.md)**.
 >
 > **Status: pre-release, actively developed.** The design is complete and recorded
 > (see [Design & reasoning](#design--reasoning)); the skills and their supporting

--- a/honest-scholar/README.md
+++ b/honest-scholar/README.md
@@ -26,8 +26,7 @@ honest-scholar --version
 honest-scholar doctor              # reports python / uv / rclone
 ```
 
-Pre-releases are on TestPyPI (`--index-url https://test.pypi.org/simple/
---extra-index-url https://pypi.org/simple/`).
+**Documentation:** <https://honest-scholar.science/>
 
 ## CLI
 
@@ -77,14 +76,14 @@ presence only.
 
 ## Learn more
 
-- **Plugin, docs, and full design record:** <https://github.com/davorrunje/honest-scholar>
-- **User guide:** <https://github.com/davorrunje/honest-scholar/blob/main/docs/USER-GUIDE.md>
+- **Documentation:** <https://honest-scholar.science/>
+- **User guide:** <https://honest-scholar.science/get-started/user-guide>
+- **Plugin, source & full design record:** <https://github.com/davorrunje/honest-scholar>
 - **Disclose your AI use & cite Honest Scholar:** <https://github.com/davorrunje/honest-scholar/blob/main/DISCLOSURE.md>
 
-## Status
+## Changelog
 
-Early / pre-release — see
-<https://github.com/davorrunje/honest-scholar/blob/main/STATUS.md>.
+<https://github.com/davorrunje/honest-scholar/blob/main/CHANGELOG.md>
 
 ## License
 

--- a/honest-scholar/pyproject.toml
+++ b/honest-scholar/pyproject.toml
@@ -30,9 +30,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage   = "https://github.com/davorrunje/honest-scholar"
-Repository = "https://github.com/davorrunje/honest-scholar"
-Issues     = "https://github.com/davorrunje/honest-scholar/issues"
+Homepage      = "https://honest-scholar.science/"
+Documentation = "https://honest-scholar.science/"
+Repository    = "https://github.com/davorrunje/honest-scholar"
+Issues        = "https://github.com/davorrunje/honest-scholar/issues"
+Changelog     = "https://github.com/davorrunje/honest-scholar/blob/main/CHANGELOG.md"
 
 [project.scripts]
 honest-scholar = "honest_scholar.cli:app"

--- a/honest-scholar/uv.lock
+++ b/honest-scholar/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "honest-scholar"
-version = "0.0.0b0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "pooch" },


### PR DESCRIPTION
## What

Fixes surfaced from the **TestPyPI 0.1.0** page (thanks for the review):

1. **Homepage → the docs site.** `pyproject [project.urls] Homepage` now points at **https://honest-scholar.science/** (was the GitHub repo).
2. **Documentation link added.** New `Documentation = https://honest-scholar.science/` (+ a `Changelog` link) → they show in the PyPI sidebar, which previously had no docs link.
3. **Package README de-staled** (`honest-scholar/README.md`, the PyPI landing): "Learn more" now leads with the docs site + the live user-guide route; dropped the stale "Pre-releases on TestPyPI" line and the "Early / pre-release" Status section (replaced with a Changelog link).
4. **Root README** now mentions the docs: a docs badge + "New here? Read the docs at honest-scholar.science."
5. **`uv.lock` synced** — #59 bumped `pyproject` to 0.1.0 but left the lock at `0.0.0b0`; corrected.

On your two framing questions:
- *Why not the root README on PyPI?* PyPI shows the **package** README by design (the pip audience: install + CLI), while the root README is the plugin/repo landing (marketplace install, design record). Keeping them separate is intentional — so I de-staled the package one and added the docs links rather than swapping in the root README.

## Important: immutability
**TestPyPI 0.1.0 can't be re-uploaded** (PyPI versions are immutable), so these fixes **land in the real PyPI 0.1.0**, which isn't published yet. Merge this **before** cutting the `v0.1.0` GitHub Release so the real publish carries the corrected metadata. (If you want another TestPyPI dry-run of the fixed build, it'd need a throwaway version like `0.1.0.post1` — but these are metadata/README-only, low-risk.)

Verified: `pre-commit run --all-files` green; toml valid; the `/get-started/user-guide` route used in the README returns 200 live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)