### PR TITLE
fix(backlog): preserve the host document when writing backlog tables (closes #94, #95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`backlog` no longer rewrites the documents it edits.** `Backlog.loads()` was
+  prose-tolerant but `dumps()`/`save()` emitted only the table, so the
+  `load → mutate → save` round trip behind every `backlog park|add|rank|promote|
+  drop` deleted every non-table line — a heading and its explanatory prose gone
+  on the first `park`. Worse, rows were parsed against the *file's* header but
+  serialized against `columns_for(level)`, so a hand-written table with any other
+  column layout was written back with its row count preserved and its cells
+  **blank**: nothing looked wrong, and the content was gone. The parser now
+  retains the prose before and after the table plus the file's own header, and
+  `save` splices only the table region back. A mutation that a host header cannot
+  carry (no `id`/`status`, or `drop` with no `note` column) raises
+  `BacklogError` naming the missing columns and both layouts, rather than writing
+  cells that serialization would drop; columns a consumer has *added* survive and
+  are left empty on new rows. **Existing consumer backlogs may already carry this
+  damage — check `git log -p` on your `portfolio-backlog.md` and `backlog.md`
+  files.** (#94)
+- **`promote` inserts the `papers.md` row into the registry table**, wherever that
+  table sits in the document, instead of appending it at end-of-file with a
+  hardcoded three-column shape. A registry documented with prose after the table
+  got a stray row orphaned below the prose, and a registry extended with e.g.
+  `readiness` / `covers (thesis aims)` columns got a ragged three-cell row; both
+  meant the registry half of `promote` had to be done by hand. The row now
+  matches the host header's column count with extra columns left empty, and a
+  registry table missing `paper-id`/`root`/`backend`, or whose rows are not
+  anchored by a GFM separator, is refused loudly rather than corrupted. (#95)
+- **A minted backlog id is no longer cut mid-word.** The 40-character cap
+  truncated blindly, yielding ids like
+  `a-survey-of-monotonicity-methods-in-mach`; since a paper-level id becomes the
+  `paper-id` keying the paper across backlog, registry, dashboard and `progress`,
+  this made `--id` effectively mandatory. It now truncates on a word boundary.
+  (#94)
 - `skills/literature/SKILL.md` §Tooling no longer claims a PRISMA-log or
   concept-matrix generator that was never implemented; the CSL-JSON registry
   loader/patcher and triage sidecar reader it also claimed are real as of

--- a/defendable-science/defendable_science/exploration/backlog.py
+++ b/defendable-science/defendable_science/exploration/backlog.py
@@ -44,8 +44,14 @@ PAPER_COLUMNS = [
     "note",
 ]
 
+#: The columns ``papers.md`` must carry for ``promote`` to register a paper.
+REGISTRY_COLUMNS = ["paper-id", "root", "backend"]
+
 #: Allowed source states for the ``rank`` transition.
 _RANK_SOURCES = frozenset({"candidate", "parked"})
+
+#: Character cap on a minted row id (truncated on a word boundary).
+_ID_MAX = 40
 
 Row = dict[str, str]
 
@@ -57,6 +63,27 @@ class BacklogError(ValueError):
 def columns_for(level: Level) -> list[str]:
     """Return the column order for a backlog `level`."""
     return list(HYPOTHESIS_COLUMNS if level == "hypothesis" else PAPER_COLUMNS)
+
+
+def _slug(one_line: str, limit: int = _ID_MAX) -> str:
+    """Kebab-case `one_line` into an id, truncated on a word boundary.
+
+    A mid-word cut is avoided because the paper-level id becomes the ``paper-id``
+    that keys the paper across backlog, registry, dashboard and ``progress``, so
+    an unreadable default id is effectively unusable.
+
+    :param one_line: The one-line summary to slugify.
+    :param limit: Maximum length; the last whole word that fits is kept, or a
+        hard cut if the first word alone exceeds it.
+    :returns: The slug, or ``"row"`` if `one_line` has no alphanumerics.
+    """
+    base = re.sub(r"[^a-z0-9]+", "-", one_line.lower()).strip("-")
+    if not base:
+        return "row"
+    if len(base) <= limit:
+        return base
+    head, sep, _ = base[: limit + 1].rpartition("-")
+    return head if sep else base[:limit]
 
 
 # --- markdown table I/O -----------------------------------------------------
@@ -100,70 +127,198 @@ def _is_separator(cells: list[str]) -> bool:
 
 
 @dataclass
-class Backlog:
-    """An in-memory backlog table.
+class _Document:
+    """A host markdown document with its table located in place.
 
-    :param level: The backlog level (selects the column profile).
+    :param preamble: Text before the table's header line, verbatim; the whole
+        document when it holds no table.
+    :param header: The column order read from the file, or ``None`` if the
+        document holds no table.
+    :param rows: The data rows, keyed by the file's own header.
+    :param postamble: Text after the table's last data row, verbatim.
+    :param saw_table_shape: Whether table-like rows were seen but never anchored
+        by a GFM separator (a malformed table, not an empty document).
+    """
+
+    preamble: str = ""
+    header: list[str] | None = None
+    rows: list[Row] = field(default_factory=list)
+    postamble: str = ""
+    saw_table_shape: bool = False
+
+
+def _collect_rows(
+    lines: list[str], header: list[str], start: int
+) -> tuple[list[Row], int]:
+    """Parse the contiguous data rows at `start`, with the index just past them.
+
+    The table ends at the first line that is not a non-separator pipe row, so
+    whatever follows is host prose to be preserved rather than table content.
+
+    :param lines: The document's lines (newlines kept).
+    :param header: The confirmed header, whose width every row must match.
+    :param start: Index of the first line after the GFM separator.
+    :returns: The parsed rows and the index of the first post-table line.
+    :raises BacklogError: If a data row's cell count does not match `header` (a
+        ragged row would otherwise silently pad/drop required columns).
+    """
+    rows: list[Row] = []
+    end = start
+    while end < len(lines):
+        if "|" not in lines[end]:
+            break
+        cells = _split_cells(lines[end])
+        if _is_separator(cells):
+            break
+        if len(cells) != len(header):
+            raise BacklogError(
+                f"ragged backlog row: {len(cells)} cells, header has "
+                f"{len(header)} ({cells!r})"
+            )
+        rows.append({header[i]: cells[i] for i in range(len(header))})
+        end += 1
+    return rows, end
+
+
+def _parse_document(text: str) -> _Document:
+    """Locate the markdown table in `text`, keeping the prose around it.
+
+    The header is the pipe line confirmed by a following GFM ``|---|`` separator;
+    that anchor is what distinguishes a real table from stray prose pipes.
+
+    :param text: The host markdown document.
+    :returns: The located document (``header is None`` if it holds no table).
+    :raises BacklogError: If a data row is ragged (see :func:`_collect_rows`).
+    """
+    lines = text.splitlines(keepends=True)
+    candidate: list[str] | None = None
+    candidate_at = 0
+    pending = 0  # consecutive unconfirmed pipe rows (a table shape sans separator)
+    saw_table_shape = False
+    for i, line in enumerate(lines):
+        if "|" not in line:
+            candidate = None  # prose breaks a pending header candidate
+            pending = 0
+            continue
+        cells = _split_cells(line)
+        if _is_separator(cells):
+            if candidate is None:
+                continue
+            rows, end = _collect_rows(lines, candidate, i + 1)
+            return _Document(
+                preamble="".join(lines[:candidate_at]),
+                header=candidate,
+                rows=rows,
+                postamble="".join(lines[end:]),
+            )
+        candidate, candidate_at = cells, i  # a header only if a separator follows
+        pending += 1
+        if pending >= 2:  # header + row(s) shape with no separator between
+            saw_table_shape = True
+    return _Document(preamble=text, saw_table_shape=saw_table_shape)
+
+
+def _render_table(header: list[str], rows: list[Row]) -> str:
+    """Render `rows` as a GFM table in `header`'s column order."""
+    lines = [
+        "| " + " | ".join(header) + " |",
+        "|" + "|".join("---" for _ in header) + "|",
+    ]
+    lines.extend(
+        "| " + " | ".join(_escape(row.get(c, "")) for c in header) + " |"
+        for row in rows
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _splice(preamble: str, postamble: str, header: list[str], rows: list[Row]) -> str:
+    """Re-emit a host document with its table region replaced.
+
+    Everything the table does not own — the heading and the prose before and
+    after it — is written back verbatim, so ``load → mutate → save`` is lossless.
+
+    :param preamble: Host text before the table.
+    :param postamble: Host text after the table.
+    :param header: The column order to render.
+    :param rows: The rows to render.
+    :returns: The whole document, table spliced in.
+    """
+    if preamble and not preamble.endswith("\n"):
+        preamble += "\n"  # a table cannot start mid-line
+    return preamble + _render_table(header, rows) + postamble
+
+
+@dataclass
+class Backlog:
+    """A backlog table together with the host document it was read from.
+
+    :param level: The backlog level (selects the canonical column profile).
     :param rows: The parsed rows, each a ``column -> value`` mapping.
+    :param preamble: Host text before the table (heading, explanatory prose),
+        re-emitted verbatim by :meth:`dumps` so a round-trip loses nothing.
+    :param postamble: Host text after the table, re-emitted verbatim.
+    :param file_header: The column order read from the file; ``None`` for a
+        backlog not read from one, which uses this level's profile.
     """
 
     level: Level
     rows: list[Row] = field(default_factory=list)
+    preamble: str = ""
+    postamble: str = ""
+    file_header: list[str] | None = None
 
     @property
     def columns(self) -> list[str]:
-        """The column order for this backlog's level."""
-        return columns_for(self.level)
+        """The column order this backlog reads and writes.
+
+        The host file's own header when one was parsed, so extra columns survive
+        and a file is never silently restructured into ``columns_for(level)``;
+        this level's canonical profile otherwise.
+        """
+        return list(self.file_header) if self.file_header else columns_for(self.level)
+
+    def _require(self, *columns: str) -> None:
+        """Guard that the host table can carry the columns a mutation writes.
+
+        :param columns: The columns the caller is about to write.
+        :raises BacklogError: Naming the missing columns and both layouts. The
+            mutation is refused rather than written into a header that cannot
+            hold it, which serialization would silently drop.
+        """
+        missing = [c for c in columns if c not in self.columns]
+        if missing:
+            raise BacklogError(
+                f"backlog table cannot carry required column(s) {missing}: its "
+                f"header is {self.columns}; add them, or migrate the table to "
+                f"the {self.level} profile {columns_for(self.level)}"
+            )
 
     @classmethod
     def loads(cls, text: str, level: Level) -> Backlog:
-        """Parse a markdown backlog table from `text`.
+        """Parse a markdown backlog table from `text`, host document included.
 
         :param text: The markdown document (may contain prose around the table).
         :param level: The backlog level.
-        :returns: The parsed backlog.
+        :returns: The parsed backlog, carrying the surrounding prose and the
+            file's own header so :meth:`dumps` can write both back.
         :raises BacklogError: If table-like content is present but never anchored
             by a GFM separator (a malformed table is not a genuinely empty one),
             or a data row's cell count does not match the header (a ragged row
             would otherwise silently pad/drop required columns).
         """
-        header: list[str] | None = None
-        rows: list[Row] = []
-        candidate: list[str] | None = None
-        pending = 0  # consecutive unconfirmed pipe rows (a table shape sans separator)
-        saw_table_shape = False
-        for line in text.splitlines():
-            if "|" not in line:
-                candidate = None  # prose breaks a pending header candidate
-                pending = 0
-                continue
-            cells = _split_cells(line)
-            if _is_separator(cells):
-                # The GFM separator confirms the preceding pipe line was the header;
-                # this is what distinguishes the table from stray prose pipes.
-                if header is None and candidate is not None:
-                    header = candidate
-                    candidate = None
-                    pending = 0
-                continue
-            if header is None:
-                candidate = cells  # a header only if a separator follows it
-                pending += 1
-                if pending >= 2:  # header + row(s) shape with no separator between
-                    saw_table_shape = True
-                continue
-            if len(cells) != len(header):
-                raise BacklogError(
-                    f"ragged backlog row: {len(cells)} cells, header has "
-                    f"{len(header)} ({cells!r})"
-                )
-            rows.append({header[i]: cells[i] for i in range(len(header))})
-        if header is None and saw_table_shape:
+        doc = _parse_document(text)
+        if doc.header is None and doc.saw_table_shape:
             raise BacklogError(
                 "malformed backlog table: table-like rows with no GFM '|---|' "
                 "separator to anchor a header"
             )
-        return cls(level=level, rows=rows)
+        return cls(
+            level=level,
+            rows=doc.rows,
+            preamble=doc.preamble,
+            postamble=doc.postamble,
+            file_header=doc.header,
+        )
 
     @classmethod
     def load(cls, path: str | Path, level: Level) -> Backlog:
@@ -174,26 +329,22 @@ class Backlog:
         return cls.loads(file_path.read_text(encoding="utf-8"), level)
 
     def dumps(self) -> str:
-        """Serialize the backlog to a markdown table string."""
-        cols = self.columns
-        lines = [
-            "| " + " | ".join(cols) + " |",
-            "|" + "|".join("---" for _ in cols) + "|",
-        ]
-        lines.extend(
-            "| " + " | ".join(_escape(row.get(c, "")) for c in cols) + " |"
-            for row in self.rows
-        )
-        return "\n".join(lines) + "\n"
+        """Serialize the backlog, host document included.
+
+        The table is rendered in :attr:`columns` order; the heading and prose
+        around it are written back verbatim.
+        """
+        return _splice(self.preamble, self.postamble, self.columns, self.rows)
 
     def save(self, path: str | Path) -> None:
-        """Write the backlog table to `path`."""
+        """Write the backlog — table and surrounding prose — to `path`."""
         Path(path).write_text(self.dumps(), encoding="utf-8")
 
     # --- lookup ---
 
     def get(self, row_id: str) -> Row:
         """Return the row with `row_id`, or raise :class:`BacklogError`."""
+        self._require("id")
         for row in self.rows:
             if row.get("id") == row_id:
                 return row
@@ -201,7 +352,7 @@ class Backlog:
 
     def _fresh_id(self, one_line: str) -> str:
         """Mint a stable, unique kebab-case id from a one-line summary."""
-        base = re.sub(r"[^a-z0-9]+", "-", one_line.lower()).strip("-")[:40] or "row"
+        base = _slug(one_line)
         existing = {row.get("id", "") for row in self.rows}
         if base not in existing:
             return base
@@ -248,6 +399,7 @@ class Backlog:
     def _append(
         self, one_line: str, provenance: str, status: str, row_id: str | None
     ) -> Row:
+        self._require("id", "one-line", "provenance", "status")
         if not provenance.strip():
             raise BacklogError("provenance is required (no orphan ideas)")
         if row_id is not None and any(r.get("id") == row_id for r in self.rows):
@@ -268,6 +420,7 @@ class Backlog:
         :raises BacklogError: If the row's status is not ``candidate``/``parked``,
             or a score key is not a column of this level.
         """
+        self._require("status")
         row = self.get(row_id)
         if row.get("status") not in _RANK_SOURCES:
             raise BacklogError(
@@ -296,6 +449,7 @@ class Backlog:
         :returns: The updated row.
         :raises BacklogError: If the row's status is not ``ranked``.
         """
+        self._require("status")
         row = self.get(row_id)
         if row.get("status") != "ranked":
             raise BacklogError(
@@ -313,6 +467,7 @@ class Backlog:
         :returns: The updated row.
         :raises BacklogError: If `reason` is empty.
         """
+        self._require("status", "note")
         if not reason.strip():
             raise BacklogError("a drop reason is required (file-drawer discipline)")
         row = self.get(row_id)
@@ -412,24 +567,44 @@ def scaffold_hypothesis(
 def append_papers_registry(
     papers_md: str | Path, paper_id: str, root: str, backend: str
 ) -> None:
-    """Append one paper row to the ``papers.md`` registry (create if absent).
+    """Insert one paper row into the ``papers.md`` registry (create if absent).
+
+    The row is spliced in as the registry table's last data row wherever that
+    table sits in the document, so prose after it stays prose instead of being
+    orphaned behind a stray row. Columns the host header carries beyond
+    :data:`REGISTRY_COLUMNS` are written empty for the author to fill, never
+    dropped and never producing a ragged row.
 
     :param papers_md: Path to ``docs/research/papers.md``.
     :param paper_id: The stable paper id (must be new).
     :param root: The paper's root path, relative to the repo.
     :param backend: The experiment-backend binding for the paper.
-    :raises BacklogError: If `paper_id` is already registered.
+    :raises BacklogError: If `paper_id` is already registered, the registry table
+        lacks one of :data:`REGISTRY_COLUMNS`, or its rows are not anchored by a
+        GFM separator (writing into a malformed registry would corrupt it).
     """
     path = Path(papers_md)
-    header = "| paper-id | root | backend |\n|---|---|---|\n"
-    text = path.read_text(encoding="utf-8") if path.is_file() else header
-    if re.search(rf"^\|\s*{re.escape(paper_id)}\s*\|", text, flags=re.MULTILINE):
+    text = path.read_text(encoding="utf-8") if path.is_file() else ""
+    doc = _parse_document(text)
+    if doc.header is None and doc.saw_table_shape:
+        raise BacklogError(
+            f"malformed registry table in {path}: table-like rows with no GFM "
+            "'|---|' separator to anchor a header"
+        )
+    header = doc.header or list(REGISTRY_COLUMNS)
+    missing = [c for c in REGISTRY_COLUMNS if c not in header]
+    if missing:
+        raise BacklogError(
+            f"registry table in {path} is missing required column(s) {missing}: "
+            f"its header is {header}"
+        )
+    if any(row.get("paper-id") == paper_id for row in doc.rows):
         raise BacklogError(f"paper-id {paper_id!r} already in {path}")
-    if not text.endswith("\n"):
-        text += "\n"
-    text += f"| {paper_id} | {root} | {backend} |\n"
+    doc.rows.append({"paper-id": paper_id, "root": root, "backend": backend})
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+    path.write_text(
+        _splice(doc.preamble, doc.postamble, header, doc.rows), encoding="utf-8"
+    )
 
 
 def _registry_root(root: Path, research: Path) -> str:

--- a/defendable-science/tests/test_backlog.py
+++ b/defendable-science/tests/test_backlog.py
@@ -345,3 +345,282 @@ def test_loads_ignores_prose_pipes_before_table() -> None:
     reloaded = b.Backlog.loads(doc, "hypothesis")
     assert [r["one-line"] for r in reloaded.rows] == ["real claim"]
     assert reloaded.columns == board.columns  # header taken from the real table
+
+
+# --- host-document preservation (#94) ----------------------------------------
+
+#: A hand-written portfolio backlog: heading, prose, table, prose after it.
+_HOST_DOC = """# Portfolio backlog
+
+Paper-level ideas not yet promoted to a paper root.
+
+| id | one-line | lens | provenance | feas | interest | status | note |
+|---|---|---|---|---|---|---|---|
+| earlier | some earlier idea | a lens | a resolved paper | med | high | parked | keep me |
+
+## How to use this file
+
+Rank before promoting; never delete a row.
+"""
+
+
+def _assert_host_doc_intact(text: str) -> None:
+    """Assert the prose and the pre-existing row survived a write."""
+    assert text.startswith("# Portfolio backlog\n")
+    assert "Paper-level ideas not yet promoted to a paper root." in text
+    assert text.endswith("Rank before promoting; never delete a row.\n")
+    assert "## How to use this file" in text
+    assert "| earlier | some earlier idea | a lens |" in text
+    assert "keep me" in text
+
+
+def test_load_mutate_save_preserves_prose(tmp_path: Path) -> None:
+    # The load → mutate → save round trip must not own anything but the table.
+    path = tmp_path / "portfolio-backlog.md"
+    path.write_text(_HOST_DOC, encoding="utf-8")
+    board = b.Backlog.load(path, "paper")
+    board.park("a fresh idea", "own")
+    board.save(path)
+    text = path.read_text(encoding="utf-8")
+    _assert_host_doc_intact(text)
+    assert "| a-fresh-idea | a fresh idea |" in text
+
+
+def test_untouched_load_save_is_byte_identical(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio-backlog.md"
+    path.write_text(_HOST_DOC, encoding="utf-8")
+    b.Backlog.load(path, "paper").save(path)
+    assert path.read_text(encoding="utf-8") == _HOST_DOC
+
+
+def test_foreign_header_refuses_mutation_rather_than_blanking() -> None:
+    # The reproduction from defendable-science#94: a three-column hand-written
+    # table. Rows must survive parsing AND serialization, and a mutation that
+    # cannot be represented is refused loudly instead of writing blank cells.
+    text = (
+        "# Portfolio backlog\n\nSome prose.\n\n"
+        "| idea | origin | note |\n|---|---|---|\n"
+        "| some earlier idea | a resolved paper | keep me |\n"
+    )
+    board = b.Backlog.loads(text, "paper")
+    assert board.rows == [
+        {"idea": "some earlier idea", "origin": "a resolved paper", "note": "keep me"}
+    ]
+    assert board.dumps() == text  # nothing restructured, nothing blanked
+    with pytest.raises(b.BacklogError, match="cannot carry required column"):
+        board.park("a new idea", "own")
+
+
+def test_superset_header_keeps_extra_columns(tmp_path: Path) -> None:
+    # A consumer that added its own columns keeps them, and a new row leaves
+    # them empty for the author rather than shifting the layout.
+    path = tmp_path / "portfolio-backlog.md"
+    cols = [*b.PAPER_COLUMNS, "readiness"]
+    path.write_text(
+        "| " + " | ".join(cols) + " |\n"
+        "|" + "|".join("---" for _ in cols) + "|\n"
+        "| earlier | old | lens | src | med | high | parked | note | ready |\n",
+        encoding="utf-8",
+    )
+    board = b.Backlog.load(path, "paper")
+    assert board.columns == cols
+    board.park("a fresh idea", "own")
+    board.save(path)
+    text = path.read_text(encoding="utf-8")
+    assert "| readiness |" in text
+    assert "| earlier | old | lens | src | med | high | parked | note | ready |" in text
+    rows = b.Backlog.load(path, "paper").rows
+    assert rows[1]["readiness"] == ""  # extra column present but unset
+    assert len(rows[1]) == len(cols)  # not ragged
+
+
+def test_content_after_table_is_prose_not_rows() -> None:
+    # A pipe line separated from the table by prose belongs to the host
+    # document; absorbing it as a row would reformat text the tool does not own.
+    text = (
+        "| id | status |\n|---|---|\n| h1 | parked |\n"
+        "\nAside: cost | benefit\n| h2 | parked |\n"
+    )
+    board = b.Backlog.loads(text, "hypothesis")
+    assert board.rows == [{"id": "h1", "status": "parked"}]
+    assert board.dumps() == text
+
+
+def test_stray_separator_after_rows_ends_the_table() -> None:
+    text = "| id | status |\n|---|---|\n| h1 | parked |\n|---|---|\ntrailing\n"
+    board = b.Backlog.loads(text, "hypothesis")
+    assert board.rows == [{"id": "h1", "status": "parked"}]
+    assert board.postamble == "|---|---|\ntrailing\n"
+    assert board.dumps() == text
+
+
+def test_prose_only_document_gains_a_table_below_the_prose() -> None:
+    # No trailing newline: the table must not be spliced mid-line.
+    board = b.Backlog.loads("just prose, no table", "hypothesis")
+    board.park("an idea", "own")
+    out = board.dumps()
+    assert out.startswith("just prose, no table\n| id |")
+
+
+def test_drop_refuses_a_table_without_a_note_column() -> None:
+    # The drop reason has nowhere to go, so the transition is refused rather
+    # than recorded and then dropped on serialization (file-drawer discipline).
+    cols = [c for c in b.HYPOTHESIS_COLUMNS if c != "note"]
+    text = (
+        "| " + " | ".join(cols) + " |\n"
+        "|" + "|".join("---" for _ in cols) + "|\n"
+        "| h1 | claim | move | src | high | med | high | frame | ranked |\n"
+    )
+    board = b.Backlog.loads(text, "hypothesis")
+    with pytest.raises(b.BacklogError, match=r"required column\(s\) \['note'\]"):
+        board.drop("h1", "superseded")
+    assert board.dumps() == text
+
+
+@pytest.mark.parametrize(
+    ("one_line", "expected"),
+    [
+        (
+            "A survey of monotonicity methods in machine learning",
+            "a-survey-of-monotonicity-methods-in",
+        ),
+        ("short enough", "short-enough"),
+        ("!!! ???", "row"),
+        ("a" * 60, "a" * 40),  # a single word longer than the cap: hard cut
+    ],
+)
+def test_slug_truncates_on_a_word_boundary(one_line: str, expected: str) -> None:
+    assert b._slug(one_line) == expected
+
+
+def test_minted_id_is_not_cut_mid_word() -> None:
+    board = b.Backlog(level="paper")
+    row = board.park("A survey of monotonicity methods in machine learning", "own")
+    assert row["id"] == "a-survey-of-monotonicity-methods-in"
+
+
+# --- CLI verbs preserve the host document (#94) ------------------------------
+
+
+def test_cli_verbs_preserve_prose(tmp_path: Path) -> None:
+    path = tmp_path / "portfolio-backlog.md"
+    path.write_text(_HOST_DOC, encoding="utf-8")
+    common = ["--backlog", str(path), "--level", "paper"]
+
+    for args in (
+        ["backlog", "park", "an idea", "--provenance", "own", "--id", "x1", *common],
+        ["backlog", "add", "a claim", "--provenance", "own", "--id", "x2", *common],
+        ["backlog", "rank", "x1", "--feas", "high", "--interest", "med", *common],
+        ["backlog", "promote", "x1", *common],
+        ["backlog", "drop", "x2", "--reason", "superseded", *common],
+    ):
+        result = runner.invoke(app, args)
+        assert result.exit_code == 0, (args, result.stdout)
+        _assert_host_doc_intact(path.read_text(encoding="utf-8"))
+
+    rows = b.Backlog.load(path, "paper").rows
+    assert [r["id"] for r in rows] == ["earlier", "x1", "x2"]
+    assert rows[1]["status"] == "promoted"
+    assert rows[2]["status"] == "dropped"
+    assert rows[2]["note"] == "superseded"
+
+
+# --- papers registry splicing (#95) ------------------------------------------
+
+_REGISTRY_DOC = """# Papers
+
+The portfolio registry.
+
+| paper-id | root | backend |
+|---|---|---|
+| first | docs/research/first | bench |
+
+## Scope notes
+
+- **first** — the anchor paper.
+"""
+
+
+def test_registry_row_lands_inside_the_table(tmp_path: Path) -> None:
+    papers = tmp_path / "papers.md"
+    papers.write_text(_REGISTRY_DOC, encoding="utf-8")
+    b.append_papers_registry(papers, "second", "docs/research/second", "sim")
+    text = papers.read_text(encoding="utf-8")
+    assert "| first | docs/research/first | bench |\n" in text
+    assert "| second | docs/research/second | sim |\n\n## Scope notes" in text
+    assert text.endswith("- **first** — the anchor paper.\n")
+    # Still one table: the parser sees both rows.
+    doc = b._parse_document(text)
+    assert [r["paper-id"] for r in doc.rows] == ["first", "second"]
+
+
+def test_registry_extra_columns_are_filled_empty(tmp_path: Path) -> None:
+    papers = tmp_path / "papers.md"
+    papers.write_text(
+        "| paper-id | root | backend | readiness | covers (thesis aims) |\n"
+        "|---|---|---|---|---|\n"
+        "| first | docs/research/first | bench | drafting | A1 |\n",
+        encoding="utf-8",
+    )
+    b.append_papers_registry(papers, "second", "docs/research/second", "sim")
+    doc = b._parse_document(papers.read_text(encoding="utf-8"))
+    assert doc.rows[1] == {
+        "paper-id": "second",
+        "root": "docs/research/second",
+        "backend": "sim",
+        "readiness": "",
+        "covers (thesis aims)": "",
+    }
+    assert doc.rows[0]["readiness"] == "drafting"  # untouched
+
+
+def test_registry_missing_required_column_raises(tmp_path: Path) -> None:
+    papers = tmp_path / "papers.md"
+    papers.write_text("| paper-id | root |\n|---|---|\n", encoding="utf-8")
+    before = papers.read_text(encoding="utf-8")
+    with pytest.raises(
+        b.BacklogError, match=r"missing required column\(s\) \['backend'\]"
+    ):
+        b.append_papers_registry(papers, "p1", "docs/research/p1", "bench")
+    assert papers.read_text(encoding="utf-8") == before
+
+
+def test_registry_malformed_table_raises(tmp_path: Path) -> None:
+    papers = tmp_path / "papers.md"
+    papers.write_text(
+        "| paper-id | root | backend |\n| first | docs/research/first | bench |\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(b.BacklogError, match="malformed registry table"):
+        b.append_papers_registry(papers, "p1", "docs/research/p1", "bench")
+
+
+def test_registry_absent_file_creates_three_column_table(tmp_path: Path) -> None:
+    papers = tmp_path / "nested" / "papers.md"
+    b.append_papers_registry(papers, "p1", "docs/research/p1", "bench")
+    assert papers.read_text(encoding="utf-8") == (
+        "| paper-id | root | backend |\n|---|---|---|\n"
+        "| p1 | docs/research/p1 | bench |\n"
+    )
+
+
+def test_registry_duplicate_id_in_prose_is_not_a_duplicate(tmp_path: Path) -> None:
+    # The guard reads parsed rows, so a mention below the table is just prose.
+    papers = tmp_path / "papers.md"
+    papers.write_text(
+        "| paper-id | root | backend |\n|---|---|---|\n\nNotes on | p1 | below.\n",
+        encoding="utf-8",
+    )
+    b.append_papers_registry(papers, "p1", "docs/research/p1", "bench")
+    assert "Notes on | p1 | below." in papers.read_text(encoding="utf-8")
+
+
+def test_scaffold_paper_row_is_inside_the_table(tmp_path: Path) -> None:
+    research = tmp_path / "docs" / "research"
+    research.mkdir(parents=True)
+    (research / "papers.md").write_text(_REGISTRY_DOC, encoding="utf-8")
+    b.scaffold_paper(research, "second", "a follow-up paper", backend="sim")
+    doc = b._parse_document((research / "papers.md").read_text(encoding="utf-8"))
+    assert [r["paper-id"] for r in doc.rows] == ["first", "second"]
+    assert doc.rows[1]["root"] == "docs/research/second"
+    assert doc.postamble.startswith("\n## Scope notes")

--- a/skills/hypothesis-exploration/SKILL.md
+++ b/skills/hypothesis-exploration/SKILL.md
@@ -69,9 +69,11 @@ carries provenance so any candidate can be traced to where it came from:
 > (`defendable_science/exploration/backlog.py`) — ensure via
 > [`ensure-tooling`](../../resources/ensure-tooling.md); shared with
 > `paper-exploration`. `add` realizes the `generate` verb's row-append; `list` is a
-> read-only inspection command. By hand (if the CLI isn't available): edit the
-> `backlog.md` table directly, keeping the column order above so the `backlog`
-> verbs (`rank`, `promote`, `list`) can parse it.
+> read-only inspection command. The table's host document is preserved — prose
+> around the table survives every verb, and columns your repo adds beyond the
+> order above are kept (left empty on new rows). By hand (if the CLI isn't
+> available): edit the `backlog.md` table directly, keeping the column order
+> above so the `backlog` verbs (`rank`, `promote`, `list`) can parse it.
 
 ## Generation moves
 

--- a/skills/paper-exploration/SKILL.md
+++ b/skills/paper-exploration/SKILL.md
@@ -56,9 +56,11 @@ explicit human pick — the exploration/resolution firewall
 > (`defendable_science/exploration/backlog.py`, shared with `hypothesis-exploration`)
 > — ensure via [`ensure-tooling`](../../resources/ensure-tooling.md),
 > operating on `portfolio-backlog.md` at the paper level. `add` realizes the
-> `generate` verb's row-append; `list` is a read-only inspection command. By hand
-> (if the CLI isn't available): edit the `portfolio-backlog.md` table directly,
-> keeping the column order.
+> `generate` verb's row-append; `list` is a read-only inspection command. The
+> table's host document is preserved — a heading and prose around the table
+> survive every verb, and columns your repo adds beyond the standard order are
+> kept (left empty on new rows). By hand (if the CLI isn't available): edit the
+> `portfolio-backlog.md` table directly, keeping the column order.
 
 ## Generation lenses
 
@@ -125,7 +127,10 @@ paper roots and their experiment-backend binding.
   the backend from this binding and contain no backend-specific logic, so
   `backend:` is set here at registration time.
 - **When it is written.** `promote` adds the registry row and scaffolds the paper
-  root (`hypotheses/`, `backlog.md`, `paper/`). A candidate in
+  root (`hypotheses/`, `backlog.md`, `paper/`). The row is spliced into the
+  registry table wherever that table sits, so `papers.md` can carry prose around
+  it, and columns you add beyond `paper-id | root | backend` are preserved and
+  left empty for you to fill. A candidate in
   `portfolio-backlog.md` is *not* in `papers.md` — the backlog is proposals; the
   registry is committed papers.
 - **paper-id.** A stable, human-readable slug (kebab-case), assigned at promotion


### PR DESCRIPTION
## What

The `backlog` writers no longer rewrite the documents they edit. `load → mutate
→ save` now preserves everything it does not own — the heading, the prose around
the table, and columns a consumer added — and a mutation that cannot be
represented in the host header is refused loudly instead of writing blanks.

Both issues were the same bug in two writers, so they are fixed by one
table-splicing helper rather than two.

## Details

**#94 — `save()` discarded prose and blanked foreign-schema rows.**
`loads()` was prose-tolerant; `dumps()`/`save()` emitted only the table, so
every `park | add | rank | promote | drop` deleted the surrounding lines. Rows
were parsed against the *file's* header but serialized against
`columns_for(level)`, so a table with any other layout came back with its row
count intact and its cells **blank** — nothing looked wrong, and the content was
gone.

- `_parse_document()` locates the GFM-separator-anchored table and retains the
  preamble, the postamble and the file's own header; `_splice()` replaces only
  the table region. `Backlog` grew `preamble` / `postamble` / `file_header`
  fields (all defaulted, so existing construction is unaffected).
- **Schema policy:** `columns` reports the host file's header when one was
  parsed. Extra columns survive and are left empty on new rows;
  `columns_for(level)` is now the profile for files we *create*, not one we
  impose on files we *read*. A mutation the header cannot carry — no
  `id`/`status`, or `drop` with no `note` column — raises `BacklogError` naming
  the missing columns and both layouts. This is deliberately not the "raise on
  any mismatch" option from the issue: that would hard-block every verb on a
  lightly-customized file, and it is not the "migrate into `note`" option
  either, since silently restructuring the research record is the thing #94 is
  complaining about.
- The table now ends at the first line that is not a non-separator pipe row, so
  a pipe line separated from the table by prose stays prose instead of being
  absorbed and reformatted.

**#95 — `append_papers_registry` appended outside the table.** It reuses the same
locator, so the row is spliced in as the registry table's last data row wherever
that table sits, with a cell count matching the host header (extras empty). A
registry missing `paper-id`/`root`/`backend`, or whose rows are not anchored by a
GFM separator, is refused rather than corrupted. The duplicate-`paper-id` guard
moved from a regex over the whole file to a check over parsed rows, so a
`paper-id` mentioned in prose below the table is no longer a false duplicate.

**Minor, folded in per #94.** `_slug()` truncates a minted id on a word boundary.
The 40-character cap cut mid-word (`a-survey-of-monotonicity-methods-in-mach`),
and since a paper-level id becomes the `paper-id` keying the paper across
backlog, registry, dashboard and `progress`, that made `--id` effectively
mandatory at the paper level.

**Generality (for #100).** `_parse_document` / `_render_table` / `_splice` read
the column names from the header row and are schema-agnostic —
`REGISTRY_COLUMNS` is only a required-*subset* check, not a fixed vocabulary. A
concept matrix whose axes the survey author invents parses and round-trips
through them unchanged, so #100 needs no second reader; it needs at most a small
extraction of the three helpers into a shared module.

**Not changed, flagged separately.** `scaffold_paper` (and so
`append_papers_registry`) has no CLI entry point — `backlog promote` only flips
the row's status, while both exploration skills document `promote` as also
scaffolding the paper root and registering the paper. That is a missing command,
not a writer bug, and is left for its own issue.

24 tests added; all 639 pre-existing tests pass untouched and the 100%
statement+branch coverage gate holds.

**Consumer impact:** existing `portfolio-backlog.md` / `backlog.md` files may
already carry the damage — the CHANGELOG entry says to check `git log -p` on
them. Downstream: davorrunje/mononet#178.

Closes #94
Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)
