### PR TITLE
dx(tools): type-clean build_docs_site.py and keep tools/ under lint

### DIFF
--- a/honest-scholar/pyproject.toml
+++ b/honest-scholar/pyproject.toml
@@ -73,7 +73,10 @@ include = ["honest_scholar"]
 include = ["honest_scholar"]
 
 [tool.mypy]
-files = ["honest_scholar", "tests"]
+# `../tools` covers the maintainer build tooling (e.g. `build_docs_site.py`) so
+# it stays type-checked even though it's outside the shipped package/coverage
+# gate (see issue #56).
+files = ["honest_scholar", "tests", "../tools"]
 strict = true
 strict_bytes = true
 local_partial_types = true
@@ -123,6 +126,7 @@ include = [
     "honest_scholar/**/*.py",
     "tests/**/*.py",
     "pyproject.toml",
+    "../tools/*.py",
 ]
 
 [tool.ruff.lint]
@@ -166,6 +170,12 @@ ignore = [
     "PLR2004",  # magic-value-comparison
     "S101",     # use assert
     "N806",     # uppercase variable names
+]
+"../tools/*.py" = [
+    "T20",      # flake8-print — a build/maintainer CLI tool; print() is its output, not debug noise
+    "C901",     # mccabe complexity — the CLI-reference tree walker is a small, tested recursive
+                # renderer just over the threshold; splitting it further would hurt readability
+    "PERF401",  # flake8-perf list.extend suggestions — pre-existing, purely stylistic
 ]
 
 [tool.ruff.lint.isort]

--- a/tools/build_docs_site.py
+++ b/tools/build_docs_site.py
@@ -44,6 +44,14 @@ import re
 import shutil
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Real Click/Typer types for the CLI-reference walker below. Typer 0.27
+    # vendors Click at ``typer._click`` (there is no standalone ``click``
+    # dependency to import), and implements command *grouping* itself via
+    # ``typer.core.TyperGroup`` rather than a vendored ``click.Group``.
+    from typer._click.core import Command, Context, Parameter
 
 # --- constants -------------------------------------------------------------------
 
@@ -153,7 +161,7 @@ def plan() -> tuple[dict[str, str | None], dict[str, object]]:
     ]
     reg("disclosure", "DISCLOSURE.md")
 
-    navigation = {
+    navigation: dict[str, object] = {
         "groups": [
             {"group": "Overview", "pages": ["index"]},
             {"group": "Get started", "pages": ["get-started/user-guide"]},
@@ -178,15 +186,24 @@ def _routes_in_nav(navigation: dict[str, object]) -> list[str]:
     """Flatten every page route referenced by the navigation tree, in order."""
     out: list[str] = []
 
-    def walk(pages: list[object]) -> None:
+    def walk(pages: object) -> None:
+        # `pages` is always a list by construction (see `plan()`) — narrow with
+        # isinstance rather than a blanket ignore so a genuine shape bug still
+        # surfaces as an AssertionError instead of being silently swallowed.
+        assert isinstance(pages, list), f"expected a list of nav entries, got {pages!r}"
         for entry in pages:
             if isinstance(entry, str):
                 out.append(entry)
             elif isinstance(entry, dict):
-                walk(entry["pages"])  # type: ignore[arg-type]
+                walk(entry["pages"])
 
-    for group in navigation["groups"]:  # type: ignore[index]
-        walk(group["pages"])  # type: ignore[index]
+    groups = navigation["groups"]
+    assert isinstance(groups, list), (
+        f"expected navigation['groups'] to be a list, got {groups!r}"
+    )
+    for group in groups:
+        assert isinstance(group, dict), f"expected a nav group dict, got {group!r}"
+        walk(group["pages"])
     return out
 
 
@@ -440,9 +457,8 @@ def _resolve_target(
     :returns: ``(new_target, error)`` — `error` is set only for a link that points
         at a repository path which does not exist.
     """
-    if (
-        target.startswith(("#", "/", "//", "mailto:"))
-        or re.match(r"^[a-z][a-z0-9+.-]*://", target)
+    if target.startswith(("#", "/", "//", "mailto:")) or re.match(
+        r"^[a-z][a-z0-9+.-]*://", target
     ):
         return target, None
 
@@ -451,9 +467,7 @@ def _resolve_target(
     if not path_part:
         return target, None
 
-    resolved = posixpath.normpath(
-        posixpath.join(posixpath.dirname(source), path_part)
-    )
+    resolved = posixpath.normpath(posixpath.join(posixpath.dirname(source), path_part))
     key = resolved.rstrip("/")
 
     if key in route_map:
@@ -518,7 +532,7 @@ def _cell(text: str) -> str:
     return " ".join((text or "").split()).replace("|", "\\|") or "—"
 
 
-def _default_cell(param: object) -> str:
+def _default_cell(param: Parameter) -> str:
     """Render an option's default value for a table cell."""
     default = getattr(param, "default", None)
     if getattr(param, "is_flag", False):
@@ -528,11 +542,20 @@ def _default_cell(param: object) -> str:
     return f"`{default}`"
 
 
-def _render_command(cmd: object, ctx_cls: type, parent_ctx: object, path: list[str]) -> str:
+def _render_command(
+    cmd: Command, ctx_cls: type[Context], parent_ctx: Context | None, path: list[str]
+) -> str:
     """Render one Typer/Click command (or group) to a markdown section."""
+    # Local import: `generate_cli_reference` already imports `honest_scholar`/typer
+    # lazily so the rest of this module works without either installed; mirror
+    # that here rather than importing typer unconditionally at module scope.
+    from typer.core import TyperGroup
+
     ctx = ctx_cls(cmd, info_name=path[-1], parent=parent_ctx)
-    is_group = hasattr(cmd, "list_commands") and hasattr(cmd, "get_command")
-    params = [p for p in cmd.get_params(ctx) if getattr(p, "name", None) != "help"]
+    is_group = isinstance(cmd, TyperGroup)
+    params: list[Parameter] = [
+        p for p in cmd.get_params(ctx) if getattr(p, "name", None) != "help"
+    ]
     arguments = [p for p in params if getattr(p, "param_type_name", "") == "argument"]
     options = [p for p in params if getattr(p, "param_type_name", "") == "option"]
 
@@ -572,8 +595,15 @@ def _render_command(cmd: object, ctx_cls: type, parent_ctx: object, path: list[s
         parts.append("")
 
     if is_group:
+        # `is_group` is exactly `isinstance(cmd, TyperGroup)`, but that narrowing
+        # doesn't survive the assignment above — re-assert it here so mypy knows
+        # `cmd` has `list_commands`/`get_command` (real `TyperGroup`-only methods).
+        assert isinstance(cmd, TyperGroup)
         for name in cmd.list_commands(ctx):
             sub = cmd.get_command(ctx, name)
+            # `get_command` is `dict.get` under the hood; `name` always comes from
+            # this same `commands` mapping via `list_commands`, so it is never None.
+            assert sub is not None, f"list_commands returned unknown command {name!r}"
             parts.append(_render_command(sub, ctx_cls, ctx, [*path, name]))
 
     return "\n".join(parts)
@@ -583,6 +613,7 @@ def generate_cli_reference() -> str:
     """Render the ``honest-scholar`` Typer command tree to markdown."""
     import typer
     from typer._click.core import Context
+    from typer.core import TyperGroup
 
     from honest_scholar.cli import app
 
@@ -599,8 +630,13 @@ def generate_cli_reference() -> str:
         "build, so it always matches the released CLI.",
         "",
     ]
+    if not isinstance(
+        root, TyperGroup
+    ):  # pragma: no cover - the app always has >1 command
+        raise BuildError("honest-scholar CLI root is not a command group")
     for name in root.list_commands(root_ctx):
         sub = root.get_command(root_ctx, name)
+        assert sub is not None, f"list_commands returned unknown command {name!r}"
         body.append(_render_command(sub, Context, root_ctx, ["honest-scholar", name]))
     return "\n".join(body)
 
@@ -621,7 +657,9 @@ def build_page(
         title = "CLI reference"
         description = "The honest-scholar command tree, generated from the Typer app."
         raw = generate_cli_reference()
-        body = rewrite_links(raw, "docs/USER-GUIDE.md", route_map, routes, errors, site_links)
+        body = rewrite_links(
+            raw, "docs/USER-GUIDE.md", route_map, routes, errors, site_links
+        )
         return frontmatter(title, description) + "\n" + mdx_safe(body).strip() + "\n"
 
     text = (REPO_ROOT / source).read_text(encoding="utf-8")
@@ -654,7 +692,9 @@ def build_page(
         body = strip_leading_h1(body)
 
     body = rewrite_links(body, source, route_map, routes, errors, site_links)
-    return frontmatter(title, description or None) + "\n" + mdx_safe(body).strip() + "\n"
+    return (
+        frontmatter(title, description or None) + "\n" + mdx_safe(body).strip() + "\n"
+    )
 
 
 def build_docs_json(navigation: dict[str, object]) -> dict[str, object]:
@@ -686,7 +726,9 @@ def build(out: Path) -> dict[str, int]:
     if set(nav_routes) != set(sources):
         missing = set(sources) - set(nav_routes)
         extra = set(nav_routes) - set(sources)
-        raise BuildError(f"navigation/pages mismatch (missing={missing}, extra={extra})")
+        raise BuildError(
+            f"navigation/pages mismatch (missing={missing}, extra={extra})"
+        )
 
     route_map = {src: route for route, src in sources.items() if src}
     routes = set(sources)
@@ -731,9 +773,13 @@ def build(out: Path) -> dict[str, int]:
             f"{len(errors)} link error(s):\n  - " + "\n  - ".join(sorted(errors))
         )
 
+    nav_groups = navigation["groups"]
+    assert isinstance(nav_groups, list), (
+        f"expected navigation['groups'] to be a list, got {nav_groups!r}"
+    )
     return {
         "pages": len(sources),
-        "groups": len(navigation["groups"]),  # type: ignore[arg-type]
+        "groups": len(nav_groups),
         "site_links": len(site_links),
     }
 

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -89,9 +89,7 @@ def bump(current: str, release: str, pre: str) -> str:
         phase, num = None, 0
     elif pre in _PRE_TO_PHASE:
         target = _PRE_TO_PHASE[pre]
-        if phase is None:
-            phase, num = target, 0
-        elif _PHASES.index(phase) < _PHASES.index(target):
+        if phase is None or _PHASES.index(phase) < _PHASES.index(target):
             phase, num = target, 0
         elif phase == target:
             num += 1

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -2,10 +2,16 @@
 set -euo pipefail
 
 # Lint the honest-scholar package with ruff (check + format verification).
+# `../tools` (the maintainer build tooling, e.g. `build_docs_site.py`) is
+# checked explicitly too: ruff's `include` glob in pyproject.toml only
+# *filters* files already discovered under its target path(s) — it does not
+# expand discovery outside the directory `ruff check .` was pointed at — so
+# `tools/` must be passed as an extra path for it to actually be scanned
+# (see issue #56).
 cd "$(dirname "$0")/../honest-scholar"
 
 echo "Running ruff linter..."
-uv run ruff check .
+uv run ruff check . ../tools
 
 echo "Running ruff formatter (check only)..."
-uv run ruff format --check .
+uv run ruff format --check . ../tools


### PR DESCRIPTION
## What

`tools/build_docs_site.py` type-checks with zero mypy errors and stays
that way: `tools/` is now covered by both mypy and ruff, closing the gap
where the maintainer build tool silently drifted out of the type/lint
gate.

## Details

- **CLI-reference walker**: walks the real `typer._click.core`
  `Command`/`Context`/`Parameter` types instead of `object`, and narrows
  group-vs-leaf commands with `isinstance(cmd, typer.core.TyperGroup)`.
  Typer 0.27 has no standalone `click` dependency to `import click`
  against (as the issue proposed) — it vendors Click's core types at
  `typer._click.core` and implements command *grouping* itself via
  `typer.core.TyperGroup`, not a vendored `click.Group`. `list_commands`/
  `get_command`/`get_params` are all real, typed methods once narrowed.
- **`plan()` return-value mismatch**: the `navigation` dict is now
  explicitly annotated `dict[str, object]` so it matches the declared
  return type — no shape change, just an honest annotation.
- **Remaining `# type: ignore`s** in `_routes_in_nav`/`build()` replaced
  with `isinstance`/`assert` narrowing (real typing, not suppression).
- **Scope going forward**: `tools/` was added to `[tool.mypy] files`
  and to ruff's `include` in `honest-scholar/pyproject.toml`. Note ruff's
  `include` glob only *filters* files already discovered under the path(s)
  passed on the command line — it doesn't expand discovery outside them —
  so `tools/lint.sh` now passes `../tools` explicitly alongside `.` for
  both `ruff check` and `ruff format --check`. mypy's `files` config
  works differently (paths are checked directly), so `typecheck.sh`
  needed no change.
- Added narrow, commented per-file-ignores for `tools/*.py`: `T20`
  (a CLI build tool's `print()` *is* its output), `C901` (the recursive
  command-tree renderer was already at 11 > 10 before this PR; not
  worsened here), `PERF401` (pre-existing, purely stylistic). Everything
  else in `tools/` is linted for real going forward.
- `tools/bump_version.py` picked up one ruff auto-fix (collapsing two
  branches with identical bodies) as a side effect of now being in
  scope; verified its behavior is unchanged.

Verified: `uv run mypy ../tools/build_docs_site.py` → 0 errors; full
`uv run mypy` / `ruff check` / `ruff format --check` all pass; the
260-test suite stays at 100% branch coverage; the built docs site is
byte-for-byte identical before/after (67 pages, 5 nav groups, 58
intra-site links); `mint validate` and `mint broken-links` both pass on
the built output.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)
