### PR TITLE
fix(defend): validate --points field types; docs: CSL-JSON as registry truth (closes #73, #74)

### DIFF
--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -644,7 +644,7 @@ def _parse_points(raw: str) -> list[record_mod.PointRecord]:
         ``location``/``gap_note`` are optional per item; empty input means no
         points.
     :raises record_mod.RecordError: If `raw` isn't a JSON array of point objects
-        with the expected fields.
+        with the expected fields and field types.
     """
     if not raw.strip():
         return []
@@ -658,10 +658,7 @@ def _parse_points(raw: str) -> list[record_mod.PointRecord]:
     for item in data:
         if not isinstance(item, dict):
             raise record_mod.RecordError("--points item must be a JSON object")
-        try:
-            points.append(record_mod.PointRecord(**item))
-        except TypeError as exc:
-            raise record_mod.RecordError(f"--points item is malformed: {exc}") from exc
+        points.append(record_mod.point_record_from_mapping(item))
     return points
 
 

--- a/defendable-science/defendable_science/defend/record.py
+++ b/defendable-science/defendable_science/defend/record.py
@@ -19,6 +19,10 @@ import re
 from dataclasses import asdict, dataclass, field
 from datetime import date as date_cls
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 TARGETS = frozenset({"claim", "cited-work", "methodology", "paper-comprehension"})
 DEFAULT_LOG_DIR = Path("docs/research/defend-log")
@@ -60,6 +64,43 @@ class PointRecord:
     resolved: bool
     location: str | None = None
     gap_note: str | None = None
+
+
+#: Each `PointRecord` field's admissible decoded-JSON types, with the phrasing
+#: used to report a mismatch.
+_POINT_FIELD_TYPES: dict[str, tuple[tuple[type, ...], str]] = {
+    "point": ((str,), "a string"),
+    "source_quote": ((str,), "a string"),
+    "reader_answer": ((str,), "a string"),
+    "resolved": ((bool,), "a boolean"),
+    "location": ((str, type(None)), "a string or null"),
+    "gap_note": ((str, type(None)), "a string or null"),
+}
+
+
+def point_record_from_mapping(item: Mapping[str, Any]) -> PointRecord:
+    """Build a `PointRecord` from a decoded JSON object, enforcing field types.
+
+    Type-checks the fields present before constructing the record. ``resolved``
+    is the load-bearing one: Python truthiness would read a ``"false"`` string
+    or a ``0``/``1`` as a bool and silently misclassify an unresolved point as
+    resolved, dropping its gap from the artifact's ``unresolved`` list.
+
+    :param item: One decoded JSON object, keyed by `PointRecord` field name.
+    :returns: The validated record.
+    :raises RecordError: If a field's value has the wrong type, or a required
+        field is missing / an unknown key is present.
+    """
+    for name, (admissible, expected) in _POINT_FIELD_TYPES.items():
+        if name in item and not isinstance(item[name], admissible):
+            raise RecordError(
+                f"point record field {name!r} must be {expected}, "
+                f"got {type(item[name]).__name__}"
+            )
+    try:
+        return PointRecord(**item)
+    except TypeError as exc:
+        raise RecordError(f"point record is malformed: {exc}") from exc
 
 
 def _unresolved_gaps(points: list[PointRecord]) -> list[str]:

--- a/defendable-science/tests/test_record.py
+++ b/defendable-science/tests/test_record.py
@@ -628,6 +628,106 @@ def test_cli_record_points_item_not_an_object_exits_1_cleanly(tmp_path: Path) ->
     assert "defend record failed" in result.stderr
 
 
+def test_point_record_from_mapping_accepts_a_well_typed_object() -> None:
+    point = r.point_record_from_mapping(
+        {
+            "point": "assumptions",
+            "source_quote": "quote",
+            "reader_answer": "answer",
+            "resolved": False,
+            "location": "§3",
+            "gap_note": "missed the i.i.d. assumption",
+        }
+    )
+    assert point == r.PointRecord(
+        point="assumptions",
+        source_quote="quote",
+        reader_answer="answer",
+        resolved=False,
+        location="§3",
+        gap_note="missed the i.i.d. assumption",
+    )
+
+
+@pytest.mark.parametrize("resolved", ["false", "true", 0, 1, None])
+def test_point_record_from_mapping_rejects_non_bool_resolved(resolved: object) -> None:
+    """A truthy/falsy non-bool must not be coerced — it would flip a gap silently."""
+    with pytest.raises(r.RecordError, match="'resolved' must be a boolean"):
+        r.point_record_from_mapping(
+            {
+                "point": "assumptions",
+                "source_quote": "quote",
+                "reader_answer": "answer",
+                "resolved": resolved,
+            }
+        )
+
+
+def test_point_record_from_mapping_rejects_non_string_field() -> None:
+    with pytest.raises(r.RecordError, match="'source_quote' must be a string"):
+        r.point_record_from_mapping(
+            {
+                "point": "assumptions",
+                "source_quote": 3,
+                "reader_answer": "answer",
+                "resolved": True,
+            }
+        )
+
+
+def test_point_record_from_mapping_rejects_non_string_optional_field() -> None:
+    with pytest.raises(r.RecordError, match="'location' must be a string or null"):
+        r.point_record_from_mapping(
+            {
+                "point": "assumptions",
+                "source_quote": "quote",
+                "reader_answer": "answer",
+                "resolved": True,
+                "location": ["§3"],
+            }
+        )
+
+
+def test_point_record_from_mapping_rejects_bad_shape() -> None:
+    with pytest.raises(r.RecordError, match="point record is malformed"):
+        r.point_record_from_mapping({"point": "x", "unexpected_key": "y"})
+
+
+def test_cli_record_points_non_bool_resolved_exits_1_cleanly(tmp_path: Path) -> None:
+    """An unresolved gap smuggled in as ``"false"`` fails loudly, not silently."""
+    artifact = _artifact(tmp_path)
+    points = _points_file(
+        tmp_path,
+        [
+            {
+                "point": "assumptions",
+                "source_quote": "quote",
+                "reader_answer": "answer",
+                "resolved": "false",
+            }
+        ],
+    )
+    result = runner.invoke(
+        app,
+        [
+            "defend",
+            "record",
+            "--artifact",
+            str(artifact),
+            "--target",
+            "methodology",
+            "--points",
+            str(points),
+            "--log-dir",
+            str(tmp_path / "log"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "'resolved' must be a boolean" in result.stderr
+    # The artifact is untouched — no half-written understanding block.
+    assert artifact.read_text(encoding="utf-8") == _ARTIFACT
+
+
 def test_cli_record_points_bad_shape_exits_1_cleanly(tmp_path: Path) -> None:
     artifact = _artifact(tmp_path)
     points = _points_file(tmp_path, [{"point": "x", "unexpected_key": "y"}])

--- a/docs/design/00-meta-spec.md
+++ b/docs/design/00-meta-spec.md
@@ -431,7 +431,7 @@ the experiment-backend implementation. After `init`/`adopt`, a consumer repo
 │   │   └── milestones.yml                 # configurable program gates (candidacy, submission, defense)
 │   ├── dashboard.md                      # GENERATED projection of status frontmatter (never hand-edited)
 │   └── literature/
-│       ├── references.bib                # or CSL-JSON — bibliographic facts
+│       ├── references.json               # CSL-JSON bibliographic facts — source of truth (ADR-0020); .bib is exported on demand
 │       └── triage.yml                    # decision sidecar (keyed by citekey/DOI)
 ├── datasets.yml                          # dataset registry (entries + checksums + tiers)
 ├── .defendable-science/
@@ -452,7 +452,7 @@ One skill, two modes — both drive a repo to the layout of §5; `adopt` is `ini
 plus an inventory-and-map phase.
 
 - **`init` (greenfield)** — scaffold the `docs/research/` layout, the registries
-  (`papers.md`, `datasets.yml`, `references.bib` + `triage.yml`), `.defendable-science/`
+  (`papers.md`, `datasets.yml`, `references.json` + `triage.yml`), `.defendable-science/`
   config (rclone remote name, literature anchors, cache directory,
   experiment-backend + engineering-backend bindings),
   and the staged-doc templates. Delegates per-item registration to the
@@ -461,7 +461,7 @@ plus an inventory-and-map phase.
   materialize with the user confirming judgment calls (licenses, tiers,
   which result maps to which hypothesis). For `mononet` specifically:
   - `docs/references/` PDFs + digests + the CLAUDE.md paper table + the eight
-    methodology digests → literature `references.bib` + `triage.yml`, with
+    methodology digests → literature `references.json` + `triage.yml`, with
     roles pre-tagged (Runje 2023 = anchor; Sartor 2025, DLN, Sill = rival /
     prior-art).
   - benchmark data + download scripts under `benchmarks/` → `datasets.yml`

--- a/docs/design/01-lifecycle.md
+++ b/docs/design/01-lifecycle.md
@@ -173,7 +173,8 @@ Per meta-spec §5: `papers.md` registry; per-paper roots with
 `hypotheses/<YYYY-MM-DD-slug>/{hypothesis,strategy,design,plan,findings}.md`,
 `backlog.md`, `paper/{pitch,positioning,outline,ledger,decision,sections/}`;
 `portfolio-backlog.md`; optional `thesis/{kappa,aims.md,milestones.yml}`;
-`literature/{references.bib,triage.yml,digests/<citekey>.md}`; generated
+`literature/{references.json,triage.yml,digests/<citekey>.md}` (CSL-JSON is the
+source of truth per ADR-0020; `.bib` is an on-demand export); generated
 `dashboard.md`. Status frontmatter on every hypothesis/paper/thesis artifact
 feeds `progress`; examination transcripts + logged overrides form the
 accountability trail.

--- a/docs/design/02-literature.md
+++ b/docs/design/02-literature.md
@@ -118,7 +118,7 @@ may be committed vs. mirror-only.
   clients, snowballing, intent classification, clustering); the bib-loader +
   triage-schema; the PRISMA-log + concept-matrix generators; reference digests.
   Deps: HTTP client + `pyyaml` (+ the substrate's rclone mirror). No heavy deps.
-- **Consumer:** the `references.bib` + `triage.yml`; mirrored PDFs; API config
+- **Consumer:** the `references.json` + `triage.yml`; mirrored PDFs; API config
   (anchors, keys) in `.defendable-science/config.yml`.
 
 ## 7. Open items


### PR DESCRIPTION
## What

Two small follow-ups flagged in the `digest` branch review (#68), both easy and
independent.

**#73 — `defend record --points` no longer coerces a malformed `resolved`.** The
parser built `PointRecord(**item)` directly from decoded JSON, so
`"resolved": "false"` (a truthy string) or `0`/`1` was accepted as a bool and
`_unresolved_gaps()` silently dropped a real gap from the artifact's
`unresolved` list — a bad input reported as a clean pass. It now exits 1 with
`point record field 'resolved' must be a boolean, got str` and leaves the
artifact untouched.

**#74 — the design docs now match ADR-0020.** `references.json` (CSL-JSON) is
named as the registry's source of truth, with `.bib` framed as an on-demand
export.

## Details

- New shared helper `point_record_from_mapping()` in
  `defendable_science/defend/record.py` (rather than an inline check in
  `cli.py`), so any future producer of `PointRecord`s from JSON gets the same
  gate; it type-checks all six ADR-0033 fields, not just `resolved`, and raises
  `RecordError` naming the offending field and its actual type.
- `Mapping[str, Any]` at the JSON boundary matches the existing
  `dict[str, Any]` convention in `core/config.py` / `literature/graph.py` — no
  new dependency, and Pydantic stays out (per CLAUDE.md).
- Docs touched: `docs/design/00-meta-spec.md` (§5 tree + the
  `research-init`/`adopt` prose), `01-lifecycle.md` §7, and `02-literature.md`
  §6 (the last one wasn't listed in #74 but contradicted ADR-0020 the same way,
  and the issue's acceptance grep covers all of `docs/design/`).
- **Deliberately not changed:** the two `references.bib` mentions in
  `docs/superpowers/plans/2026-07-27-digest-skill-plan.md` — a historical plan
  record that quotes the docs as they read at the time.
- No ADR: this enforces ADR-0033's declared types and applies ADR-0020's
  already-recorded resolution; no new decision.

## Verification

`ruff check` / `ruff format --check` / `mypy` clean; `pytest` 313 passed at
**100% statement+branch coverage** (ADR-0028); `./tools/validate-plugin.sh` and
`pre-commit run --all-files` pass; codespell clean on the changed files. Also
checked by hand against a real artifact: exit 1, clear message, frontmatter and
log dir untouched.

Closes #73
Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)
