### PR TITLE
fix(core): key store defaults outside the repo, gitignore as backstop

### DIFF
--- a/decisions/0029-api-key-handling.md
+++ b/decisions/0029-api-key-handling.md
@@ -2,6 +2,12 @@
 
 - Status: accepted · Date: 2026-07-19 · Deciders: Davor Runje
 
+> **Refined by ADR-0032.** The default store location moves outside the
+> consumer repo's work tree (XDG config, not `.honest-scholar/keys.json`),
+> closing a secret-leak gap the in-repo default left open
+> (honest-scholar#66). The in-repo path below remains available as an
+> explicit opt-in and is still gitignored by `research-init`.
+
 ## Context
 
 The skills reach external services that key-gate their useful rate limits —

--- a/decisions/0032-keys-store-outside-repo-by-default.md
+++ b/decisions/0032-keys-store-outside-repo-by-default.md
@@ -1,0 +1,117 @@
+# ADR-0032: Key store defaults outside the repo (XDG); in-repo store is an explicit, gitignored opt-in
+
+- Status: accepted · Date: 2026-07-22 · Deciders: Davor Runje
+
+## Context
+
+ADR-0029 put the CLI-owned key store at `.honest-scholar/keys.json` — **inside
+the consumer repo's work tree** — relying on `research-init` to gitignore it.
+Onboarding `davorrunje/mononet` surfaced that `research-init` never actually
+added that entry: `honest-scholar keys path` resolved to
+`.honest-scholar/keys.json`, and `git check-ignore -v` on it produced no
+output — not ignored, therefore committable. `keys set` correctly takes values
+from stdin/a hidden prompt (never `argv`), so a secret never lands in shell
+history, but the **at-rest store itself** was one missed scaffolding step away
+from landing in a commit (honest-scholar#66). That is exactly the failure mode
+ADR-0029 set out to avoid, and it contradicts the secret-hygiene stance applied
+elsewhere in this repo (`rclone.conf` is gitignored and only
+`rclone.conf.example` is tracked).
+
+A gitignore entry is a **single point of failure**: it protects a fresh,
+correctly-scaffolded repo, but a missing line, a hand-edited `.gitignore`, or a
+consumer repo onboarded before the fix all leave the secret exposed with no
+second line of defense.
+
+## Decision drivers
+
+- A stored key must **never be committable by default** — not "committable
+  unless `.gitignore` happens to be right."
+- Defense-in-depth: even a correct gitignore entry is one mistake away from a
+  leak; prefer removing the repo from the equation entirely.
+- Preserve ADR-0029's other properties unchanged: `os.environ` > store >
+  unset precedence, stdin/hidden-prompt-only writes, scoped in-memory `env`
+  for child processes, plaintext-at-rest honesty.
+- Stay light-dependency (ADR-0024) — no new package for this.
+- Don't break an existing in-repo store outright; give it an explicit,
+  documented path back for anyone who wants it (e.g. a shared dev container
+  where `$HOME` isn't durable).
+
+## Considered options
+
+1. **Minimal: just add the gitignore line.** `research-init` gitignores
+   `.honest-scholar/keys.json`, store location unchanged.
+2. **Move the default store outside the repo (XDG config), keep the in-repo
+   path as an explicit opt-in** + a runtime guardrail that warns if a
+   resolved store is ever inside a non-gitignored work tree. *(chosen)*
+3. **OS secure store (Keychain / libsecret / Credential Manager) now.**
+
+## Decision
+
+Option 2.
+
+- **Default store location.** `honest_scholar.core.keys.default_store_path()`
+  resolves to `$XDG_CONFIG_HOME/honest-scholar/keys.json`, falling back to
+  `~/.config/honest-scholar/keys.json` per the XDG Base Directory spec —
+  never inside the consumer repo's work tree. No dependency added
+  (`platformdirs` was considered and rejected as unnecessary weight for two
+  environment variables); implemented with stdlib `os.environ` + `Path.home()`.
+- **Opt-in override.** `HONEST_SCHOLAR_KEYS_PATH` is an explicit override —
+  set to any path, including the legacy in-repo `.honest-scholar/keys.json`
+  (kept as `keys.IN_REPO_STORE_PATH`) — for anyone who wants the store to
+  travel with the repo instead of `$HOME`. `research-init` continues to
+  gitignore `.honest-scholar/keys.json`, so that opt-in still lands safely.
+- **Runtime guardrail.** `keys.store_at_risk(path)` reports whether the
+  *resolved* store sits inside a git work tree (walking up for a `.git` entry)
+  and is not *confirmed* ignored (`git check-ignore`, run in that work tree's
+  root regardless of the CLI's actual cwd). `keys set` calls this before
+  writing and **warns** — never refuses — when it is true; an inconclusive
+  answer (no `git` binary, not a git repo at all... i.e. any non-"definitely
+  ignored" result) is treated as at-risk, matching the "no news is not good
+  news for a secret" posture. Warn, not refuse, because: (a) the default path
+  already keeps a fresh setup safe, so this only fires for an explicit
+  opt-in a user made deliberately; (b) it matches the existing convention in
+  this module (`keys set` on an unrecognised name warns but still stores) —
+  CLAUDE.md's failure-honesty stance asks for an explicit, actionable signal,
+  not a silent success *or* a hard stop on a deliberate choice.
+- **Everything else from ADR-0029 is unchanged**: precedence, stdin-only
+  writes, scoped child-process env, plaintext-at-rest disclosure.
+
+## Consequences
+
+- A fresh `research-init` + `keys set` sequence can never produce a
+  committable secret file — `git status` shows nothing, because the store
+  never entered the work tree.
+- An existing consumer repo that already has an in-repo store is unaffected by
+  the code change alone (nothing migrates automatically) but gets a warning
+  the next time it writes if it opts into `HONEST_SCHOLAR_KEYS_PATH` pointed
+  at an un-ignored location; `research-init` re-runs will still add the
+  gitignore line as a backstop.
+- One more environment variable to document (`HONEST_SCHOLAR_KEYS_PATH`,
+  alongside the existing `HONEST_SCHOLAR_LIVE`).
+- The guardrail shells out to `git check-ignore` (a fixed, argument-list
+  subprocess call, no shell) — the same trust boundary already accepted for
+  `rclone` (ADR-0011) and the `--version` probes in `doctor`.
+- Tests that exercise the default path must isolate `HOME`/`XDG_CONFIG_HOME`
+  (a `tests/conftest.py` autouse fixture does this for the whole suite) so the
+  suite never touches a real developer's `~/.config`.
+
+## Rejected alternatives
+
+- **Just add the gitignore line (option 1)** — the minimal fix the issue
+  proposed, but it is exactly the single point of failure that caused #66 in
+  the first place: it protects only a freshly, correctly scaffolded repo.
+  Implemented anyway as defense-in-depth (`research-init` still gitignores
+  the in-repo path), just not relied on as the primary control.
+- **OS secure store now (option 3)** — the right at-rest answer eventually,
+  but heavy/platform-specific with a headless/CI fallback to design; already
+  deferred to issue #49 by ADR-0029 and still the better place for it.
+
+## Links
+
+`honest-scholar/honest_scholar/core/keys.py` (`store_path`, `default_store_path`,
+`store_at_risk`, `is_gitignored`); `honest-scholar/honest_scholar/cli.py` (`keys
+set`'s `_warn_if_store_committable`); `skills/research-init/SKILL.md`;
+ADR-0029 (the store this refines); ADR-0024 (light-dependency posture);
+honest-scholar#66 (this decision); honest-scholar#49 (OS-keychain follow-up,
+unaffected); honest-scholar#65 (a related but distinct scaffolding-vs-runtime
+mismatch for the dataset cache path, fixed separately — not in scope here).

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -43,5 +43,6 @@ Migrates to the plugin's `decisions/` alongside `resources/references/`.
 | [0029](0029-api-key-handling.md) | Unified API-key handling — a CLI-managed JSON store (not `.env`), stdin writes, scoped in-memory env for children | accepted |
 | [0030](0030-docs-site-mintlify.md) | Docs site on Mintlify, published from a generated docs repo to `honest-scholar.science` | accepted |
 | [0031](0031-config-driven-cache-dir.md) | Source the cache root from `config.yml` (`cache_dir:`), not a hardcoded literal | accepted |
+| [0032](0032-keys-store-outside-repo-by-default.md) | Key store defaults outside the repo (XDG); in-repo store is an explicit, gitignored opt-in with a committable-store runtime guardrail | accepted |
 
 Format: MADR (Markdown Any Decision Records). Deciders: Davor Runje (with Claude).

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -334,11 +334,14 @@ the throttling that otherwise stalls citation-graph work.
 | `OPENALEX_MAILTO` | OpenAlex | Joins the "polite pool" (a contact email) for faster, more reliable responses. | <https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication> |
 | `RCLONE_CONFIG_<REMOTE>_*` | Private dataset mirror | rclone remote credentials, handed to rclone as scoped env vars (no config file needed). | Per your rclone remote (see `rclone config`). |
 
-Honest Scholar keeps keys in a **CLI-managed JSON store** at
-`.honest-scholar/keys.json` — never a `.env` — and reads them with
-**`os.environ` > store > unset** precedence, so an environment variable always
-wins (CI / secrets injection is unaffected) and an unset key just degrades the
-service. Manage the store with the `keys` command group:
+Honest Scholar keeps keys in a **CLI-managed JSON store** — never a `.env` — at
+an XDG config path **outside any repo's work tree**:
+`$XDG_CONFIG_HOME/honest-scholar/keys.json`, falling back to
+`~/.config/honest-scholar/keys.json` (ADR-0032). A stored key can therefore
+never be committed by accident. Keys are read with **`os.environ` > store >
+unset** precedence, so an environment variable always wins (CI / secrets
+injection is unaffected) and an unset key just degrades the service. Manage
+the store with the `keys` command group:
 
 ```
 honest-scholar keys set S2_API_KEY        # prompts hidden, or reads piped stdin
@@ -355,11 +358,16 @@ prompt — so a secret never lands in your shell history or the process list.
 `keys list`/`check` and `doctor` report only **presence and source**, never a
 value.
 
+Set `HONEST_SCHOLAR_KEYS_PATH` to opt into a different location, e.g. the
+legacy in-repo `.honest-scholar/keys.json` — `research-init` still gitignores
+that path for anyone who does — but the store then warns (never silently) if
+the resolved path sits in a git work tree and is not confirmed gitignored.
+
 > **Honesty caveat — plaintext at rest.** The store is **not encrypted**.
-> Gitignore (`.honest-scholar/keys.json` is ignored) and `0600` file permissions
-> limit exposure, but anyone who can read the file reads the keys. Treat it as
-> convenience storage, not a secret vault. OS-keychain backing behind the same
-> `keys` interface is a planned follow-up (issue #49).
+> Living outside the repo (or being gitignored + `0600` file permissions when
+> opted in) limits exposure, but anyone who can read the file reads the keys.
+> Treat it as convenience storage, not a secret vault. OS-keychain backing
+> behind the same `keys` interface is a planned follow-up (issue #49).
 
 ## 9. Everyday tips
 

--- a/honest-scholar/honest_scholar/cli.py
+++ b/honest-scholar/honest_scholar/cli.py
@@ -933,6 +933,26 @@ def _warn_unknown(name: str) -> None:
         typer.echo(f"warning: {name!r} is not a known key; storing it anyway", err=True)
 
 
+def _warn_if_store_committable() -> None:
+    """Warn on stderr when the resolved store sits in a non-gitignored repo.
+
+    Defense-in-depth (honest-scholar#66, ADR-0032): the default store lives
+    outside any repo, but anyone who opts into :envvar:`STORE_PATH_ENV` — e.g.
+    the legacy in-repo location — could otherwise commit a secret file without
+    noticing. Warns and continues; the out-of-repo default is the real fix, so
+    this never refuses.
+    """
+    resolved = keys_mod.store_path()
+    if keys_mod.store_at_risk(resolved):
+        typer.echo(
+            f"warning: the key store at {resolved} is inside a git work tree and "
+            "does not appear to be gitignored — a stored key here is committable; "
+            "gitignore it, or unset "
+            f"{keys_mod.STORE_PATH_ENV} to use the default out-of-repo store",
+            err=True,
+        )
+
+
 def _set_many(blob: dict[str, object]) -> None:
     """Set every entry of a piped JSON object; never echoes a value.
 
@@ -942,6 +962,7 @@ def _set_many(blob: dict[str, object]) -> None:
     if not blob:
         typer.echo("keys set: the JSON object is empty", err=True)
         raise typer.Exit(code=2)
+    _warn_if_store_committable()
     for name, value in blob.items():
         if not isinstance(value, str):
             typer.echo(f"keys set: value for {name!r} must be a string", err=True)
@@ -985,6 +1006,7 @@ def set_(
     if not value:
         typer.echo(f"keys set: empty value for {name}", err=True)
         raise typer.Exit(code=2)
+    _warn_if_store_committable()
     _warn_unknown(name)
     keys_mod.set_key(name, value)
     typer.echo(f"stored {name} (source: store)")

--- a/honest-scholar/honest_scholar/core/keys.py
+++ b/honest-scholar/honest_scholar/core/keys.py
@@ -1,41 +1,62 @@
-"""CLI-owned API-key store (ADR-0029).
+"""CLI-owned API-key store (ADR-0029, ADR-0032).
 
 A single, controlled place to store, read and check the service keys the tooling
 uses — Semantic Scholar (``S2_API_KEY``), the OpenAlex polite pool
 (``OPENALEX_MAILTO``) and private rclone-mirror credentials — without leaking a
 secret through shell history, ``argv`` or an over-broad always-present file.
 
-Design (ADR-0029):
+Design (ADR-0029, ADR-0032):
 
-- **Store.** A JSON object ``{name: value}`` at ``.honest-scholar/keys.json`` —
-  gitignored, created ``0600``. JSON (not ``.env``) because the CLI is the sole
-  reader/writer. Per-key *metadata* (service, how-to-obtain link, rate-limit
-  benefit) lives in the :data:`KNOWN_KEYS` registry — the single source of truth —
-  rather than being duplicated into every stored record.
+- **Store location.** A JSON object ``{name: value}`` at an **XDG config
+  location outside the repo** — ``$XDG_CONFIG_HOME/honest-scholar/keys.json``,
+  falling back to ``~/.config/honest-scholar/keys.json`` — created ``0600``, so a
+  stored secret can never be committed to a consumer repo's work tree
+  (ADR-0032). :envvar:`STORE_PATH_ENV` (``HONEST_SCHOLAR_KEYS_PATH``) is an
+  explicit opt-in override, e.g. to restore the legacy in-repo location at
+  :data:`IN_REPO_STORE_PATH` (``.honest-scholar/keys.json``, which
+  ``research-init`` still gitignores for anyone who opts in). JSON (not
+  ``.env``) because the CLI is the sole reader/writer. Per-key *metadata*
+  (service, how-to-obtain link, rate-limit benefit) lives in the
+  :data:`KNOWN_KEYS` registry — the single source of truth — rather than being
+  duplicated into every stored record.
 - **Precedence.** :func:`get` resolves ``os.environ`` **>** the store **>**
   ``None``, so an injected environment variable always wins (CI / secrets
   injection) and the service degrades gracefully when a key is unset.
 - **Least privilege.** :func:`scoped_env` / :func:`rclone_scoped_env` build an
   in-memory ``env`` dict holding *only* the secrets a given child process needs —
   never the whole store, never a file on the default path.
-- **Honesty.** The store is **plaintext at rest**. ``gitignore`` + ``0600`` limit
-  exposure but are *not* encryption; OS-keychain backing is the follow-up (#49).
-  Nothing in this module logs or echoes a value.
+- **Guardrail.** :func:`store_at_risk` flags a resolved store path that sits
+  inside a git work tree and is not confirmed gitignored — the CLI's ``keys
+  set`` warns (never silently) when that is the case, defense-in-depth for
+  anyone who opts into an in-repo store without gitignoring it.
+- **Honesty.** The store is **plaintext at rest**. Living outside the repo (or
+  being gitignored + ``0600`` when opted in) limits exposure but is *not*
+  encryption; OS-keychain backing is the follow-up (#49). Nothing in this
+  module logs or echoes a value.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import subprocess  # nosec B404 - used only for `git check-ignore`, fixed args
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
-#: The CLI-owned store path (relative to the project root / current directory).
-STORE_PATH = Path(".honest-scholar/keys.json")
+#: Explicit override for the resolved store path (honest-scholar#66) — set this
+#: to opt out of the XDG default, e.g. to the legacy in-repo
+#: :data:`IN_REPO_STORE_PATH`.
+STORE_PATH_ENV = "HONEST_SCHOLAR_KEYS_PATH"
+
+#: The legacy in-repo store location. No longer the default (ADR-0032), but
+#: still supported via :data:`STORE_PATH_ENV` and still gitignored by
+#: ``research-init`` for anyone who opts in.
+IN_REPO_STORE_PATH = Path(".honest-scholar/keys.json")
 
 #: Prefix for rclone remote-config credentials handed to the rclone subprocess as
 #: ``RCLONE_CONFIG_<REMOTE>_<PARAM>`` environment variables (no config file).
@@ -93,13 +114,45 @@ def is_known(name: str) -> bool:
     return name in KNOWN_KEYS or name.startswith(RCLONE_ENV_PREFIX)
 
 
-def store_path(path: str | Path | None = None) -> Path:
-    """Resolve the store path, defaulting to :data:`STORE_PATH`.
+def xdg_config_home() -> Path:
+    """Return the XDG config-home directory (``$XDG_CONFIG_HOME`` or ``~/.config``).
 
-    :param path: An explicit override; ``None`` uses the default store path.
+    :returns: The resolved XDG config-home directory (per the XDG Base
+        Directory spec — not created; callers create it as needed).
+    """
+    override = os.environ.get("XDG_CONFIG_HOME")
+    if override:
+        return Path(override)
+    return Path.home() / ".config"
+
+
+def default_store_path() -> Path:
+    """Return the default, out-of-the-repo store path (ADR-0032).
+
+    :returns: ``$XDG_CONFIG_HOME/honest-scholar/keys.json`` (or the
+        ``~/.config`` fallback) — outside any consumer repo's work tree, so a
+        stored key is never committable by default (honest-scholar#66).
+    """
+    return xdg_config_home() / "honest-scholar" / "keys.json"
+
+
+def store_path(path: str | Path | None = None) -> Path:
+    """Resolve the store path.
+
+    Resolution order: an explicit `path` argument, then
+    :data:`STORE_PATH_ENV` (an explicit opt-in override, e.g. to
+    :data:`IN_REPO_STORE_PATH`), then the out-of-repo :func:`default_store_path`
+    (ADR-0032).
+
+    :param path: An explicit override; ``None`` consults the environment/default.
     :returns: The path the store is read from / written to.
     """
-    return Path(path) if path is not None else STORE_PATH
+    if path is not None:
+        return Path(path)
+    env_override = os.environ.get(STORE_PATH_ENV)
+    if env_override:
+        return Path(env_override)
+    return default_store_path()
 
 
 def load_store(path: str | Path | None = None) -> dict[str, str]:
@@ -108,7 +161,7 @@ def load_store(path: str | Path | None = None) -> dict[str, str]:
     A missing store yields an empty mapping rather than an error, so callers can
     treat an unconfigured project as "no stored keys".
 
-    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :param path: Store path override; defaults to the resolved :func:`store_path`.
     :returns: The stored ``{name: value}`` pairs (empty if the file is absent).
     :raises ValueError: If the file exists but is not a JSON object of strings.
     """
@@ -140,7 +193,7 @@ def write_store(mapping: Mapping[str, str], path: str | Path | None = None) -> N
     is not encryption; see the module docstring).
 
     :param mapping: The ``{name: value}`` pairs to persist.
-    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :param path: Store path override; defaults to the resolved :func:`store_path`.
     """
     resolved = store_path(path)
     resolved.parent.mkdir(parents=True, exist_ok=True)
@@ -154,7 +207,7 @@ def set_key(name: str, value: str, path: str | Path | None = None) -> None:
 
     :param name: The key name.
     :param value: The secret value (never logged or echoed).
-    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :param path: Store path override; defaults to the resolved :func:`store_path`.
     """
     store = load_store(path)
     store[name] = value
@@ -165,7 +218,7 @@ def unset_key(name: str, path: str | Path | None = None) -> bool:
     """Remove a key from the store.
 
     :param name: The key name to remove.
-    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :param path: Store path override; defaults to the resolved :func:`store_path`.
     :returns: ``True`` if the key was present and removed, ``False`` if absent.
     """
     store = load_store(path)
@@ -190,7 +243,7 @@ def get(
     """Resolve a key value with ``os.environ`` > store > ``None`` precedence.
 
     :param name: The key name.
-    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :param path: Store path override; defaults to the resolved :func:`store_path`.
     :param environ: Environment mapping override (for tests); defaults to
         :data:`os.environ`.
     :returns: The resolved value, or ``None`` if unset in both sources.
@@ -210,7 +263,7 @@ def source_of(
     """Report *where* a key would resolve from — without exposing its value.
 
     :param name: The key name.
-    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :param path: Store path override; defaults to the resolved :func:`store_path`.
     :param environ: Environment mapping override; defaults to :data:`os.environ`.
     :returns: ``"env"`` if an environment variable would win, ``"store"`` if the
         store would supply it, or ``None`` if it is unset everywhere.
@@ -236,7 +289,7 @@ def scoped_env(
     from the store.
 
     :param names: The key names the job is allowed to see.
-    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :param path: Store path override; defaults to the resolved :func:`store_path`.
     :param environ: Environment mapping override; defaults to :data:`os.environ`.
     :returns: A ``{name: value}`` dict of the present requested secrets.
     """
@@ -275,7 +328,7 @@ def rclone_scoped_env(
     credentials are stored for the remote (a ``rclone.conf`` may still cover it).
 
     :param remote: The rclone remote name.
-    :param path: Store path override; defaults to :data:`STORE_PATH`.
+    :param path: Store path override; defaults to the resolved :func:`store_path`.
     :param environ: Environment mapping override; defaults to :data:`os.environ`.
     :returns: A ``{RCLONE_CONFIG_<REMOTE>_<PARAM>: value}`` dict.
     """
@@ -286,3 +339,88 @@ def rclone_scoped_env(
         if name.startswith(prefix)
     }
     return scoped_env(sorted(candidates), path=path, environ=environ)
+
+
+# --- guardrail: warn on a committable in-repo store (honest-scholar#66) -----
+
+
+class _GitProc(Protocol):
+    """The minimal completed-process shape a git runner must return."""
+
+    returncode: int
+
+
+#: A ``git`` subprocess runner with the ``subprocess.run`` shape (injectable
+#: for tests, mirroring :data:`honest_scholar.dataset.retrieval.Runner`).
+GitRunner = Callable[..., _GitProc]
+
+
+def _git_root_for(path: Path) -> Path | None:
+    """Walk upward from `path`'s parent looking for a ``.git`` entry.
+
+    :param path: The (needn't exist) path to check; only its ancestry matters.
+    :returns: The git work-tree root directory, or ``None`` if none is found.
+    """
+    start = path.resolve().parent
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def is_gitignored(
+    path: str | Path,
+    *,
+    cwd: str | Path | None = None,
+    run: GitRunner = subprocess.run,
+) -> bool | None:
+    """Return whether `path` is covered by a gitignore rule.
+
+    Delegates to ``git check-ignore``, the same mechanism the issue's own
+    reproduction used, rather than reimplementing gitignore-pattern matching.
+
+    :param path: The path to check.
+    :param cwd: The directory to run ``git`` in — pass the target repo's root
+        so the check uses *that* repository regardless of the caller's actual
+        working directory; ``None`` inherits the current process's cwd.
+    :param run: The subprocess runner (defaults to :func:`subprocess.run`;
+        injectable so tests never need a real ``git`` binary).
+    :returns: ``True``/``False`` if git could answer conclusively, or ``None``
+        if git is unavailable or the answer is inconclusive (e.g. not inside a
+        git repository at all).
+    """
+    try:
+        proc = run(  # nosec B603 - fixed git args, no shell
+            ["git", "check-ignore", "-q", str(path)],
+            capture_output=True,
+            check=False,
+            cwd=str(cwd) if cwd is not None else None,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode in (0, 1):
+        return proc.returncode == 0
+    return None
+
+
+def store_at_risk(path: str | Path, *, run: GitRunner = subprocess.run) -> bool:
+    """Return whether `path` is a committable secret store (honest-scholar#66).
+
+    A resolved store path is "at risk" when it sits inside a git work tree and
+    is not *confirmed* gitignored — including when git cannot confirm either
+    way (no news is not good news for a secret). Used as the ``keys set``
+    guardrail: a warning, not a refusal, since the out-of-repo default already
+    keeps a fresh setup safe (ADR-0032) and this only fires for an explicit
+    opt-in.
+
+    :param path: The resolved store path to check.
+    :param run: Injectable subprocess runner for ``git check-ignore``.
+    :returns: ``True`` if `path` is inside a git work tree and not confirmed
+        ignored; ``False`` if it is outside any work tree, or inside one and
+        confirmed ignored.
+    """
+    resolved = Path(path)
+    root = _git_root_for(resolved)
+    if root is None:
+        return False
+    return is_gitignored(resolved, cwd=root, run=run) is not True

--- a/honest-scholar/tests/conftest.py
+++ b/honest-scholar/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Shared, hermetic test fixtures.
+
+Nothing here is test-specific logic — only environment guards so the suite
+never touches a real developer's home directory.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _isolated_xdg_config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point ``HOME``/``XDG_CONFIG_HOME`` at a throwaway directory for every test.
+
+    The key store now defaults to an XDG config location outside any repo
+    (honest-scholar#66, ADR-0032) — resolved from ``$XDG_CONFIG_HOME`` or
+    ``~/.config`` when a test does not pass an explicit store path. Without this
+    guard, any test that exercises that default path (directly via
+    ``honest_scholar.core.keys``, or indirectly via the ``keys``/``doctor``/
+    ``literature`` CLI commands) would read or write a real developer's
+    ``~/.config/honest-scholar/keys.json``. Every test gets its own empty,
+    disposable ``$XDG_CONFIG_HOME`` instead.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(fake_home / ".config"))
+    monkeypatch.delenv("HONEST_SCHOLAR_KEYS_PATH", raising=False)

--- a/honest-scholar/tests/test_keys.py
+++ b/honest-scholar/tests/test_keys.py
@@ -1,15 +1,20 @@
-"""Tests for the CLI-owned API-key store and the ``keys`` command group (#42).
+"""Tests for the CLI-owned API-key store and the ``keys`` command group (#42, #66).
 
 Deterministic throughout: the store path is a ``tmp_path`` (module tests) or the
 CLI's cwd via ``monkeypatch.chdir``; the environment is driven with
 ``monkeypatch``; stdin is fed via ``CliRunner(input=...)``. No test ever asserts a
-secret *value* appears in output — only presence/absence and source.
+secret *value* appears in output — only presence/absence and source. The
+``tests/conftest.py`` autouse fixture points ``HOME``/``XDG_CONFIG_HOME`` at a
+throwaway directory for every test, so the new out-of-repo default store path
+(ADR-0032) never touches a real developer's home directory.
 """
 
 from __future__ import annotations
 
 import json
 import stat
+import subprocess
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
@@ -38,9 +43,52 @@ def test_is_known_registry_rclone_and_unknown() -> None:
 
 
 def test_store_path_default_and_override(tmp_path: Path) -> None:
-    assert keys_mod.store_path() == keys_mod.STORE_PATH
+    assert keys_mod.store_path() == keys_mod.default_store_path()
     override = tmp_path / "k.json"
     assert keys_mod.store_path(override) == override
+
+
+# --- default store location: XDG, outside the repo (honest-scholar#66) ------
+
+
+def test_xdg_config_home_uses_env_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    xdg = tmp_path / "xdg-config"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    assert keys_mod.xdg_config_home() == xdg
+
+
+def test_xdg_config_home_falls_back_to_dot_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert keys_mod.xdg_config_home() == tmp_path / ".config"
+
+
+def test_default_store_path_is_xdg_honest_scholar_keys_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    xdg = tmp_path / "xdg-config"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    assert keys_mod.default_store_path() == xdg / "honest-scholar" / "keys.json"
+
+
+def test_store_path_env_override_wins_over_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    in_repo = tmp_path / ".honest-scholar" / "keys.json"
+    monkeypatch.setenv(keys_mod.STORE_PATH_ENV, str(in_repo))
+    assert keys_mod.store_path() == in_repo
+
+
+def test_store_path_explicit_arg_wins_over_env_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(keys_mod.STORE_PATH_ENV, str(tmp_path / "env.json"))
+    explicit = tmp_path / "explicit.json"
+    assert keys_mod.store_path(explicit) == explicit
 
 
 def test_missing_store_is_empty(tmp_path: Path) -> None:
@@ -172,6 +220,93 @@ def test_rclone_scoped_env_is_per_remote(tmp_path: Path) -> None:
     assert scoped_env_only["RCLONE_CONFIG_STORE_TOKEN"] == "fake-token"
 
 
+# --- guardrail: committable in-repo store (honest-scholar#66) ---------------
+
+
+def _fake_run(returncode: int) -> keys_mod.GitRunner:
+    """Build a fake ``git`` runner that always returns `returncode`."""
+
+    def _run(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(returncode=returncode)
+
+    return _run
+
+
+def _raising_run(*_args: object, **_kwargs: object) -> SimpleNamespace:
+    raise FileNotFoundError("git not found")
+
+
+def test_git_root_for_finds_ancestor_dot_git(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    nested = tmp_path / "a" / "b" / "keys.json"
+    assert keys_mod._git_root_for(nested) == tmp_path.resolve()
+
+
+def test_git_root_for_none_outside_a_work_tree(tmp_path: Path) -> None:
+    assert keys_mod._git_root_for(tmp_path / "keys.json") is None
+
+
+def test_is_gitignored_true_false_and_inconclusive() -> None:
+    assert keys_mod.is_gitignored("x", run=_fake_run(0)) is True
+    assert keys_mod.is_gitignored("x", run=_fake_run(1)) is False
+    assert keys_mod.is_gitignored("x", run=_fake_run(128)) is None
+
+
+def test_is_gitignored_none_when_git_binary_missing() -> None:
+    assert keys_mod.is_gitignored("x", run=_raising_run) is None
+
+
+def test_store_at_risk_false_outside_a_work_tree(tmp_path: Path) -> None:
+    assert keys_mod.store_at_risk(tmp_path / "keys.json", run=_fake_run(0)) is False
+
+
+def test_store_at_risk_false_when_confirmed_ignored(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    path = tmp_path / ".honest-scholar" / "keys.json"
+    assert keys_mod.store_at_risk(path, run=_fake_run(0)) is False
+
+
+def test_store_at_risk_true_when_not_ignored(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    path = tmp_path / ".honest-scholar" / "keys.json"
+    assert keys_mod.store_at_risk(path, run=_fake_run(1)) is True
+
+
+def test_store_at_risk_true_when_inconclusive(tmp_path: Path) -> None:
+    (tmp_path / ".git").mkdir()
+    path = tmp_path / ".honest-scholar" / "keys.json"
+    assert keys_mod.store_at_risk(path, run=_fake_run(128)) is True
+
+
+def test_store_at_risk_runs_git_in_the_repo_root(tmp_path: Path) -> None:
+    # Regression guard: `git check-ignore` must run in the *target* repo's
+    # root, not the caller's actual cwd, or the check silently uses the wrong
+    # repository when `keys set` is invoked from elsewhere.
+    (tmp_path / ".git").mkdir()
+    path = tmp_path / "nested" / ".honest-scholar" / "keys.json"
+    seen: dict[str, object] = {}
+
+    def _run(*args: object, **kwargs: object) -> SimpleNamespace:
+        seen["cwd"] = kwargs.get("cwd")
+        return SimpleNamespace(returncode=0)
+
+    keys_mod.store_at_risk(path, run=_run)
+    assert seen["cwd"] == str(tmp_path.resolve())
+
+
+def test_store_at_risk_real_git_matches_check_ignore(tmp_path: Path) -> None:
+    """End-to-end with the real ``git`` binary — the issue's own reproduction."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)  # nosec B603 B607
+    path = tmp_path / ".honest-scholar" / "keys.json"
+    # not yet gitignored -> committable
+    assert keys_mod.store_at_risk(path) is True
+    (tmp_path / ".gitignore").write_text(
+        ".honest-scholar/keys.json\n", encoding="utf-8"
+    )
+    # gitignored -> no longer at risk
+    assert keys_mod.store_at_risk(path) is False
+
+
 # --- keys CLI group ---------------------------------------------------------
 
 
@@ -183,6 +318,33 @@ def test_set_single_via_stdin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     assert keys_mod.load_store() == {
         "S2_API_KEY": "fake-s2-key"  # pragma: allowlist secret
     }
+    # the default (out-of-repo) store never triggers the committable warning
+    assert "committable" not in result.stderr
+
+
+def test_set_warns_when_resolved_store_is_committable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(keys_mod, "store_at_risk", lambda *_a, **_k: True)
+    result = runner.invoke(app, ["keys", "set", "S2_API_KEY"], input="v\n")
+    assert result.exit_code == 0
+    assert "committable" in result.stderr
+    assert keys_mod.STORE_PATH_ENV in result.stderr
+    # still stores the value — this is a warning, never a refusal
+    assert keys_mod.load_store() == {"S2_API_KEY": "v"}
+
+
+def test_set_many_warns_when_resolved_store_is_committable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(keys_mod, "store_at_risk", lambda *_a, **_k: True)
+    blob = json.dumps({"S2_API_KEY": "a"})
+    result = runner.invoke(app, ["keys", "set"], input=blob)
+    assert result.exit_code == 0
+    assert "committable" in result.stderr
+    assert keys_mod.load_store() == {"S2_API_KEY": "a"}
 
 
 def test_set_numeric_value_is_not_treated_as_json(
@@ -338,7 +500,17 @@ def test_unset_present_then_absent(
 def test_path_prints_store_path() -> None:
     result = runner.invoke(app, ["keys", "path"])
     assert result.exit_code == 0
-    assert result.stdout.strip() == str(keys_mod.STORE_PATH)
+    assert result.stdout.strip() == str(keys_mod.default_store_path())
+
+
+def test_path_prints_in_repo_override_when_opted_in(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    in_repo = tmp_path / ".honest-scholar" / "keys.json"
+    monkeypatch.setenv(keys_mod.STORE_PATH_ENV, str(in_repo))
+    result = runner.invoke(app, ["keys", "path"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == str(in_repo)
 
 
 # --- integration: doctor + _lit_client --------------------------------------

--- a/skills/research-init/SKILL.md
+++ b/skills/research-init/SKILL.md
@@ -70,6 +70,8 @@ datasets.yml                     # dataset registry (entries + checksums + tiers
   cache/                         # gitignored materialized data + HTTP cache (path from config.yml `cache_dir:`)
   rclone.conf.example            # committed template (remote name/type only)
   rclone.conf                    # gitignored (credentials)
+  # keys.json is NOT scaffolded here — `honest-scholar keys` stores API keys
+  # outside the repo by default (ADR-0032); see the note below.
 ```
 
 Registries are created **empty but valid** (a parseable `papers.md`,
@@ -87,7 +89,17 @@ contract), the **engineering-backend binding** (`engineering_backend:` — the
 ADR-0023), and the **cache directory** (`cache_dir:`, default `.honest-scholar/cache/`
 — the CLI's dataset + HTTP caches always live under exactly this path;
 [ADR-0031](../../decisions/0031-config-driven-cache-dir.md)). `.gitignore` is
-updated to exclude the configured `cache_dir:` path and `.honest-scholar/rclone.conf`.
+updated to exclude the configured `cache_dir:` path, `.honest-scholar/rclone.conf`,
+and (defense-in-depth) `.honest-scholar/keys.json`.
+
+**API keys never enter the repo by default.** `honest-scholar keys set` (ADR-0029)
+stores credentials at an XDG config path outside the repo's work tree —
+`$XDG_CONFIG_HOME/honest-scholar/keys.json`, falling back to
+`~/.config/honest-scholar/keys.json` — never at a path this skill scaffolds
+(ADR-0032, honest-scholar#66). An author can opt into the legacy in-repo path
+(`HONEST_SCHOLAR_KEYS_PATH=.honest-scholar/keys.json`), which is why the
+`.gitignore` entry above still exists; `keys set` also warns if the resolved
+store ever sits in a git work tree without being gitignored.
 
 The `thesis/` tree is optional — scaffold it only when the repo is a
 thesis-by-publication; a plain portfolio repo omits the top level.


### PR DESCRIPTION
## Summary

- `honest-scholar keys` stored credentials at `.honest-scholar/keys.json` — inside the consumer repo's work tree — but `research-init` never added it to `.gitignore`, so a stored key was one missed scaffolding step from being committable (found onboarding `davorrunje/mononet`).
- The store now defaults to an XDG config location **outside any repo**: `$XDG_CONFIG_HOME/honest-scholar/keys.json`, falling back to `~/.config/honest-scholar/keys.json`.
- The legacy in-repo path (`.honest-scholar/keys.json`) is preserved as an explicit `HONEST_SCHOLAR_KEYS_PATH` opt-in; `research-init`'s scaffolded `.gitignore` still excludes it as defense-in-depth.
- `keys set` now warns (never refuses) when the resolved store sits inside a git work tree and is not confirmed gitignored (`keys.store_at_risk`, backed by `git check-ignore` run in the target repo's root).
- Added ADR-0031 documenting the decision and refining ADR-0029; updated `docs/USER-GUIDE.md` and `skills/research-init/SKILL.md`.

## Test plan

- [x] `uv run pytest -q` — 278 passed, 14 skipped (opt-in live tests unaffected), 100% statement+branch coverage across the package (the coverage gate, `fail_under = 100`, is enforced).
- [x] `uv run ruff check` / `uv run ruff format --check` — clean.
- [x] `uv run mypy` — clean.
- [x] `./tools/validate-plugin.sh` — passes (touched `skills/research-init/SKILL.md`).
- [x] `uvx codespell` on changed files — clean.
- [x] New `tests/conftest.py` autouse fixture isolates `HOME`/`XDG_CONFIG_HOME` per test so the suite never touches a real developer's home directory.
- [x] Manual acceptance check against the issue's own reproduction: `test_store_at_risk_real_git_matches_check_ignore` runs a real `git init` + `git check-ignore` round-trip (committable before a `.gitignore` entry, not-at-risk after).

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)
