### PR TITLE
fix(package): source the cache root from config.yml, not two hardcoded literals

### DIFF
--- a/decisions/0031-config-driven-cache-dir.md
+++ b/decisions/0031-config-driven-cache-dir.md
@@ -1,0 +1,87 @@
+# ADR-0031: Source the cache root from `config.yml` (`cache_dir:`), not a hardcoded literal
+
+- Status: accepted · Date: 2026-07-22 · Deciders: Davor Runje
+
+## Context
+
+`research-init` scaffolded a project's `.gitignore` with `.datasets-cache/`, but
+`honest_scholar/cli.py` hardcoded the directory it actually wrote to as
+`.honest-scholar/cache/datasets` (the dataset content-addressed cache,
+`_DATASET_CACHE`) and `.honest-scholar/cache/http` (the literature HTTP cache,
+inside `_lit_client`) — two independent literals that were never reconciled with
+the scaffold. This surfaced during onboarding of a real consumer repo
+(`davorrunje/mononet`): after `dataset fetch`/`verify` and a `literature` run,
+cached bytes landed under `.honest-scholar/cache/…`, which the scaffolded
+`.gitignore` did **not** exclude (risk of committing large cached blobs), while
+the gitignored `.datasets-cache/` was dead — never written to, and misleading
+about where the cache actually lives (`honest-scholar#65`). This was a known open
+item — sub-spec 4 §7 flagged "`.datasets-cache/` vs `.honest-scholar/`" as
+needing reconciliation before this fix.
+
+## Decision drivers
+
+- The path `research-init` gitignores and the path the CLI writes to must be
+  the same path, **by construction** — not by two hand-synced literals.
+- Consumers occasionally need the cache elsewhere (a scratch volume, a CI cache
+  mount) — worth a one-line override, not a code change.
+- Keep the change minimal and consistent with the existing config-loading
+  pattern (`_lit_client` already reads `literature.mailto` from
+  `.honest-scholar/config.yml`, with the same invalid-YAML/mapping error
+  handling this ADR reuses).
+- No new dependency (stdlib + the existing `pyyaml`-backed `load_config`); no
+  Pydantic (ADR rejecting it stands).
+
+## Considered options
+
+1. **Minimal**: point `research-init`'s scaffold at whatever `cli.py` already
+   hardcodes (`.honest-scholar/cache/`), leaving both sides as literals.
+2. **Config-driven** *(chosen)*: add a `cache_dir:` key to
+   `.honest-scholar/config.yml` (default `.honest-scholar/cache/`); `cli.py`
+   resolves the dataset cache (`<cache_dir>/datasets`) and the literature HTTP
+   cache (`<cache_dir>/http`) from it; `research-init` gitignores exactly that
+   configured path.
+3. Separate `dataset.cache_dir` / `literature.cache_dir` keys per capability.
+
+## Decision
+
+Option 2. A single top-level `cache_dir:` key in `.honest-scholar/config.yml`,
+default `.honest-scholar/cache/` when absent. `honest_scholar/cli.py` gains a
+shared `_cache_root(config)` resolver (invalid-type → a clean `typer.Exit(1)`,
+matching the existing config-error convention, never a raw traceback) that both
+`_dataset_cache_dir()` (`<cache_dir>/datasets`) and `_lit_client()`
+(`<cache_dir>/http`) call — one source of truth for both capabilities'
+sub-caches. `research-init`'s scaffold and prose now reference
+`.honest-scholar/cache/` (via `cache_dir:`) instead of the dead
+`.datasets-cache/`, and `.gitignore` excludes exactly that configured path.
+
+## Consequences
+
+- A fresh `research-init` + `dataset fetch`/`verify` + a `literature` run
+  leaves no un-ignored cache files — scaffold and runtime cannot drift apart,
+  because both read from the same config key.
+- One config key covers both capabilities' caches; a consumer who wants the
+  cache elsewhere sets `cache_dir:` once.
+- `.datasets-cache/` is retired from the scaffold — not left as a second,
+  inert path (the "both-and-neither" failure mode this ADR closes).
+- Reads `.honest-scholar/config.yml` on every `dataset fetch/verify/mirror/audit`
+  invocation (previously these commands did not touch config at all); a
+  malformed `config.yml` now surfaces as a clean exit 1 on those commands too,
+  consistent with how `literature` commands already behaved.
+
+## Rejected alternatives
+
+- **Minimal (point the scaffold at the hardcoded literal)** — fixes today's
+  drift but leaves two independent literals that can drift again on the next
+  edit; does not answer the acceptance criterion that scaffold and runtime
+  cannot drift *by construction*.
+- **Per-capability cache keys** — no present need for dataset and literature
+  caches to live in different places, and it multiplies the scaffold/runtime
+  reconciliation surface this ADR exists to shrink.
+
+## Links
+
+`honest-scholar/honest_scholar/cli.py` (`_cache_root`, `_dataset_cache_dir`,
+`_lit_client`); `honest-scholar/honest_scholar/core/config.py` (`load_config`);
+`skills/research-init/SKILL.md`; `docs/design/03-dataset.md` §7 (the open item
+this closes); `honest-scholar#65`; ADR-0029 (the config-error-handling
+convention this reuses).

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -42,5 +42,6 @@ Migrates to the plugin's `decisions/` alongside `resources/references/`.
 | [0028](0028-100-percent-coverage-gate.md) | 100% statement + branch coverage gate on the package | accepted |
 | [0029](0029-api-key-handling.md) | Unified API-key handling — a CLI-managed JSON store (not `.env`), stdin writes, scoped in-memory env for children | accepted |
 | [0030](0030-docs-site-mintlify.md) | Docs site on Mintlify, published from a generated docs repo to `honest-scholar.science` | accepted |
+| [0031](0031-config-driven-cache-dir.md) | Source the cache root from `config.yml` (`cache_dir:`), not a hardcoded literal | accepted |
 
 Format: MADR (Markdown Any Decision Records). Deciders: Davor Runje (with Claude).

--- a/docs/design/00-meta-spec.md
+++ b/docs/design/00-meta-spec.md
@@ -433,9 +433,9 @@ the experiment-backend implementation. After `init`/`adopt`, a consumer repo
 │       ├── references.bib                # or CSL-JSON — bibliographic facts
 │       └── triage.yml                    # decision sidecar (keyed by citekey/DOI)
 ├── datasets.yml                          # dataset registry (entries + checksums + tiers)
-├── .datasets-cache/                      # gitignored materialized data
 ├── .honest-scholar/
-│   ├── config.yml                        # rclone remote name, lit anchors, experiment-backend + engineering_backend bindings
+│   ├── config.yml                        # rclone remote name, lit anchors, cache_dir, experiment-backend + engineering_backend bindings
+│   ├── cache/                            # gitignored materialized data + HTTP cache (path from `cache_dir:`; ADR-0031)
 │   ├── rclone.conf                       # gitignored (creds)
 │   └── rclone.conf.example               # committed template (remote name/type only)
 └── <experiment-backend implementation>   # supplied by the consuming project; not shipped with the plugin
@@ -452,8 +452,8 @@ plus an inventory-and-map phase.
 
 - **`init` (greenfield)** — scaffold the `docs/research/` layout, the registries
   (`papers.md`, `datasets.yml`, `references.bib` + `triage.yml`), `.honest-scholar/`
-  config (rclone remote name, literature anchors, experiment-backend +
-  engineering-backend bindings),
+  config (rclone remote name, literature anchors, cache directory,
+  experiment-backend + engineering-backend bindings),
   and the staged-doc templates. Delegates per-item registration to the
   capability skills' own verbs rather than reimplementing them.
 - **`adopt` (backfill)** — inventory an existing repo, propose mappings,

--- a/docs/design/03-dataset.md
+++ b/docs/design/03-dataset.md
@@ -104,5 +104,7 @@ deps; HTTP/FTP/SFTP + `doi:`); Tier-A uses git/LFS; Tier-C is instruct-drop-veri
   hash as transport check only.
 - **Croissant version** — target the current MLCommons spec; treat as export
   format, registry is the superset source of truth.
-- **`.datasets-cache/` vs `.honest-scholar/`** — confirm cache directory placement with
-  the meta-spec `.honest-scholar/` decision.
+- **`.datasets-cache/` vs `.honest-scholar/`** — **settled** (ADR-0031): the cache
+  lives under `.honest-scholar/cache/` by default, sourced from a `cache_dir:`
+  key in `config.yml` so `research-init`'s `.gitignore` scaffold and the CLI's
+  runtime cache path cannot drift apart; `.datasets-cache/` is retired.

--- a/docs/design/proposals/literature-citation-graph-client.md
+++ b/docs/design/proposals/literature-citation-graph-client.md
@@ -105,8 +105,10 @@ Light-dep, per SKILL.md and `../../../resources/substrate/asset-registry.md`:
   approximate? What `--top` default?
 - S2 batch endpoint (`/paper/batch`) vs. per-id calls for hydration — batch cuts
   request count but couples to a second response shape.
-- Where does the cache live — gitignored under `.honest-scholar/cache/` shared with the
-  substrate cache, or a private dir? TTL / invalidation policy?
+- ~~Where does the cache live~~ — **settled** (ADR-0031): gitignored under
+  `.honest-scholar/cache/http`, sharing the `cache_dir:`-configured root with
+  the dataset substrate cache (`<cache_dir>/datasets`). TTL / invalidation
+  policy is still open.
 - Does `resolve` need Crossref as a DOI fallback when OpenAlex misses, or is
   OpenAlex-only acceptable for v1?
 

--- a/honest-scholar/honest_scholar/cli.py
+++ b/honest-scholar/honest_scholar/cli.py
@@ -17,7 +17,7 @@ import subprocess  # nosec B404 - used only to read `--version` of trusted tools
 import sys
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
 
@@ -116,6 +116,54 @@ def doctor() -> None:
     raise typer.Exit(code=0)
 
 
+# --- shared cache-root config (honest-scholar#65) ---------------------------------
+_DEFAULT_CACHE_ROOT = Path(".honest-scholar/cache")
+
+
+def _load_config_or_exit() -> dict[str, Any]:
+    """Load ``.honest-scholar/config.yml``, exiting 1 on invalid YAML/mapping.
+
+    :returns: The parsed configuration mapping (empty if the file is absent).
+    :raises typer.Exit: Code 1 if the file exists but is not a valid YAML
+        mapping.
+    """
+    from honest_scholar.core.config import load_config
+
+    try:
+        return load_config()
+    except ValueError as exc:
+        typer.echo(f"invalid .honest-scholar/config.yml: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+def _cache_root(config: dict[str, Any] | None = None) -> Path:
+    """Resolve the cache root from ``config.yml``'s ``cache_dir:`` key.
+
+    Both the dataset content-addressed cache and the literature HTTP cache
+    live under this single root, and ``research-init`` gitignores exactly
+    this path (see the SKILL.md scaffold). Sourcing it from config instead of
+    hardcoding it in two places is what keeps the scaffolded ``.gitignore``
+    and the runtime cache location from drifting apart (honest-scholar#65).
+
+    :param config: A pre-loaded config mapping; loaded fresh when omitted.
+    :returns: The configured cache root, or :data:`_DEFAULT_CACHE_ROOT` when
+        ``cache_dir`` is unset.
+    :raises typer.Exit: Code 1 if ``cache_dir`` is present but not a string.
+    """
+    if config is None:
+        config = _load_config_or_exit()
+    cache_dir = config.get("cache_dir")
+    if cache_dir is None:
+        return _DEFAULT_CACHE_ROOT
+    if not isinstance(cache_dir, str):
+        typer.echo(
+            "invalid .honest-scholar/config.yml: 'cache_dir' must be a string",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    return Path(cache_dir)
+
+
 # --- literature (honest-scholar#1) ------------------------------------------------
 literature = typer.Typer(
     help="Citation-graph and metadata tools.", no_args_is_help=True
@@ -155,18 +203,13 @@ def _lit_client() -> HttpClient:
     reads ``literature.s2_rps`` / ``literature.openalex_rps`` — proactive
     per-host rate-limit caps (honest-scholar#67) — falling back to
     :class:`HttpClient`'s own conservative defaults (S2 below its 1 req/s
-    per-key ceiling) when absent. Caches responses under
-    ``.honest-scholar/cache/http``. Tests monkeypatch this to inject a fake
-    client.
+    per-key ceiling) when absent. Caches responses under ``<cache_dir>/http``
+    (``cache_dir:`` in config, default ``.honest-scholar/cache/``; see
+    :func:`_cache_root`). Tests monkeypatch this to inject a fake client.
     """
-    from honest_scholar.core.config import load_config
     from honest_scholar.core.http import HttpClient
 
-    try:
-        config = load_config()
-    except ValueError as exc:
-        typer.echo(f"invalid .honest-scholar/config.yml: {exc}", err=True)
-        raise typer.Exit(code=1) from exc
+    config = _load_config_or_exit()
     lit = config.get("literature")
     if lit is not None and not isinstance(lit, dict):
         typer.echo(
@@ -177,7 +220,7 @@ def _lit_client() -> HttpClient:
     mailto = lit.get("mailto") if isinstance(lit, dict) else None
     defaults = HttpClient()
     return HttpClient(
-        cache_dir=Path(".honest-scholar/cache/http"),
+        cache_dir=_cache_root(config) / "http",
         mailto=mailto or keys_mod.get("OPENALEX_MAILTO"),
         s2_key=keys_mod.get("S2_API_KEY"),
         s2_rps=_rps_from_config(lit, "s2_rps", defaults.s2_rps),
@@ -416,7 +459,12 @@ def emit(
     raise typer.Exit(code=1)
 
 
-_DATASET_CACHE = Path(".honest-scholar/cache/datasets")
+def _dataset_cache_dir() -> Path:
+    """Return the dataset content-addressed cache dir, under the cache root.
+
+    :returns: ``<cache_root>/datasets`` (see :func:`_cache_root`).
+    """
+    return _cache_root() / "datasets"
 
 
 def _load_manifest_or_exit(path: str) -> manifest_mod.Manifest:
@@ -475,7 +523,7 @@ def fetch(
     entry = _entry_or_exit(parsed, identifier)
     try:
         paths = retrieval_mod.fetch(
-            entry, cache_dir=_DATASET_CACHE, mirror=_mirror_from(parsed)
+            entry, cache_dir=_dataset_cache_dir(), mirror=_mirror_from(parsed)
         )
     except retrieval_mod.RetrievalError as exc:
         typer.echo(f"fetch failed: {exc}", err=True)
@@ -499,7 +547,7 @@ def verify(
     """
     parsed = _load_manifest_or_exit(manifest)
     entry = _entry_or_exit(parsed, identifier)
-    report = retrieval_mod.verify(entry, cache_dir=_DATASET_CACHE)
+    report = retrieval_mod.verify(entry, cache_dir=_dataset_cache_dir())
     typer.echo(json.dumps(dataclasses.asdict(report) | {"ok": report.ok}, indent=2))
     raise typer.Exit(code=0 if report.ok else 1)
 
@@ -524,7 +572,7 @@ def mirror(
         typer.echo("no mirror configured in the manifest", err=True)
         raise typer.Exit(code=1)
     try:
-        paths = retrieval_mod.fetch(entry, cache_dir=_DATASET_CACHE, mirror=mir)
+        paths = retrieval_mod.fetch(entry, cache_dir=_dataset_cache_dir(), mirror=mir)
         for path, ref in zip(paths, entry.files, strict=True):
             mir.put(path, ref.sha256)
     except retrieval_mod.RetrievalError as exc:
@@ -554,7 +602,7 @@ def audit(
         entry = _entry_or_exit(parsed, identifier)
         parsed = manifest_mod.Manifest(mirror=parsed.mirror, datasets=[entry])
     report = retrieval_mod.audit(
-        parsed, cache_dir=_DATASET_CACHE, mirror=_mirror_from(parsed)
+        parsed, cache_dir=_dataset_cache_dir(), mirror=_mirror_from(parsed)
     )
     typer.echo(
         json.dumps(

--- a/honest-scholar/tests/test_cache_config.py
+++ b/honest-scholar/tests/test_cache_config.py
@@ -1,0 +1,87 @@
+"""Tests for the shared cache-root resolution (honest-scholar#65).
+
+The dataset content-addressed cache and the literature HTTP cache both live
+under one configurable root (``cache_dir:`` in ``.honest-scholar/config.yml``,
+default ``.honest-scholar/cache/``) so the directory ``research-init``
+gitignores and the directory the CLI actually writes to cannot drift apart.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typer
+
+from honest_scholar import cli
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    cfg_dir = tmp_path / ".honest-scholar"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yml").write_text(body, encoding="utf-8")
+
+
+def test_cache_root_defaults_when_unconfigured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert cli._cache_root() == cli._DEFAULT_CACHE_ROOT
+    assert Path(".honest-scholar/cache") == cli._DEFAULT_CACHE_ROOT
+
+
+def test_cache_root_reads_configured_cache_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, "cache_dir: .custom-cache\n")
+    assert cli._cache_root() == Path(".custom-cache")
+
+
+def test_cache_root_accepts_a_preloaded_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert cli._cache_root({"cache_dir": ".preloaded"}) == Path(".preloaded")
+
+
+def test_cache_root_rejects_non_string_cache_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, "cache_dir:\n  - not\n  - a-string\n")
+    with pytest.raises(typer.Exit) as exc:
+        cli._cache_root()
+    assert exc.value.exit_code == 1
+
+
+def test_dataset_cache_dir_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert cli._dataset_cache_dir() == Path(".honest-scholar/cache/datasets")
+
+
+def test_dataset_cache_dir_follows_configured_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, "cache_dir: .custom-cache\n")
+    assert cli._dataset_cache_dir() == Path(".custom-cache/datasets")
+
+
+def test_load_config_or_exit_returns_empty_when_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert cli._load_config_or_exit() == {}
+
+
+def test_load_config_or_exit_surfaces_invalid_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, "cache_dir: [unclosed\n")
+    with pytest.raises(typer.Exit) as exc:
+        cli._load_config_or_exit()
+    assert exc.value.exit_code == 1

--- a/honest-scholar/tests/test_cli_commands.py
+++ b/honest-scholar/tests/test_cli_commands.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from typer.testing import CliRunner
 
 from honest_scholar.cli import app
+from honest_scholar.dataset import retrieval as retrieval_mod
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     import pytest
 
 runner = CliRunner()
@@ -85,6 +85,65 @@ def test_fetch_and_verify_tier_a(
     verify = runner.invoke(app, ["dataset", "verify", "ds-a"])
     assert verify.exit_code == 0
     assert json.loads(verify.stdout)["ok"] is True
+
+
+def test_fetch_verify_audit_use_configured_cache_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dataset fetch/verify/audit resolve the cache dir from config.yml (#65).
+
+    The cache directory the CLI actually passes to :mod:`retrieval` must be
+    exactly the one ``research-init`` gitignores — sourced from
+    ``cache_dir:`` instead of a hardcoded literal, so the two cannot drift.
+    """
+    monkeypatch.chdir(_tier_a_project(tmp_path))
+    cfg = tmp_path / ".honest-scholar"
+    cfg.mkdir()
+    (cfg / "config.yml").write_text("cache_dir: .custom-cache\n", encoding="utf-8")
+
+    seen: list[Path] = []
+    original_fetch = retrieval_mod.fetch
+    original_verify = retrieval_mod.verify
+    original_audit = retrieval_mod.audit
+
+    def _fetch_spy(entry, *, cache_dir, mirror=None, **kw):  # type: ignore[no-untyped-def]
+        seen.append(Path(cache_dir))
+        return original_fetch(entry, cache_dir=cache_dir, mirror=mirror, **kw)
+
+    def _verify_spy(entry, *, cache_dir):  # type: ignore[no-untyped-def]
+        seen.append(Path(cache_dir))
+        return original_verify(entry, cache_dir=cache_dir)
+
+    def _audit_spy(manifest, *, cache_dir, mirror=None):  # type: ignore[no-untyped-def]
+        seen.append(Path(cache_dir))
+        return original_audit(manifest, cache_dir=cache_dir, mirror=mirror)
+
+    monkeypatch.setattr(retrieval_mod, "fetch", _fetch_spy)
+    monkeypatch.setattr(retrieval_mod, "verify", _verify_spy)
+    monkeypatch.setattr(retrieval_mod, "audit", _audit_spy)
+
+    assert runner.invoke(app, ["dataset", "fetch", "ds-a"]).exit_code == 0
+    assert runner.invoke(app, ["dataset", "verify", "ds-a"]).exit_code == 0
+    assert runner.invoke(app, ["dataset", "audit"]).exit_code == 0
+
+    # `audit` internally re-runs `verify`, so more than 3 calls may land here —
+    # what matters is that every one of them got the *configured* root, never
+    # the old hardcoded ``.honest-scholar/cache/datasets`` literal.
+    expected = Path(".custom-cache/datasets")
+    assert len(seen) >= 3
+    assert all(path == expected for path in seen)
+
+
+def test_fetch_exits_1_on_invalid_cache_dir_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(_tier_a_project(tmp_path))
+    cfg = tmp_path / ".honest-scholar"
+    cfg.mkdir()
+    (cfg / "config.yml").write_text("cache_dir:\n  - nope\n", encoding="utf-8")
+    result = runner.invoke(app, ["dataset", "fetch", "ds-a"])
+    assert result.exit_code == 1
+    assert "cache_dir" in result.stderr
 
 
 def test_fetch_unknown_id_exits_1(

--- a/honest-scholar/tests/test_literature.py
+++ b/honest-scholar/tests/test_literature.py
@@ -402,6 +402,29 @@ def test_lit_client_builds_from_config(
     assert client.mailto == "me@x.org"
 
 
+def test_lit_client_http_cache_defaults_under_cache_root(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    client = cli._lit_client()
+    # Same root the dataset cache and research-init's .gitignore scaffold use
+    # (honest-scholar#65) — no more hardcoded, independently-drifting paths.
+    assert client.cache_dir == cli._DEFAULT_CACHE_ROOT / "http"
+
+
+def test_lit_client_http_cache_follows_configured_cache_dir(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    cfg = tmp_path / ".honest-scholar"
+    cfg.mkdir()
+    (cfg / "config.yml").write_text("cache_dir: .custom-cache\n", encoding="utf-8")
+    client = cli._lit_client()
+    from pathlib import Path
+
+    assert client.cache_dir == Path(".custom-cache/http")
+
+
 class _BadJSON(FakeResponse):
     def json(self) -> object:
         raise ValueError("not json")

--- a/skills/research-init/SKILL.md
+++ b/skills/research-init/SKILL.md
@@ -65,9 +65,9 @@ docs/research/
     references.json              # CSL-JSON — bibliographic facts (source of truth; ADR-0020)
     triage.yml                    # decision sidecar (role, disposition, rationale), keyed by id/DOI
 datasets.yml                     # dataset registry (entries + checksums + tiers + license)
-.datasets-cache/                 # gitignored materialized data
 .honest-scholar/
-  config.yml                     # rclone remote name, literature anchors, experiment-backend + engineering_backend bindings
+  config.yml                     # rclone remote name, literature anchors, cache_dir, experiment-backend + engineering_backend bindings
+  cache/                         # gitignored materialized data + HTTP cache (path from config.yml `cache_dir:`)
   rclone.conf.example            # committed template (remote name/type only)
   rclone.conf                    # gitignored (credentials)
 ```
@@ -78,14 +78,16 @@ paper comes from the shared templates in
 [`resources/templates/`](../../resources/templates/); every hypothesis/paper/thesis
 artifact carries the status frontmatter block that feeds `progress`.
 
-`.honest-scholar/config.yml` records the four consumer bindings: the **rclone remote
+`.honest-scholar/config.yml` records the five consumer bindings: the **rclone remote
 name** for the private mirror, the **literature anchors** (seed works/authors the
 `literature` capability ranks around), the **experiment-backend binding**
 (which repo-local harness implements the run/evidence/tables/is-current
-contract), and the **engineering-backend binding** (`engineering_backend:` — the
+contract), the **engineering-backend binding** (`engineering_backend:` — the
 `design`/`plan`/`implement` delegate the pipeline skills hand engineering off to;
-ADR-0023). `.gitignore` is updated to exclude `.datasets-cache/` and
-`.honest-scholar/rclone.conf`.
+ADR-0023), and the **cache directory** (`cache_dir:`, default `.honest-scholar/cache/`
+— the CLI's dataset + HTTP caches always live under exactly this path;
+[ADR-0031](../../decisions/0031-config-driven-cache-dir.md)). `.gitignore` is
+updated to exclude the configured `cache_dir:` path and `.honest-scholar/rclone.conf`.
 
 The `thesis/` tree is optional — scaffold it only when the repo is a
 thesis-by-publication; a plain portfolio repo omits the top level.


### PR DESCRIPTION
## What

`research-init` gitignored `.datasets-cache/`, but the CLI actually wrote
dataset + HTTP caches under `.honest-scholar/cache/…` — two hardcoded paths
that never matched, so real cache bytes were un-ignored while the ignored
path was dead (surfaced onboarding `davorrunje/mononet`). The cache root is
now a single `cache_dir:` config key (default `.honest-scholar/cache/`) that
both the CLI and the `research-init` scaffold read, so the two cannot drift
apart.

## Details

- `honest_scholar/cli.py`: added `_load_config_or_exit()` / `_cache_root()`
  helpers; `_dataset_cache_dir()` replaces the `_DATASET_CACHE` literal, and
  `_lit_client()`'s HTTP cache now resolves through `_cache_root()` too — one
  source of truth for both capabilities' sub-caches.
- Invalid `cache_dir:` (non-string) exits 1 with a clean message, matching the
  existing config-error convention (never a raw traceback).
- `skills/research-init/SKILL.md`: scaffold + prose now reference
  `.honest-scholar/cache/` via `cache_dir:`; `.datasets-cache/` is retired
  (not left as a second, inert path).
- `docs/design/00-meta-spec.md`, `docs/design/03-dataset.md` (§7 open item,
  now settled), `docs/design/proposals/literature-citation-graph-client.md`
  (open question, now settled): updated to match.
- New ADR: `decisions/0031-config-driven-cache-dir.md`.
- Tests: `tests/test_cache_config.py` (new — `_cache_root`/`_dataset_cache_dir`
  defaults, config override, invalid-type error); `tests/test_literature.py`
  (`_lit_client`'s HTTP cache follows `cache_dir:`); `tests/test_cli_commands.py`
  (integration spy proving `fetch`/`verify`/`audit` thread the configured root
  through to `retrieval_mod`, plus a CLI-level invalid-config exit-1 case).
- `cd honest-scholar && uv run pytest -q` (272 passed, 100% coverage),
  `ruff check`, `ruff format --check`, `mypy` all clean;
  `./tools/validate-plugin.sh` passes.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)
