### PR TITLE
fix(core): an unreachable mirror is not an absent key (closes #108)

### DIFF
--- a/defendable-science/defendable_science/core/mirror.py
+++ b/defendable-science/defendable_science/core/mirror.py
@@ -5,6 +5,14 @@ through the injectable `run` callable, so rclone is a Go binary invoked as a
 subprocess — never a Python dependency — and the mirror is testable without it.
 Shared by the ``dataset`` and ``literature`` front-ends
 (``docs/design/04-substrate-and-contract.md`` §2.3).
+
+**A mirror we could not reach is not a mirror that does not have it.** rclone's
+exit code carries that distinction (:data:`ABSENT_EXIT_CODES`), and this module
+keeps it: an absence is a ``False`` return, everything else is a raised
+:class:`MirrorUnreachableError`. It is the same rule
+:class:`~defendable_science.core.download.DownloadError` applies to HTTP status
+codes one layer over — ``404`` is a fact about the object, a ``403`` or a
+dropped connection is a fact about us.
 """
 
 from __future__ import annotations
@@ -21,15 +29,74 @@ from defendable_science.core.fixity import RetrievalError, bare_sha256
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+#: The rclone exit codes that establish an **absence**: ``3`` (directory not
+#: found) and ``4`` (file not found). The remote answered, and its answer was
+#: "there is no such key". Every other non-zero exit — ``1`` syntax/usage,
+#: ``2`` unknown error, ``5`` temporary error, ``6`` less-serious error,
+#: ``7`` fatal error, ``8`` transfer limit exceeded — means the question was
+#: never answered: an expired credential, a quota, a network outage or a
+#: malformed remote all land there, and none of them is evidence about what the
+#: mirror holds.
+ABSENT_EXIT_CODES = frozenset({3, 4})
+
+
+class MirrorUnreachableError(RetrievalError):
+    """Raised when an rclone call failed for a reason that is not an absence.
+
+    A :class:`~defendable_science.core.fixity.RetrievalError` subclass, so a
+    caller that only wants "the hop failed" needs no change; a caller that must
+    distinguish "the mirror does not hold this key" from "we could not ask"
+    catches this instead. Reporting the second as the first is how a paper
+    sitting behind an expired token becomes a line on a human's hand-download
+    worklist.
+
+    A **missing rclone binary** is deliberately *not* this exception: it is a
+    plain `RetrievalError`, because it is a configuration fault that affects
+    every entry of a run identically and should abort it rather than be
+    absorbed into a per-entry report.
+
+    :param message: The human-readable failure.
+    :param returncode: The rclone exit code.
+    :param stderr: What rclone wrote to stderr, decoded and stripped.
+    """
+
+    def __init__(self, message: str, *, returncode: int, stderr: str = "") -> None:
+        """Record the failure alongside what rclone said about it."""
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+
 
 class _Proc(Protocol):
     """The minimal completed-process shape a runner must return."""
 
-    returncode: int
+    @property
+    def returncode(self) -> int:
+        """The process exit code."""
+
+    @property
+    def stderr(self) -> bytes | str | None:
+        """The captured standard error, if the runner captured any."""
 
 
 #: A subprocess runner with the ``subprocess.run`` shape (injectable for tests).
 Runner = Callable[..., _Proc]
+
+
+def _stderr_text(raw: bytes | str | None, *, limit: int = 400) -> str:
+    """Return captured stderr as a bounded, single-paragraph string.
+
+    :param raw: The captured stream (``bytes`` under ``capture_output``, ``str``
+        under a text-mode runner, ``None`` when nothing was captured).
+    :param limit: Maximum characters kept, so an rclone dump cannot swamp a
+        report row.
+    :returns: The decoded, stripped, truncated text (empty when there is none).
+    """
+    if raw is None:
+        return ""
+    text = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else raw
+    text = " ".join(text.split())
+    return text if len(text) <= limit else text[:limit] + "…"
 
 
 @dataclass
@@ -69,6 +136,16 @@ class Mirror:
         return [*base, *args]
 
     def _run_ok(self, *args: str) -> bool:
+        """Run one rclone call, returning success and *raising* on non-absence.
+
+        :param args: The rclone verb and its arguments.
+        :returns: ``True`` on exit ``0``; ``False`` on an exit code in
+            :data:`ABSENT_EXIT_CODES`, the only non-zero codes that mean the
+            object is not there.
+        :raises RetrievalError: If the rclone binary is not on ``PATH``.
+        :raises MirrorUnreachableError: On any other non-zero exit — the call failed
+            for a reason that says nothing about whether the key exists.
+        """
         kwargs: dict[str, object] = {"capture_output": True, "check": False}
         if self.env is not None:
             kwargs["env"] = {**os.environ, **self.env}
@@ -80,20 +157,56 @@ class Mirror:
             raise RetrievalError(
                 "rclone not found on PATH — install it or unset the mirror"
             ) from exc
-        return proc.returncode == 0
+        if proc.returncode == 0:
+            return True
+        if proc.returncode in ABSENT_EXIT_CODES:
+            return False
+        detail = _stderr_text(proc.stderr)
+        raise MirrorUnreachableError(
+            f"rclone {args[0]} on {self.remote!r} failed with exit "
+            f"{proc.returncode}{': ' + detail if detail else ''} — the mirror "
+            "could not be reached, so whether it holds this key is unknown "
+            "(check credentials, quota and connectivity)",
+            returncode=proc.returncode,
+            stderr=detail,
+        )
 
     def put(self, local: str | Path, sha256: str) -> None:
-        """Copy `local` to the content-addressed mirror key."""
+        """Copy `local` to the content-addressed mirror key.
+
+        :param local: The local file to push.
+        :param sha256: The checksum naming the mirror key.
+        :raises RetrievalError: If the copy fails, including because `local` is
+            not there (exit ``3``/``4``) or rclone is not installed.
+        :raises MirrorUnreachableError: If the mirror could not be reached at all.
+        """
         if not self._run_ok("copyto", str(local), self._target(sha256)):
             raise RetrievalError(
                 f"rclone copyto to mirror failed for {bare_sha256(sha256)}"
             )
 
     def get(self, sha256: str, dst: str | Path) -> bool:
-        """Copy from the mirror key to `dst`; return whether it succeeded."""
+        """Copy from the mirror key to `dst`; return whether it succeeded.
+
+        :param sha256: The checksum naming the mirror key.
+        :param dst: Where to write the bytes (parents are created).
+        :returns: ``True`` when the bytes were retrieved, ``False`` when the
+            mirror answered that it does not hold the key. Never ``False`` for a
+            failure to ask.
+        :raises RetrievalError: If rclone is not installed.
+        :raises MirrorUnreachableError: If the mirror could not be reached — the
+            caller must not read that as an absence and fall through.
+        """
         Path(dst).parent.mkdir(parents=True, exist_ok=True)
         return self._run_ok("copyto", self._target(sha256), str(dst))
 
     def check(self, sha256: str) -> bool:
-        """Return whether the mirror holds the key (transport-level probe)."""
+        """Return whether the mirror holds the key (transport-level probe).
+
+        :param sha256: The checksum naming the mirror key.
+        :returns: ``True`` when the key is there, ``False`` when the mirror
+            answered that it is not. Never ``False`` for a failure to ask.
+        :raises RetrievalError: If rclone is not installed.
+        :raises MirrorUnreachableError: If the mirror could not be reached.
+        """
         return self._run_ok("lsf", self._target(sha256))

--- a/defendable-science/defendable_science/dataset/retrieval.py
+++ b/defendable-science/defendable_science/dataset/retrieval.py
@@ -29,8 +29,11 @@ from defendable_science.core.fixity import bare_sha256 as bare_sha256
 from defendable_science.core.fixity import blob_path as blob_path
 from defendable_science.core.fixity import sha256_file as sha256_file
 from defendable_science.core.fixity import verified as verified
+
+# Runtime re-exports: callers reach these through this module (``r.Mirror``).
+from defendable_science.core.mirror import Mirror as Mirror
 from defendable_science.core.mirror import (
-    Mirror as Mirror,  # noqa: TC001 - runtime re-export, callers reach `r.Mirror`
+    MirrorUnreachableError as MirrorUnreachableError,
 )
 from defendable_science.dataset import manifest as manifest_mod
 
@@ -72,7 +75,14 @@ def _resolve_file(
 ) -> Path:
     """Resolve one file through the chain, verifying at every hop.
 
+    An **unreachable** mirror stops the chain rather than being read as "the
+    mirror does not have it": falling through to the Tier-B fetch (or, for a
+    Tier-C entry, to the gated-manual message) would answer a question the
+    mirror never got to answer, and for Tier C would tell a human to acquire by
+    hand bytes that may be sitting behind an expired credential.
+
     :raises RetrievalError: If the chain is exhausted without verified bytes.
+    :raises MirrorUnreachableError: If a configured mirror could not be reached.
     """
     # Tier A: the file is committed in-repo at its path; verify in place.
     if entry.tier == "A":
@@ -197,12 +207,14 @@ class AuditReport:
 
     :param validation: The manifest schema/tier validation report.
     :param fixity: Per-entry verification reports.
-    :param mirror_present: Per-entry mirror-presence flags (if a mirror is given).
+    :param mirror_present: Per-entry mirror-presence flags (if a mirror is
+        given). ``None`` — ``null`` in the JSON report — means **unknown**: the
+        mirror could not be reached, so its answer is not evidence of absence.
     """
 
     validation: manifest_mod.ValidationReport
     fixity: list[VerifyReport] = field(default_factory=list)
-    mirror_present: dict[str, bool] = field(default_factory=dict)
+    mirror_present: dict[str, bool | None] = field(default_factory=dict)
 
     @property
     def ok(self) -> bool:
@@ -218,6 +230,12 @@ def audit(
     Folds in the manifest loader/validator (schema, license, datasheet,
     tier-consistency) alongside the byte-level fixity and mirror-presence checks.
 
+    A mirror that cannot be reached is reported as ``None`` (unknown) rather
+    than ``False``: an audit exists to say what is true, and "we could not ask"
+    is not "it is not there". The audit still completes — the fixity half of it
+    is entirely local and remains valid — so the failure narrows to the entries
+    it actually touched.
+
     :param manifest: The parsed manifest.
     :param cache_dir: The content-addressed cache directory.
     :param mirror: Optional mirror to probe for presence.
@@ -227,7 +245,20 @@ def audit(
     for entry in manifest.datasets:
         report.fixity.append(verify(entry, cache_dir=cache_dir))
         if mirror is not None:
-            report.mirror_present[entry.id] = all(
-                mirror.check(ref.sha256) for ref in entry.files
-            )
+            report.mirror_present[entry.id] = _mirror_presence(mirror, entry)
     return report
+
+
+def _mirror_presence(mirror: Mirror, entry: DatasetEntry) -> bool | None:
+    """Return whether the mirror holds every file of `entry`, or ``None``.
+
+    :param mirror: The mirror to probe.
+    :param entry: The manifest entry whose files to probe.
+    :returns: ``True`` when every file is present, ``False`` when the mirror
+        answered that at least one is not, and ``None`` when the mirror could
+        not be reached and the question therefore went unanswered.
+    """
+    try:
+        return all(mirror.check(ref.sha256) for ref in entry.files)
+    except MirrorUnreachableError:
+        return None

--- a/defendable-science/defendable_science/literature/acquire.py
+++ b/defendable-science/defendable_science/literature/acquire.py
@@ -27,6 +27,7 @@ from defendable_science.core.fixity import (
     sha256_file,
     verified,
 )
+from defendable_science.core.mirror import MirrorUnreachableError
 from defendable_science.literature.graph import OPENALEX, resolve
 from defendable_science.literature.registry import (
     Acquisition,
@@ -87,7 +88,13 @@ if TYPE_CHECKING:
         """
 
         def check(self, sha256: str) -> bool:
-            """Return whether the mirror holds the key."""
+            """Return whether the mirror holds the key.
+
+            A stand-in must keep `Mirror`'s contract: ``False`` only when the
+            mirror answered that the key is absent, and a raise (a
+            :class:`~defendable_science.core.mirror.MirrorUnreachableError`, say)
+            when it could not be asked.
+            """
 
         def put(self, local: str | Path, sha256: str) -> None:
             """Copy `local` to the content-addressed mirror key."""
@@ -1156,9 +1163,17 @@ def _resolve_recorded(entry: Entry, ctx: Context, asset: Asset, sha: str) -> Out
     reporting the same sentence for both is the failure-honesty rule's exact
     complaint in miniature.
 
-    :returns: :data:`BUCKET_CACHED` when the bytes are resolvable, otherwise
-        :data:`BUCKET_MANUAL` — the recorded bytes are gone, which is a fact
-        about this paper and belongs on the human worklist.
+    A mirror that could not be *reached* is a third case and the one this
+    function must be most careful with: it is a tooling failure, so it becomes
+    an :data:`BUCKET_ERROR` row. Filing it as ``manual`` would put a paper that
+    is very probably sitting in the mirror, behind an expired credential, on a
+    human's hand-download worklist — and, because ``manual`` is a worklist and
+    not a failure, would do so with ``complete: true`` and exit 0.
+
+    :returns: :data:`BUCKET_CACHED` when the bytes are resolvable,
+        :data:`BUCKET_ERROR` when a configured mirror could not be reached, and
+        otherwise :data:`BUCKET_MANUAL` — the recorded bytes are gone, which is
+        a fact about this paper and belongs on the human worklist.
     """
     blob = blob_path(ctx.cache_dir, sha)
     faults: list[str] = []
@@ -1169,7 +1184,22 @@ def _resolve_recorded(entry: Entry, ctx: Context, asset: Asset, sha: str) -> Out
         faults.append(
             "the cached blob did not match the recorded checksum and was discarded"
         )
-    if ctx.mirror is not None and ctx.mirror.get(sha, blob):
+    try:
+        from_mirror = ctx.mirror is not None and ctx.mirror.get(sha, blob)
+    except MirrorUnreachableError as exc:
+        return Outcome(
+            citekey=entry.citekey,
+            bucket=BUCKET_ERROR,
+            sha256=sha,
+            reason=(
+                f"recorded checksum sha256:{sha} could not be resolved: "
+                + ("; ".join(faults) + "; " if faults else "")
+                + f"the mirror could not be reached to look for it: {exc}. This "
+                "is a tooling failure, not a missing paper — the mirror may "
+                "well hold these bytes."
+            ),
+        )
+    if from_mirror:
         if verified(blob, sha):
             return _cached_outcome(entry, asset, sha, path=blob)
         blob.unlink(missing_ok=True)
@@ -1762,9 +1792,11 @@ def acquire_one(
     :raises RateLimitError: If a provider throttles a metadata call, or a PDF
         host throttles a byte download.
     :raises HttpError: On a metadata transport failure.
-    :raises RetrievalError: If a configured mirror cannot be reached at all
-        (a missing ``rclone``), which is a configuration fault, not a fact about
-        this paper.
+    :raises RetrievalError: If ``rclone`` is missing altogether, which is a
+        configuration fault affecting every entry, not a fact about this paper.
+        A mirror that is present but *unreachable* (credentials, quota,
+        network) is per-entry and becomes an :data:`BUCKET_ERROR` outcome
+        instead, so a sweep reports it and continues.
     """
     recorded = _recorded(entry)
     if recorded is not None and not refetch:
@@ -2189,19 +2221,14 @@ def mirror_entry(
     Probes the mirror before deciding what to do with each file: a copy
     already there is reported as such rather than re-pushed, and
     `check_only` never calls :meth:`Mirror.put` regardless of what the probe
-    finds. A transport failure that `Mirror` *raises* — most commonly a
-    missing ``rclone`` binary — is not caught here: it propagates as the
-    actionable ``RetrievalError``, because a transport failure and "no copy in
-    the mirror" are different problems with different fixes.
-
-    .. warning::
-       That distinction is only as good as the probe underneath it, and today
-       it is **not** watertight. ``Mirror._run_ok`` reads a non-zero
-       ``rclone`` exit as "absent", so an auth, quota or network failure on
-       the probe is reported here as `missing` rather than raised. Treat a
-       `missing` entry as "not confirmed present", never as "the mirror has
-       been checked and does not have it". Tracked as a follow-up on the
-       promoted ``core/mirror.py`` module, which ``dataset`` shares.
+    finds. A transport failure that `Mirror` *raises* — a missing ``rclone``
+    binary, or a probe that failed for any reason other than the key being
+    absent (an expired credential, a quota, an outage) — is not caught here:
+    it propagates as the actionable ``RetrievalError`` /
+    :class:`~defendable_science.core.mirror.MirrorUnreachableError`, because a
+    transport failure and "no copy in the mirror" are different problems with
+    different fixes. A `missing` entry therefore means the mirror was asked
+    and answered.
 
     **A local blob is re-hashed before it is pushed.** Every other path that
     calls :meth:`Mirror.put` in this codebase does so immediately after
@@ -2232,9 +2259,8 @@ def mirror_entry(
         ``corrupt`` (a local blob whose bytes no longer match the recorded
         checksum — never pushed).
     :raises RetrievalError: If the mirror transport raises — a missing
-        ``rclone`` binary, or a push that fails — surfaced intact rather than
-        folded into `missing`. A *probe* that fails without raising is the
-        gap the warning above describes.
+        ``rclone`` binary, a push that fails, or a probe that could not reach
+        the mirror — surfaced intact rather than folded into `missing`.
     """
     report: dict[str, Any] = {
         "citekey": entry.citekey,

--- a/defendable-science/tests/test_acquire.py
+++ b/defendable-science/tests/test_acquire.py
@@ -12,6 +12,7 @@ import pytest
 from defendable_science.core.download import DownloadError, FetchedBytes
 from defendable_science.core.fixity import RetrievalError
 from defendable_science.core.http import HttpError, RateLimitError
+from defendable_science.core.mirror import MirrorUnreachableError
 from defendable_science.literature import acquire as a
 from defendable_science.literature import registry as reg
 
@@ -878,11 +879,13 @@ class FakeMirror:
         body: bytes | None = None,
         put_error: Exception | None = None,
         check_error: Exception | None = None,
+        get_error: Exception | None = None,
         present: bool | None = None,
     ) -> None:
         self.body = body
         self.put_error = put_error
         self.check_error = check_error
+        self.get_error = get_error
         self.present = present
         self.puts: list[tuple[str, str]] = []
         self.checks: list[str] = []
@@ -895,6 +898,8 @@ class FakeMirror:
         self.puts.append((str(local), sha256))
 
     def get(self, sha256: str, dst: str | Path) -> bool:
+        if self.get_error is not None:
+            raise self.get_error
         if self.body is None:
             return False
         target = Path(dst)
@@ -1096,6 +1101,76 @@ def test_a_mirror_that_does_not_hold_the_key_is_manual(tmp_path: Path) -> None:
         entry, _ctx(tmp_path, FakeClient({}), NeverFetcher(), mirror=FakeMirror())
     )
     assert outcome.bucket == a.BUCKET_MANUAL
+
+
+def _unreachable_mirror() -> FakeMirror:
+    return FakeMirror(
+        get_error=MirrorUnreachableError(
+            "rclone copyto on 'papers' failed with exit 7: SignatureDoesNotMatch — "
+            "the mirror could not be reached",
+            returncode=7,
+            stderr="SignatureDoesNotMatch",
+        )
+    )
+
+
+def test_a_mirror_that_could_not_be_reached_is_an_error_never_manual(
+    tmp_path: Path,
+) -> None:
+    """The negative that matters: no `manual` row for a mirror we never asked.
+
+    A ``manual`` row is a worklist item — it leaves the sweep ``complete`` and
+    exit 0 — so filing an expired credential there tells a researcher to
+    hand-download a paper that is very likely sitting in their own mirror.
+    """
+    _path, entry = _registry(tmp_path, spine=_spine())
+
+    outcome = a.acquire_one(
+        entry,
+        _ctx(tmp_path, FakeClient({}), NeverFetcher(), mirror=_unreachable_mirror()),
+    )
+
+    assert outcome.bucket != a.BUCKET_MANUAL
+    assert outcome.bucket == a.BUCKET_ERROR
+    assert outcome.reason is not None
+    assert "could not be reached" in outcome.reason
+    assert "not in the mirror either" not in outcome.reason
+    # Serialized under ``error``, the key an ``errors[]`` reader looks at.
+    assert "could not be reached" in outcome.as_json()["error"]
+
+
+def test_an_unreachable_mirror_still_reports_a_corrupt_cache_blob(
+    tmp_path: Path,
+) -> None:
+    """Both faults are true at once, and the row says so."""
+    _path, entry = _registry(tmp_path, spine=_spine())
+    blob = tmp_path / "cache" / "sha256" / PDF_SHA
+    blob.parent.mkdir(parents=True, exist_ok=True)
+    blob.write_bytes(b"corrupt")
+
+    outcome = a.acquire_one(
+        entry,
+        _ctx(tmp_path, FakeClient({}), NeverFetcher(), mirror=_unreachable_mirror()),
+    )
+
+    assert outcome.bucket == a.BUCKET_ERROR
+    assert outcome.reason is not None
+    assert "did not match the recorded checksum" in outcome.reason
+    assert "could not be reached" in outcome.reason
+
+
+def test_a_sweep_reports_an_unreachable_mirror_and_keeps_going(
+    tmp_path: Path,
+) -> None:
+    """Per-entry, not fatal: the row lands in ``errors`` and the sweep completes."""
+    _path, _entry_obj = _registry(tmp_path, spine=_spine())
+    ctx = _ctx(tmp_path, FakeClient({}), NeverFetcher(), mirror=_unreachable_mirror())
+
+    report = a.fetch_all(ctx)
+
+    assert report["manual"] == []
+    assert len(report["errors"]) == 1
+    assert "could not be reached" in report["errors"][0]["error"]
 
 
 def test_mirror_bytes_that_do_not_verify_are_treated_as_absent(

--- a/defendable-science/tests/test_acquire_cli.py
+++ b/defendable-science/tests/test_acquire_cli.py
@@ -80,16 +80,28 @@ def _fake_client(routes: dict[str, Any] | None = None, **kw: Any) -> http.HttpCl
 
 
 class _Proc:
-    def __init__(self, returncode: int = 0) -> None:
+    def __init__(self, returncode: int = 0, stderr: bytes | None = None) -> None:
         self.returncode = returncode
+        self.stderr = stderr
+
+
+#: rclone's "file not found" — the only kind of non-zero exit that means the key
+#: is genuinely absent rather than unaskable (``core.mirror.ABSENT_EXIT_CODES``).
+ABSENT = 4
 
 
 def _run_ok(_args: list[str], **_kw: Any) -> _Proc:
     return _Proc(0)
 
 
-def _run_fail(_args: list[str], **_kw: Any) -> _Proc:
-    return _Proc(1)
+def _run_absent(_args: list[str], **_kw: Any) -> _Proc:
+    """Rclone answered: the key is not there."""
+    return _Proc(ABSENT)
+
+
+def _run_unreachable(_args: list[str], **_kw: Any) -> _Proc:
+    """Rclone could not ask — an expired credential, say (exit 7, fatal)."""
+    return _Proc(7, b"SignatureDoesNotMatch: the token has expired")
 
 
 def _run_missing_rclone(_args: list[str], **_kw: Any) -> _Proc:
@@ -401,7 +413,7 @@ def test_mirror_check_absent_key_exits_1(
         tmp_path, {"registry": "references.json", "mirror": {"remote": "papers"}}
     )
     monkeypatch.setattr(
-        cli, "_lit_mirror", lambda _lit: Mirror(remote="papers", run=_run_fail)
+        cli, "_lit_mirror", lambda _lit: Mirror(remote="papers", run=_run_absent)
     )
 
     result = runner.invoke(app, ["literature", "mirror", "k1", "--check"])
@@ -425,7 +437,7 @@ def test_mirror_distinguishes_corrupt_from_missing(
         tmp_path, {"registry": "references.json", "mirror": {"remote": "papers"}}
     )
     monkeypatch.setattr(
-        cli, "_lit_mirror", lambda _lit: Mirror(remote="papers", run=_run_fail)
+        cli, "_lit_mirror", lambda _lit: Mirror(remote="papers", run=_run_absent)
     )
 
     result = runner.invoke(app, ["literature", "mirror", "k1"])
@@ -462,7 +474,7 @@ def _run_fail_then_ok() -> Any:
     """``lsf`` (check) fails, so the entry isn't already present; ``copyto`` succeeds."""
 
     def _run(args: list[str], **_kw: Any) -> _Proc:
-        return _Proc(1 if "lsf" in args else 0)
+        return _Proc(ABSENT if "lsf" in args else 0)
 
     return _run
 
@@ -534,6 +546,61 @@ def test_fetch_all_missing_rclone_exits_1_with_actionable_message(
 
     assert result.exit_code == 1
     assert "rclone not found on PATH" in result.stderr
+    assert "Traceback" not in (result.stdout + result.stderr)
+
+
+def test_fetch_an_unreachable_mirror_is_an_error_row_and_a_non_zero_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End to end: a failing rclone cannot produce a `manual` worklist row.
+
+    The whole point of the fix, asserted where a researcher would see it: an
+    expired credential must not come back as ``complete: true``, exit 0, and a
+    line telling them to go and download the paper by hand.
+    """
+    monkeypatch.chdir(tmp_path)
+    # Recorded checksum, no local blob — the mirror is the only place to look.
+    _write_registry(tmp_path / "references.json", [_item("k1", spine=_spine(PDF_SHA))])
+    _write_config(
+        tmp_path, {"registry": "references.json", "mirror": {"remote": "papers"}}
+    )
+    monkeypatch.setattr(cli, "_lit_client", lambda: _fake_client())
+    monkeypatch.setattr(
+        cli,
+        "_lit_mirror",
+        lambda _lit: Mirror(remote="papers", run=_run_unreachable),
+    )
+
+    result = runner.invoke(app, ["literature", "fetch", "k1"])
+
+    assert result.exit_code == 1
+    report = json.loads(result.stdout)
+    assert report["manual"] == []
+    assert len(report["errors"]) == 1
+    error = report["errors"][0]["error"]
+    assert "could not be reached" in error
+    assert "the token has expired" in error
+    assert "Traceback" not in (result.stdout + result.stderr)
+
+
+def test_mirror_check_does_not_report_missing_for_an_unreachable_mirror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``literature mirror --check`` reports nothing rather than "not present"."""
+    monkeypatch.chdir(tmp_path)
+    _write_registry(tmp_path / "references.json", [_item("k1", spine=_spine(PDF_SHA))])
+    _write_config(
+        tmp_path, {"registry": "references.json", "mirror": {"remote": "papers"}}
+    )
+    monkeypatch.setattr(
+        cli, "_lit_mirror", lambda _lit: Mirror(remote="papers", run=_run_unreachable)
+    )
+
+    result = runner.invoke(app, ["literature", "mirror", "k1", "--check"])
+
+    assert result.exit_code == 1
+    assert "could not be reached" in result.stderr
+    assert result.stdout.strip() == ""
     assert "Traceback" not in (result.stdout + result.stderr)
 
 

--- a/defendable-science/tests/test_cli_commands.py
+++ b/defendable-science/tests/test_cli_commands.py
@@ -230,6 +230,7 @@ def test_mirror_success_with_fake_rclone(
 
     class _Proc:
         returncode = 0
+        stderr = b""
 
     def _ok(args: list[str], **_kw: object) -> _Proc:
         return _Proc()

--- a/defendable-science/tests/test_mirror.py
+++ b/defendable-science/tests/test_mirror.py
@@ -2,15 +2,25 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from defendable_science.core import fixity as fx
 from defendable_science.core import mirror as mirror_mod
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 class FakeProc:
-    def __init__(self, returncode: int) -> None:
+    def __init__(self, returncode: int, stderr: bytes | str | None = None) -> None:
         self.returncode = returncode
+        self.stderr = stderr
+
+
+#: What rclone exits with when the key genuinely is not there (file not found).
+ABSENT = 4
 
 
 class FakeRclone:
@@ -24,12 +34,12 @@ class FakeRclone:
         self.calls.append(args)
         verb = args[1] if args[1] != "--config" else args[3]
         if verb == "lsf":
-            return FakeProc(0 if self.present else 1)
+            return FakeProc(0 if self.present else ABSENT)
         if verb == "copyto":
             # A "get" (mirror -> local) only succeeds when present.
             src = args[-2]
             is_get = ":" in src
-            return FakeProc(0 if (not is_get or self.present) else 1)
+            return FakeProc(0 if (not is_get or self.present) else ABSENT)
         return FakeProc(0)
 
 
@@ -87,10 +97,104 @@ def test_mirror_without_env_passes_no_env_kwarg() -> None:
     assert "env" not in captured
 
 
-def test_mirror_put_failure_raises() -> None:
-    def _fail(args: list[str], **_kw: object) -> FakeProc:
-        return FakeProc(1)
+def test_mirror_put_of_a_missing_local_file_raises() -> None:
+    """Rclone's "not found" on a *push* means the local source is not there."""
 
-    mirror = mirror_mod.Mirror(remote="s", run=_fail)
+    def _absent(args: list[str], **_kw: object) -> FakeProc:
+        return FakeProc(ABSENT)
+
+    mirror = mirror_mod.Mirror(remote="s", run=_absent)
     with pytest.raises(fx.RetrievalError, match="copyto to mirror failed"):
-        mirror.put("/tmp/x", "a" * 64)
+        mirror.put("/tmp/x", "a" * 64)  # nosec B108 - never opened, rclone is a fake
+
+
+# --- the negative: an unreachable mirror is never reported as an absence ------
+#
+# The point of the module. Every one of these asserts what must *not* happen —
+# that a failing runner cannot talk `Mirror` into an "absent" verdict — because
+# a suite that only asserts the happy path is exactly how the same defect
+# survived at the byte layer (#107) until it was found by hand.
+
+#: Exit codes that are *not* an absence: syntax, unknown, temporary, less
+#: serious, fatal, transfer-limit. Auth failures, expired tokens, quota refusals
+#: and network outages all arrive as one of these.
+UNREACHABLE_CODES = (1, 2, 5, 6, 7, 8)
+
+
+def _runner(returncode: int, stderr: bytes | str | None = None) -> mirror_mod.Runner:
+    def _run(args: list[str], **_kw: object) -> FakeProc:
+        return FakeProc(returncode, stderr)
+
+    return _run
+
+
+@pytest.mark.parametrize("code", UNREACHABLE_CODES)
+def test_check_raises_rather_than_reporting_absent(code: int) -> None:
+    mirror = mirror_mod.Mirror(remote="s", run=_runner(code))
+    verdicts: list[bool] = []
+    with pytest.raises(mirror_mod.MirrorUnreachableError) as caught:
+        verdicts.append(mirror.check("a" * 64))
+    # Not merely "it did not say True" — it returned no verdict at all.
+    assert verdicts == []
+    assert caught.value.returncode == code
+
+
+@pytest.mark.parametrize("code", UNREACHABLE_CODES)
+def test_get_raises_rather_than_reporting_absent(code: int, tmp_path: Path) -> None:
+    mirror = mirror_mod.Mirror(remote="s", run=_runner(code))
+    verdicts: list[bool] = []
+    with pytest.raises(mirror_mod.MirrorUnreachableError) as caught:
+        verdicts.append(mirror.get("a" * 64, tmp_path / "blob"))
+    assert verdicts == []
+    assert caught.value.returncode == code
+
+
+@pytest.mark.parametrize("code", [3, 4])
+def test_only_not_found_exit_codes_mean_absent(code: int, tmp_path: Path) -> None:
+    """``3`` directory-not-found and ``4`` file-not-found — and nothing else."""
+    mirror = mirror_mod.Mirror(remote="s", run=_runner(code))
+    assert mirror.check("a" * 64) is False
+    assert mirror.get("a" * 64, tmp_path / "blob") is False
+
+
+def test_unreachable_is_a_retrieval_error_carrying_rclone_stderr() -> None:
+    """A caller that only knows `RetrievalError` still sees the failure."""
+    mirror = mirror_mod.Mirror(
+        remote="store", run=_runner(7, b"  Failed to lsf:  \n AccessDenied\n")
+    )
+    with pytest.raises(fx.RetrievalError) as caught:
+        mirror.check("a" * 64)
+    error = caught.value
+    assert isinstance(error, mirror_mod.MirrorUnreachableError)
+    assert error.stderr == "Failed to lsf: AccessDenied"
+    message = str(error)
+    assert "AccessDenied" in message
+    assert "exit 7" in message
+    assert "could not be reached" in message
+    # It must not read as a verdict about the key.
+    assert "not in the mirror" not in message
+
+
+def test_unreachable_put_reports_the_transport_not_a_missing_source() -> None:
+    mirror = mirror_mod.Mirror(remote="s", run=_runner(1, "quota exceeded"))
+    with pytest.raises(mirror_mod.MirrorUnreachableError, match="quota exceeded"):
+        mirror.put("/tmp/x", "a" * 64)  # nosec B108 - never opened, rclone is a fake
+
+
+def test_text_mode_and_uncaptured_stderr_both_degrade_cleanly() -> None:
+    """The runner is injectable, so stderr may be ``str`` or absent entirely."""
+    text = mirror_mod.Mirror(remote="s", run=_runner(7, "boom"))
+    with pytest.raises(mirror_mod.MirrorUnreachableError, match="boom"):
+        text.check("a" * 64)
+    silent = mirror_mod.Mirror(remote="s", run=_runner(7, None))
+    with pytest.raises(mirror_mod.MirrorUnreachableError) as caught:
+        silent.check("a" * 64)
+    assert caught.value.stderr == ""
+    assert "exit 7 — the mirror could not be reached" in str(caught.value)
+
+
+def test_a_long_rclone_dump_is_truncated_in_the_message() -> None:
+    mirror = mirror_mod.Mirror(remote="s", run=_runner(7, b"x" * 900))
+    with pytest.raises(mirror_mod.MirrorUnreachableError) as caught:
+        mirror.check("a" * 64)
+    assert caught.value.stderr == "x" * 400 + "…"

--- a/defendable-science/tests/test_retrieval.py
+++ b/defendable-science/tests/test_retrieval.py
@@ -40,8 +40,14 @@ def _entry(
 
 
 class FakeProc:
-    def __init__(self, returncode: int) -> None:
+    def __init__(self, returncode: int, stderr: bytes | None = None) -> None:
         self.returncode = returncode
+        self.stderr = stderr
+
+
+#: rclone's "file not found" — the only kind of non-zero exit that means the key
+#: is genuinely absent rather than unaskable (``core.mirror.ABSENT_EXIT_CODES``).
+ABSENT = 4
 
 
 class FakeRclone:
@@ -55,13 +61,24 @@ class FakeRclone:
         self.calls.append(args)
         verb = args[1] if args[1] != "--config" else args[3]
         if verb == "lsf":
-            return FakeProc(0 if self.present else 1)
+            return FakeProc(0 if self.present else ABSENT)
         if verb == "copyto":
             # A "get" (mirror -> local) only succeeds when present.
             src = args[-2]
             is_get = ":" in src
-            return FakeProc(0 if (not is_get or self.present) else 1)
+            return FakeProc(0 if (not is_get or self.present) else ABSENT)
         return FakeProc(0)
+
+
+class UnreachableRclone:
+    """A mirror we cannot ask: rclone exits 7 (fatal) on every call."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args: list[str], **_kw: object) -> FakeProc:
+        self.calls.append(args)
+        return FakeProc(7, b"NoCredentialProviders: no valid providers in chain")
 
 
 # --- sha256 / verify --------------------------------------------------------
@@ -279,3 +296,85 @@ def test_audit_with_mirror_present(tmp_path: Path) -> None:
         m.Manifest(datasets=[entry]), cache_dir=tmp_path / "c", mirror=mirror
     )
     assert report.mirror_present["d1"] is True
+
+
+# --- the negative: an unreachable mirror is not an absent one -----------------
+
+
+def test_audit_reports_an_unreachable_mirror_as_unknown_not_absent(
+    tmp_path: Path,
+) -> None:
+    """``None`` (unknown), never ``False`` — an audit must not invent a verdict."""
+    payload = b"p"
+    digest = hashlib.sha256(payload).hexdigest()
+    blob = tmp_path / "c" / "sha256" / digest
+    blob.parent.mkdir(parents=True)
+    blob.write_bytes(payload)
+    entry = _entry("B", digest, retrieval=m.Retrieval(kind="http", url="u"))
+    mirror = r.Mirror(remote="s", run=UnreachableRclone())
+
+    report = r.audit(
+        m.Manifest(datasets=[entry]), cache_dir=tmp_path / "c", mirror=mirror
+    )
+
+    assert report.mirror_present["d1"] is None
+    assert report.mirror_present["d1"] is not False
+
+
+def test_audit_still_reports_a_genuinely_absent_key_as_false(tmp_path: Path) -> None:
+    payload = b"p"
+    digest = hashlib.sha256(payload).hexdigest()
+    blob = tmp_path / "c" / "sha256" / digest
+    blob.parent.mkdir(parents=True)
+    blob.write_bytes(payload)
+    entry = _entry("B", digest, retrieval=m.Retrieval(kind="http", url="u"))
+    mirror = r.Mirror(remote="s", run=FakeRclone(present=False))
+
+    report = r.audit(
+        m.Manifest(datasets=[entry]), cache_dir=tmp_path / "c", mirror=mirror
+    )
+
+    assert report.mirror_present["d1"] is False
+
+
+def test_fetch_does_not_fall_through_to_tier_b_when_the_mirror_is_unreachable(
+    tmp_path: Path,
+) -> None:
+    """The chain stops: a mirror that never answered is not a mirror that said no."""
+    payload = b"downloaded bytes"
+    digest = hashlib.sha256(payload).hexdigest()
+    entry = _entry("B", digest, retrieval=m.Retrieval(kind="http", url="https://x"))
+    fetched: list[str] = []
+
+    def _fetcher(url: str, sha256: str, dest: Path) -> Path:
+        fetched.append(url)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(payload)
+        return dest
+
+    with pytest.raises(r.MirrorUnreachableError, match="could not be reached"):
+        r.fetch(
+            entry,
+            cache_dir=tmp_path / "cache",
+            mirror=r.Mirror(remote="s", run=UnreachableRclone()),
+            tier_b_fetch=_fetcher,
+        )
+
+    assert fetched == []
+
+
+def test_gated_fetch_does_not_blame_the_human_for_an_unreachable_mirror(
+    tmp_path: Path,
+) -> None:
+    """Tier C: "acquire manually" must not stand in for a probe that never ran."""
+    entry = _entry("C", "d" * 64, access="gated", instructions="email the authors")
+
+    with pytest.raises(r.RetrievalError) as caught:
+        r.fetch(
+            entry,
+            cache_dir=tmp_path / "cache",
+            mirror=r.Mirror(remote="s", run=UnreachableRclone()),
+        )
+
+    assert "could not be reached" in str(caught.value)
+    assert "acquire manually" not in str(caught.value)

--- a/docs/design/04-substrate-and-contract.md
+++ b/docs/design/04-substrate-and-contract.md
@@ -105,6 +105,13 @@ treated as absent and the chain continues:
 4  GATED / MANUAL   print acquisition instructions → wait for operator drop → verify → populate mirror → return
 ```
 
+Step 2 falls through only when the mirror **answered** that it does not hold the
+key (rclone exit `3`/`4`). A mirror that could not be reached at all — an expired
+credential, a quota, an outage — stops the chain with a
+`MirrorUnreachableError`: "we could not ask" is not "it is not there", and
+letting it fall through would let a transport failure be reported as a missing
+asset (the failure-honesty rule).
+
 Front-ends supply step-3 fetchers; the substrate owns steps 1, 2, 4 and all
 fixity checks. The mirror is populated on first successful acquisition, giving
 link-rot insurance (dataset Tier B) and a re-acquirable home for gated assets


### PR DESCRIPTION
## What

`Mirror` told its callers "the mirror does not hold this key" whenever rclone
exited non-zero for *any* reason other than a missing binary — an auth failure,
an expired token, a quota refusal, a network outage, a malformed remote. So
`literature fetch` put a paper that is sitting in the mirror behind a stale
credential on the human hand-download worklist (`manual[]`, `complete: true`,
exit 0), and `dataset audit` reported `mirror_present: false` for a mirror it
never reached. "We could not ask" was reported as "it is not there".

Now the mirror distinguishes the two, using rclone's documented exit codes:
`3` (directory not found) and `4` (file not found) are the only non-zero exits
that mean *absent* and still return `False`; everything else raises the new
`MirrorUnreachableError`.

## Details

- **`core/mirror.py`** — `MirrorUnreachableError(RetrievalError)` carries
  `returncode` and the rclone `stderr` that `capture_output=True` was already
  collecting and throwing away. This is the shape #107 gave the byte layer
  (`DownloadError.status` / `hard_miss`, where `404` is a fact about the object
  and `403` is a fact about us) — the same rule one layer down, deliberately not
  a third vocabulary. A **missing rclone binary stays a plain `RetrievalError`**
  with its existing actionable message: it is a configuration fault affecting
  every entry, so it should abort a run rather than be absorbed into a per-entry
  report. Raising rather than returning a tri-state was chosen because every
  existing call site is `if mirror.get(...)`; a new enum member would have been
  silently truthy at each of them, whereas a raise fails loud and matches how
  the missing-binary case already behaved.
- **`literature`** — `_resolve_recorded` routes an unreachable mirror to an
  `errors[]` row (exit 1, sweep continues) instead of `manual[]`. The
  `.. warning::` on `mirror_entry` that documented this gap is removed, since
  the behaviour now matches the docstring. `_populate_mirror` needed no change:
  it already catches `RetrievalError`, so a failed push is still a partial-
  success note rather than a lost acquisition.
- **`dataset` — what changed for its consumers.** Two observable changes, both
  in the honest direction:
  1. `audit` reports `mirror_present` as `null` (unknown) instead of `false`
     for a mirror it could not reach. The field type is now
     `dict[str, bool | None]` and the JSON can carry `null`. `report.ok` is
     unchanged — mirror presence has never contributed to it.
  2. `fetch` (`_resolve_file`) stops the chain on an unreachable mirror instead
     of falling through to the Tier-B fetch, or — worse — to the Tier-C
     "acquire manually then re-verify" message, which would tell a human to
     hand-acquire bytes that may be sitting behind an expired credential.
  Nothing else in `dataset` changes: a mirror that answers "absent" behaves
  exactly as before.
- **Test fakes were wrong, and that is the signal.** `dataset`'s and the
  literature CLI's rclone fakes used exit `1` to mean "absent" — a code rclone
  never uses for that. Because the old `_run_ok` treated every non-zero exit
  alike, nothing noticed. They now return `4`, so the fakes model rclone rather
  than the bug.
- **Tests assert the negative.** A failing runner cannot produce an "absent"
  verdict: parametrized over every non-absence exit code at the `Mirror` API
  (asserting no value was returned at all, not merely that it was not `True`),
  through `dataset audit`/`fetch` (the Tier-B fetcher must never be called), and
  end to end through `literature fetch` (`manual == []`, one `errors[]` row,
  exit 1). #107's four defects all survived a 100%-coverage suite precisely
  because every test asserted what should happen and none asserted what must
  not.
- `docs/design/04-substrate-and-contract.md` §2.3's chain diagram said step 2
  "falls through"; it now says it falls through only on an answered absence.

## Checks

```
$ cd defendable-science && uv run ruff check . && uv run ruff format --check . && uv run mypy && uv run pytest -q
All checks passed!
39 files already formatted
Success: no issues found in 41 source files
...
TOTAL                                         2762      0    836      0   100%
Required test coverage of 100.0% reached. Total coverage: 100.00%
666 passed, 14 skipped in 3.46s
```

`./tools/validate-plugin.sh` → `✔ Validation passed`; `uvx pre-commit run
--all-files` → all hooks Passed.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
