### PR TITLE
docs(docs): stop presenting literature/dataset skill modes as shell commands

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -198,10 +198,13 @@ claim is false is successful science.
   It keeps the `references.json` + `triage.yml` registry; it **proposes and
   surfaces, never adjudicates novelty**.
 
-  ```
-  literature scout --level hypothesis      # feeds hypothesis-exploration
-  literature position --level hypothesis   # feeds strategy.md
-  ```
+  > **Ask the assistant.** Scout the citation graph for research leads at
+  > hypothesis level (`literature` in `scout` mode) — feeds
+  > `hypothesis-exploration`. Or, once a claim is committed, position it
+  > against prior work at hypothesis level (`position` mode) — feeds
+  > `strategy.md`. There is no `defendable-science literature scout` or
+  > `literature position` command; these are skill modes you ask the
+  > assistant for (see [`docs/guides/literature.md`](guides/literature.md)).
 
 - [`dataset`](../skills/dataset/SKILL.md) manages the data your strategy declares:
   verbs `init / register / fetch / verify / mirror / audit` over `datasets.yml`.
@@ -209,9 +212,12 @@ claim is false is successful science.
   gated), a **SHA-256 fingerprint** (authoritative; a mismatch is a hard fail),
   and a Gebru **datasheet**. You confirm tier and license — the skill proposes.
 
-  ```
-  dataset register imagenet-c            # add an entry; confirm tier + license
-  dataset fetch imagenet-c               # materialize + verify against the registry
+  > **Ask the assistant.** Register `imagenet-c` in the dataset manifest —
+  > propose a tier and license for me to confirm. `register` is a `dataset`
+  > skill mode, not a CLI verb.
+
+  ```bash
+  defendable-science dataset fetch imagenet-c    # materialize + verify against the registry
   ```
 
 ### 4d. How runs become evidence — the experiment-backend contract


### PR DESCRIPTION
## What

`docs/USER-GUIDE.md` §4c fenced two blocks as bare shell code that a reader
would naturally copy into a terminal — `literature scout`/`literature
position` and `dataset register`/`dataset fetch` — but neither `scout` nor
`position` is a CLI command (they are `literature` skill *modes*, invoked by
asking the assistant), and `register` is not one of the seven real `dataset`
CLI verbs (`validate | ingest | emit | fetch | verify | mirror | audit`).
Copying either block gave "no such command".

## Details

- Reformatted both blocks to follow `docs/guides/literature.md`'s existing
  two-convention rule: skill-mode requests are now unfenceable
  `> **Ask the assistant.**` blockquotes, and the one genuinely real CLI verb
  in the dataset block (`fetch`) is now a real
  `defendable-science dataset fetch imagenet-c` shell invocation.
- Verified ground truth by running the real CLI from `defendable-science/`
  (`--help` for the root, `literature`, `dataset`, `defend`, `backlog`,
  `keys` groups) and cross-checking every command/flag `USER-GUIDE.md` shows
  against it.
- Audit result beyond the two known blocks: no further instances of the same
  defect. The other command-shaped blocks in the file either name skills by
  their own identifier (`research-init`, `hypothesis-exploration`,
  `paper-exploration`, `progress`, `defend`) — a distinct, pre-existing,
  consistently-used shorthand explained in §2 ("skills are invoked by name…
  in your Claude Code session"), out of this bug's scope and left alone per
  the "no restructuring" instruction (that's #103) — or are genuine
  `defendable-science …` CLI invocations that already match the real verbs
  exactly (e.g. the `keys` block in §8).
- Deliberately **not** a restructuring pass — diff is limited to the two
  offending blocks.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)
