### PR TITLE
release: defendable-science v0.2.1

### DIFF
--- a/defendable-science/pyproject.toml
+++ b/defendable-science/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "defendable-science"
-version = "0.2.1rc1"
+version = "0.2.1"
 description = "defendable-science — a CLI for honest, defensible AI-assisted research (tooling for the defendable-science plugin)"
 authors = [{ name = "Davor Runje", email = "davor@synthpop.ai" }]
 maintainers = [{ name = "Davor Runje", email = "davor@synthpop.ai" }]


### PR DESCRIPTION
Bumps the **defendable-science package** to `v0.2.1`
(`--release none --pre final`).

The plugin (`.claude-plugin/plugin.json`) is versioned independently and is
**not** touched here.

### Publish after merging
```bash
git switch main && git pull
git tag v0.2.1
git push origin v0.2.1   # → publish.yml → PyPI
```
To validate on **TestPyPI** first, run the `Publish` workflow via
*workflow_dispatch* before tagging.

> If no CI checks appear on this PR, it was created with `GITHUB_TOKEN`
> (which can't trigger workflows). Add a `RELEASE_PAT` repo secret so the
> bump commit triggers CI, or re-run CI / admin-merge.