### PR TITLE
docs(readme): describe the honest failure handling

### DIFF
--- a/honest-scholar/README.md
+++ b/honest-scholar/README.md
@@ -41,8 +41,13 @@ honest-scholar backlog    park|add|list|rank|promote|drop       # exploration ba
 honest-scholar keys       set|list|check|unset|path             # API-key & credential store
 ```
 
-Every command is implemented and emits JSON (the skills parse it). Network- and
-`rclone`-backed commands degrade gracefully when a key or the binary is absent.
+Every command is implemented and emits JSON (the skills parse it). **Failures are
+surfaced honestly:** a rate-limit or transient network error is retried with
+backoff (honoring `Retry-After`) and, if it persists, reported as a distinct,
+actionable message — never a silent "not found" and never a traceback. A missing
+API key or `rclone` binary is reported cleanly, and an optional key (e.g.
+`S2_API_KEY`) simply lifts the rate ceiling — see
+[API keys & credentials](#api-keys--credentials).
 
 ## API keys & credentials
 


### PR DESCRIPTION
## What

The PyPI landing README (`honest-scholar/README.md`) still said commands "degrade gracefully when a key or the binary is absent" — which undersells the system we actually built (#41 honest rate-limit handling, #43 failure-honesty audit). Replaced with an accurate description:

> Failures are surfaced honestly: a rate-limit or transient network error is retried (honoring `Retry-After`) and, if it persists, reported as a distinct, actionable message — never a silent "not found" and never a traceback. A missing API key or `rclone` binary is reported cleanly, and an optional key (e.g. `S2_API_KEY`) simply lifts the rate ceiling.

Note: 0.1.0 on PyPI is immutable, so this shows on the PyPI page at the **next release**; it's live on GitHub immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)