### PR TITLE
release: honest-scholar v0.1.1 (distinct PyPI Documentation link)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-07-21
+
+Package patch (metadata + docs). The plugin is unchanged (still `0.1.0`).
+
+### Fixed
+
+- PyPI project links: `Documentation` now points to a distinct URL
+  (`honest-scholar.science/get-started/user-guide`) so it renders separately from
+  `Homepage` (both previously pointed at the same URL, which PyPI collapsed).
+
+### Changed
+
+- Package README describes the honest failure handling (retry + `Retry-After`,
+  distinct actionable errors, never a silent miss or a traceback) instead of the
+  vague "degrade gracefully".
+
 ## [0.1.0] - 2026-07-19
 
 First public release — a Claude Code plugin for the scientific research workflow,

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,7 +16,7 @@ authors:
     email: davor.runje@fer.hr
 repository-code: "https://github.com/davorrunje/honest-scholar"
 url: "https://github.com/davorrunje/honest-scholar"
-version: 0.1.0
+version: 0.1.1
 license: Apache-2.0
 keywords:
   - research integrity

--- a/honest-scholar/pyproject.toml
+++ b/honest-scholar/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "honest-scholar"
-version = "0.1.0"
+version = "0.1.1"
 description = "honest-scholar — a CLI for honest, defensible AI-assisted research (tooling for the honest-scholar plugin)"
 authors = [{ name = "Davor Runje", email = "davor@synthpop.ai" }]
 maintainers = [{ name = "Davor Runje", email = "davor@synthpop.ai" }]
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.urls]
 Homepage      = "https://honest-scholar.science/"
-Documentation = "https://honest-scholar.science/"
+Documentation = "https://honest-scholar.science/get-started/user-guide"
 Repository    = "https://github.com/davorrunje/honest-scholar"
 Issues        = "https://github.com/davorrunje/honest-scholar/issues"
 Changelog     = "https://github.com/davorrunje/honest-scholar/blob/main/CHANGELOG.md"

--- a/honest-scholar/uv.lock
+++ b/honest-scholar/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "honest-scholar"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "pooch" },


### PR DESCRIPTION
## What

Fixes the PyPI "Project links" — `Homepage` and `Documentation` were the **same** URL (`honest-scholar.science`), which PyPI collapses. Since **0.1.0 is immutable on PyPI**, the fix rides a patch release.

- **`Documentation` → `https://honest-scholar.science/get-started/user-guide`** (distinct from `Homepage`, which stays the docs root) → both links render.
- Package **0.1.0 → 0.1.1** (`pyproject` + `uv.lock`); `CITATION.cff` → 0.1.1. **Plugin unchanged** at 0.1.0 (independent versioning, ADR-0026).
- `CHANGELOG.md` `[0.1.1]` entry — also notes that #62's README failure-handling wording reaches PyPI on this release.

Verified: `honest-scholar --version` → `0.1.1`; pre-commit green.

## To publish (after merge)
Create a **GitHub Release `v0.1.1`** → `publish.yml` → PyPI (tag↔version guard checks `v0.1.1` == `0.1.1`). Then the PyPI page shows distinct Homepage + Documentation links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)