### PR TITLE
fix(core): proactive per-host rate limiting for the HTTP client (closes #67)

### DIFF
--- a/honest-scholar/honest_scholar/cli.py
+++ b/honest-scholar/honest_scholar/cli.py
@@ -123,14 +123,41 @@ literature = typer.Typer(
 app.add_typer(literature, name="literature")
 
 
+def _rps_from_config(lit: object, field_name: str, default: float) -> float:
+    """Read a numeric ``literature.<field_name>`` override from `lit`, or `default`.
+
+    :param lit: The parsed ``literature:`` config block (or ``None``/non-mapping).
+    :param field_name: The config key (``s2_rps`` or ``openalex_rps``).
+    :param default: The value to use when the key is absent.
+    :returns: The configured rps, or `default` when unset.
+    :raises typer.Exit: Code 1 if the key is present but not a number.
+    """
+    raw = lit.get(field_name) if isinstance(lit, dict) else None
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError) as exc:
+        typer.echo(
+            f"invalid .honest-scholar/config.yml: 'literature.{field_name}' "
+            "must be a number",
+            err=True,
+        )
+        raise typer.Exit(code=1) from exc
+
+
 def _lit_client() -> HttpClient:
     """Build the literature HTTP client from config + the key store.
 
     Reads ``literature.mailto`` from ``.honest-scholar/config.yml`` (polite pool),
     falling back to ``OPENALEX_MAILTO``, and sources ``S2_API_KEY`` through the
-    key store — both with ``os.environ`` > store precedence (ADR-0029). Caches
-    responses under ``.honest-scholar/cache/http``. Tests monkeypatch this to
-    inject a fake client.
+    key store — both with ``os.environ`` > store precedence (ADR-0029). Also
+    reads ``literature.s2_rps`` / ``literature.openalex_rps`` — proactive
+    per-host rate-limit caps (honest-scholar#67) — falling back to
+    :class:`HttpClient`'s own conservative defaults (S2 below its 1 req/s
+    per-key ceiling) when absent. Caches responses under
+    ``.honest-scholar/cache/http``. Tests monkeypatch this to inject a fake
+    client.
     """
     from honest_scholar.core.config import load_config
     from honest_scholar.core.http import HttpClient
@@ -148,10 +175,13 @@ def _lit_client() -> HttpClient:
         )
         raise typer.Exit(code=1)
     mailto = lit.get("mailto") if isinstance(lit, dict) else None
+    defaults = HttpClient()
     return HttpClient(
         cache_dir=Path(".honest-scholar/cache/http"),
         mailto=mailto or keys_mod.get("OPENALEX_MAILTO"),
         s2_key=keys_mod.get("S2_API_KEY"),
+        s2_rps=_rps_from_config(lit, "s2_rps", defaults.s2_rps),
+        openalex_rps=_rps_from_config(lit, "openalex_rps", defaults.openalex_rps),
     )
 
 

--- a/honest-scholar/honest_scholar/core/http.py
+++ b/honest-scholar/honest_scholar/core/http.py
@@ -1,9 +1,11 @@
 """A small caching JSON-over-HTTP client — the package's house HTTP layer.
 
 Wraps ``requests`` with an on-disk, content-addressed response cache (the
-provenance root — never silently refreshed within a run) and exponential backoff
-on ``429`` / ``5xx``. The transport (`session`) and the sleep function are
-injectable so the client is fully testable without touching the network.
+provenance root — never silently refreshed within a run), a **proactive**
+per-host rate limiter (paces requests *before* sending), and **reactive**
+exponential backoff on ``429`` / ``5xx`` as the fallback. The transport
+(`session`), the clock, and the sleep function are injectable so the client is
+fully testable without touching the network or a real wall clock.
 
 Design: ``docs/design/proposals/literature-citation-graph-client.md`` (deps &
 posture), ``docs/design/proposals/tooling-package.md`` (house HTTP client).
@@ -100,9 +102,16 @@ class HttpClient:
     :param mailto: Email for the OpenAlex polite pool (sent as ``mailto=``).
     :param s2_key: Optional Semantic Scholar API key (sent as ``x-api-key``).
     :param session: The HTTP transport (defaults to a ``requests.Session``).
-    :param sleep: Sleep function for backoff (injectable for tests).
+    :param sleep: Sleep function for backoff and throttling (injectable for tests).
+    :param clock: Monotonic clock for the proactive throttle (injectable for tests).
     :param timeout: Per-request timeout in seconds.
     :param max_retries: Attempts on ``429`` / ``5xx`` before giving up.
+    :param s2_rps: Proactive cap on Semantic Scholar requests/second. Default is
+        conservatively *below* S2's documented per-key ceiling of 1 req/s
+        cumulative, per their "stay below this threshold" guidance. ``0``
+        disables the proactive throttle (reactive backoff still applies).
+    :param openalex_rps: Proactive cap on OpenAlex requests/second — a polite
+        pace under OpenAlex's documented 10 req/s ceiling. ``0`` disables it.
     """
 
     cache_dir: Path | None = None
@@ -110,8 +119,14 @@ class HttpClient:
     s2_key: str | None = None
     session: Session = field(default_factory=requests.Session)
     sleep: object = time.sleep
+    clock: object = time.monotonic
     timeout: float = 30.0
     max_retries: int = 4
+    s2_rps: float = 0.9
+    openalex_rps: float = 10.0
+    _last_request: dict[str, float] = field(
+        default_factory=dict, init=False, repr=False, compare=False
+    )
 
     def _cached(self, key: str) -> JsonValue | None:
         if self.cache_dir is None:
@@ -168,12 +183,40 @@ class HttpClient:
         if (hit := self._cached(key)) is not None:
             return hit
 
-        value = self._fetch(url, query, request_headers)
+        value = self._fetch(url, query, request_headers, s2=s2)
         self._store(key, value)
         return value
 
+    def _throttle(self, *, s2: bool) -> None:
+        """Proactively pace requests to a host, before the reactive retry loop.
+
+        Sleeps just enough that this send lands at least ``1 / rps`` after the
+        last send to the same host (Semantic Scholar vs. OpenAlex are tracked
+        independently, since each has its own ceiling). This is the *proactive*
+        half of rate-limit handling: it runs once per :meth:`get_json` call — on
+        the first attempt only — so a sweep of many calls self-throttles instead
+        of bursting and collecting ``429``s. Retries *within* one call still rely
+        on the existing reactive backoff/``Retry-After`` handling, unchanged.
+
+        :param s2: Whether this call targets Semantic Scholar (selects
+            ``s2_rps`` vs. ``openalex_rps``, and the per-host tracking key).
+        """
+        rps = self.s2_rps if s2 else self.openalex_rps
+        if rps <= 0:
+            return
+        min_interval = 1.0 / rps
+        key = "s2" if s2 else "openalex"
+        now: float = self.clock()  # type: ignore[operator]
+        last = self._last_request.get(key)
+        if last is not None:
+            wait = min_interval - (now - last)
+            if wait > 0:
+                self.sleep(wait)  # type: ignore[operator]
+                now = self.clock()  # type: ignore[operator]
+        self._last_request[key] = now
+
     def _fetch(
-        self, url: str, query: dict[str, str], headers: dict[str, str]
+        self, url: str, query: dict[str, str], headers: dict[str, str], *, s2: bool
     ) -> JsonValue:
         """Issue the request with retries; the network side of :meth:`get_json`.
 
@@ -181,7 +224,11 @@ class HttpClient:
         backs off exponentially with jitter. A rate-limit signal (``429``, or a
         ``503`` carrying ``Retry-After``) that survives every retry surfaces as a
         :class:`RateLimitError` so it is never mistaken for a permanent miss.
+
+        :param s2: Whether this call targets Semantic Scholar (selects the
+            proactive throttle's rps + tracking key; see :meth:`_throttle`).
         """
+        self._throttle(s2=s2)
         last_error = "no attempt made"
         rate_limited = False
         for attempt in range(self.max_retries):

--- a/honest-scholar/tests/test_literature.py
+++ b/honest-scholar/tests/test_literature.py
@@ -701,6 +701,139 @@ def test_http_503_without_retry_after_is_plain_http_error() -> None:
     assert not isinstance(exc.value, http.RateLimitError)  # 503 sans header is not RL
 
 
+# --- proactive rate limiting (honest-scholar#67) ------------------------------
+
+
+class FakeClock:
+    """A deterministic clock/sleep pair: ``sleep`` advances ``now`` in lockstep.
+
+    Keeps the throttle tests fully offline and exact — no real wall-clock time
+    ever elapses, but the elapsed-time arithmetic in
+    :meth:`http.HttpClient._throttle` behaves as if it had.
+    """
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.t = start
+        self.sleeps: list[float] = []
+
+    def now(self) -> float:
+        return self.t
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.t += seconds
+
+
+def test_http_throttle_spaces_back_to_back_s2_calls() -> None:
+    clock = FakeClock()
+    session = FakeSession({"https://s2/a": {"n": 1}, "https://s2/b": {"n": 2}})
+    client = http.HttpClient(
+        session=session,
+        cache_dir=None,
+        s2_rps=1.0,
+        clock=clock.now,
+        sleep=clock.sleep,
+    )
+    client.get_json("https://s2/a", s2=True)
+    client.get_json("https://s2/b", s2=True)
+    # No 429 round-trip involved: the second call alone triggers exactly one
+    # sleep, for the full 1s/req interval (elapsed time since the first was 0).
+    assert clock.sleeps == [1.0]
+    assert clock.t == 1.0
+
+
+def test_http_throttle_no_wait_when_interval_already_elapsed() -> None:
+    clock = FakeClock()
+    session = FakeSession({"https://s2/a": {"n": 1}, "https://s2/b": {"n": 2}})
+    client = http.HttpClient(
+        session=session,
+        cache_dir=None,
+        s2_rps=1.0,
+        clock=clock.now,
+        sleep=clock.sleep,
+    )
+    client.get_json("https://s2/a", s2=True)
+    clock.t += 5.0  # plenty of real time passed between calls
+    client.get_json("https://s2/b", s2=True)
+    assert clock.sleeps == []  # already spaced further apart than min_interval
+
+
+def test_http_throttle_tracks_s2_and_openalex_independently() -> None:
+    clock = FakeClock()
+    session = FakeSession({"https://s2/a": {"n": 1}, "https://oa/a": {"n": 2}})
+    client = http.HttpClient(
+        session=session,
+        cache_dir=None,
+        s2_rps=1.0,
+        openalex_rps=1.0,
+        clock=clock.now,
+        sleep=clock.sleep,
+    )
+    client.get_json("https://s2/a", s2=True)
+    client.get_json("https://oa/a", s2=False)
+    # Different hosts, same instant: neither has a prior send on *its* key.
+    assert clock.sleeps == []
+
+
+def test_http_throttle_disabled_when_rps_is_zero() -> None:
+    clock = FakeClock()
+    session = FakeSession({"https://s2/a": {"n": 1}, "https://s2/b": {"n": 2}})
+    client = http.HttpClient(
+        session=session, cache_dir=None, s2_rps=0.0, clock=clock.now, sleep=clock.sleep
+    )
+    client.get_json("https://s2/a", s2=True)
+    client.get_json("https://s2/b", s2=True)
+    assert clock.sleeps == []
+
+
+def test_http_throttle_defaults_are_conservative_for_s2_and_polite_for_openalex() -> (
+    None
+):
+    client = http.HttpClient(cache_dir=None)
+    assert client.s2_rps < 1.0  # strictly below S2's 1 req/s cumulative ceiling
+    assert client.openalex_rps == 10.0  # OpenAlex's documented ceiling
+
+
+def test_http_throttle_runs_once_per_call_not_per_retry() -> None:
+    # Retries within one get_json() call must keep relying on the existing
+    # reactive Retry-After/backoff handling, unchanged — not get re-throttled.
+    sleeps: list[float] = []
+    session = FakeSession(
+        {"https://x": [FakeResponse(429, {}, {"Retry-After": "7"}), {"ok": 1}]}
+    )
+    client = http.HttpClient(session=session, sleep=sleeps.append, cache_dir=None)
+    assert client.get_json("https://x") == {"ok": 1}
+    assert sleeps == [7.0]  # only the Retry-After sleep — no extra throttle sleep
+
+
+def test_lit_client_reads_rps_from_config(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    cfg = tmp_path / ".honest-scholar"
+    cfg.mkdir()
+    (cfg / "config.yml").write_text(
+        "literature:\n  s2_rps: 0.5\n  openalex_rps: 3\n", encoding="utf-8"
+    )
+    client = cli._lit_client()
+    assert client.s2_rps == 0.5
+    assert client.openalex_rps == 3.0
+
+
+def test_lit_client_rejects_non_numeric_rps(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    cfg = tmp_path / ".honest-scholar"
+    cfg.mkdir()
+    (cfg / "config.yml").write_text(
+        "literature:\n  s2_rps: not-a-number\n", encoding="utf-8"
+    )
+    with pytest.raises(typer.Exit) as exc:
+        cli._lit_client()
+    assert exc.value.exit_code == 1
+
+
 def test_resolve_rate_limit_propagates_not_miss() -> None:
     # A throttle must never be recorded as {resolved: False} ("no such work").
     client = _client(


### PR DESCRIPTION
## What

Adds a **proactive** per-host rate limiter to `HttpClient` so literature
sweeps self-throttle instead of bursting past Semantic Scholar's per-key
limit and relying on the existing reactive `429` backoff to recover.

## Details

- `HttpClient._throttle` (new) sleeps as needed so back-to-back sends to a
  host land at least `1 / rps` apart. Tracked independently per host
  (`s2` vs. `openalex`) since each has its own ceiling.
- Defaults: `s2_rps=0.9` — conservatively *below* Semantic Scholar's
  documented "1 request per second, cumulative across all endpoints" per-key
  limit, per their "stay below this threshold" guidance; `openalex_rps=10.0`
  — OpenAlex's documented ceiling (already referenced in
  `docs/design/proposals/literature-citation-graph-client.md`).
- Both are configurable via `literature.s2_rps` / `literature.openalex_rps` in
  `.honest-scholar/config.yml`, wired in `cli._lit_client`.
- The throttle runs **once per `get_json()` call**, before the retry loop —
  not once per retry attempt — so the existing reactive
  backoff/`Retry-After` handling (and its tests) is unchanged and remains the
  fallback if a server still rejects a request.
- The clock is injectable (`clock`, mirroring the existing `sleep`
  injection), so the pacing is verified with deterministic, offline tests —
  no real `time.sleep` or network access.
- Deliberately out of scope (per the issue): cache-path and API-key logic,
  which sibling issues #65/#66 cover in separate PRs.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)
