### PR TITLE
fix(literature): report rung 6 as trusted, recover suffix-less landing pages (closes #104, #105)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,9 +133,9 @@
         "filename": "docs/guides/literature.md",
         "hashed_secret": "aee0a7bd78ec2f13647c0990b6644f2ddf9ab2ff",
         "is_verified": false,
-        "line_number": 279
+        "line_number": 287
       }
     ]
   },
-  "generated_at": "2026-08-27T11:10:18Z"
+  "generated_at": "2026-08-27T15:18:20Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Rung 6 (`venue_resolvers`) no longer reports a verification it never
+  performed.** `RUNG_VENUE` was in `GATED_RUNGS`, so every consumer-configured
+  venue candidate ran through `evaluate_match` — but `venue_candidates` builds
+  its candidate from the *anchor work*, the same OpenAlex record the citekey
+  already resolved to. The gate was therefore comparing the registry entry
+  against itself and could not do anything but pass, landing
+  `{"verdict": "accept", "title": "exact", "author": "exact", "year": "exact"}`
+  in the audit trail for a URL nothing had checked. Rung 6 is now recorded with a
+  new `trusted` verdict and a reason naming the situation, with all three axes
+  `null` because none was compared; `%PDF-` remains the only real constraint, and
+  now the report says so. **Behaviour change:** rung 6 no longer inherits
+  `evaluate_match`'s thin-metadata refusal — that refusal was about the entry's
+  own metadata, not the consumer's template, so a resolver now applies even to an
+  entry missing title/year/author. See ADR-0038 for why fetch-and-parse
+  verification was rejected as disproportionate. (#105)
+- **Suffix-less PDF-serving landing pages are recovered instead of dropped
+  unseen.** The landing rung kept only `landing_page_url`s whose string ended in
+  `.pdf`, so a publisher serving a PDF from an extension-less path (arXiv's
+  `/pdf/2409.11078` is the observed shape) was filtered out before
+  `looks_like_pdf`'s magic-byte check could accept it, and the paper went to
+  `manual[]` for a human to click. `.pdf`-shaped URLs still come first and stay
+  unbounded; up to `LANDING_SNIFF_LIMIT` (3) suffix-less ones now follow and are
+  judged on their bytes. The cap is what keeps a work with a long `locations[]`
+  array from turning into one round-trip per entry. (#104)
 - **`backlog` no longer rewrites the documents it edits.** `Backlog.loads()` was
   prose-tolerant but `dumps()`/`save()` emitted only the table, so the
   `load → mutate → save` round trip behind every `backlog park|add|rank|promote|

--- a/decisions/0038-venue-resolvers-trusted-not-gated.md
+++ b/decisions/0038-venue-resolvers-trusted-not-gated.md
@@ -1,0 +1,121 @@
+# ADR-0038: Rung 6 (`venue_resolvers`) is *trusted*, not gated — and says so
+
+- Status: accepted · Date: 2026-08-27 · Deciders: Davor Runje
+
+## Context
+
+ADR-0037 established a three-way match gate (accept / quarantine / refuse) over
+the acquisition ladder's search-derived rungs, on the principle that "a wrong
+PDF one keystroke from a citekey is worse than no PDF." The design spec
+(`docs/superpowers/specs/2026-08-27-literature-asset-acquisition-design.md`
+§5.1) marks rung 6 — the consumer-configured `venue_resolvers` templates —
+**gated: yes**, and the code complied: `RUNG_VENUE` was in `GATED_RUNGS`, so
+every rung-6 candidate went through `evaluate_match`.
+
+The gate was vacuous there, and worse than vacuous. `venue_candidates` builds
+its candidate with `candidate_from_work(work, url, RUNG_VENUE)` — from the
+**anchor work**, the same OpenAlex record the citekey already resolved to. So
+`evaluate_match(entry, candidate)` compared the registry entry against metadata
+derived from its own resolved work, never against whatever the consumer's
+`url_template` actually points at. It could not do anything but pass.
+
+The consequence was not a missing check but a **false record**. Rung 6
+candidates landed in the audit trail as:
+
+```json
+"match": {"verdict": "accept", "title": "exact", "author": "exact", "year": "exact"}
+```
+
+A reader of that report — the whole point of `MatchRecord` being per-axis, per
+ADR-0037, is that "a refusal is explainable" — sees three exact axes and
+concludes the bytes were checked against the venue URL. Nothing was. The
+`%PDF-` magic-byte test in `looks_like_pdf` was the only real constraint, and
+it accepts *any* PDF, including the wrong paper's.
+
+`venue_candidates`'s docstring already carried a `.. warning::` saying exactly
+this, which is how #105 came to be filed. A warning in a docstring does not
+reach the person reading a JSON report.
+
+## Decision drivers
+
+- **Failure honesty (repo-wide rule).** Never let an uncertain condition be
+  reported as a legitimate result. A fabricated `accept` in an integrity tool's
+  own audit trail is the sharpest possible version of that failure.
+- **Never guess at a citation binding** (ADR-0037). Where we cannot verify, the
+  record must say we did not verify — not stay silent, and not claim otherwise.
+- **Domain-neutrality.** `venue_resolvers` exists precisely so ML-venue logic
+  stays out of the plugin (ADR-0037); it is consumer config by construction, and
+  the plugin has no way to know what a consumer's template resolves to.
+- **Proportionate cost.** Rung 6 ships empty (`venue_resolvers: []`) and is
+  entirely opt-in, so exposure is low; the remedy should be proportionate.
+
+## Options considered
+
+1. **Real verification.** Fetch the resolved URL and extract title / author /
+   year from what it serves, then run `evaluate_match` against *that*.
+2. **Document the posture only.** Leave the code as-is; record in an ADR that
+   rung 6 is trusted-by-configuration.
+3. **Report the truth: a `trusted` verdict.** Take rung 6 out of `GATED_RUNGS`
+   and record a distinct verdict stating that the candidate was admitted on the
+   operator's configuration and not verified.
+
+## Decision
+
+**Option 3**, with this ADR as the documentation option 2 asked for.
+
+- `RUNG_VENUE` leaves `GATED_RUNGS`. The set now means what its name says.
+- A new verdict, `TRUSTED`, sits alongside `IDENTITY` (ungated because identity
+  was established by resolution) and `ACCEPT` (gated and passed). It carries a
+  `reason` naming the situation: admitted on a consumer-configured venue
+  resolver, not verified against the URL's own record, `%PDF-` is the only gate.
+- No axis is populated, because no axis was compared. `title`, `author` and
+  `year` stay `null` rather than reporting `exact`.
+
+Option 1 was rejected as disproportionate: a rung-6 URL *is* the PDF, so
+verifying it means extracting text from PDF bytes — a new capability, a new
+dependency (the package deliberately stays light: `requests`, `pooch`, `pyyaml`,
+no Pydantic), and an unreliable one. Venues that expose cheaper metadata at a
+stable URL are the exception. Buying a weak check at that price, for an opt-in
+rung that ships empty, is not worth it.
+
+Option 2 was rejected on its own: it leaves the false `accept` in the report.
+Documenting a known-misleading output is not the same as not emitting it.
+
+## Consequences
+
+- The audit trail distinguishes three provenances instead of conflating two:
+  `identity` (the URL came from the anchor's own record), `trusted` (the
+  operator vouched), `accept` (a gate compared and it passed).
+- **Rung 6 no longer inherits `evaluate_match`'s thin-metadata refusal.** An
+  entry missing title / year / first author used to have its rung-6 candidates
+  refused. That refusal was about the *entry's* metadata and said nothing about
+  the consumer's template, so it was incidental protection, not principled; it
+  is gone. A consumer who configures a resolver gets it applied.
+- The spec's §5.1 rung table ("gated: yes" for rung 6) is superseded here. The
+  spec is left unedited as the historical design record, per how ADRs work in
+  this repo.
+- A consumer relying on `venue_resolvers` gets a report that tells them plainly
+  that this rung is theirs to vouch for. That is the actual protection: an
+  operator who knows the tool is not checking can check.
+
+## Rejected alternatives
+
+- **Fetch-and-parse PDF text to verify** (option 1) — cost and dependency weight
+  out of proportion to an opt-in, empty-by-default rung. Revisit if
+  `venue_resolvers` ever ships non-empty, which ADR-0037 forbids on
+  domain-neutrality grounds.
+- **Quarantine every rung-6 candidate.** Would force a human `confirm` on every
+  venue-resolved PDF. Punishes the consumer for using a documented feature, and
+  the human confirming has no more information than the template author had.
+- **Drop rung 6 entirely.** The generic rungs cover the cases that motivated the
+  feature (ADR-0037), but the escape hatch is cheap and the alternative for an
+  exotic venue is hand-downloading every PDF.
+
+## References
+
+- #105 (the issue), #104 (the sibling landing-page recall fix in the same PR)
+- ADR-0037 (`0037-literature-asset-acquisition.md`) — the gate this refines
+- `defendable-science/defendable_science/literature/acquire.py` —
+  `GATED_RUNGS`, `TRUSTED`, `_gate`, `venue_candidates`
+- `docs/superpowers/specs/2026-08-27-literature-asset-acquisition-design.md`
+  §5.1 — the superseded "gated: yes" rung table

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -49,5 +49,6 @@ Migrates to the plugin's `decisions/` alongside `resources/references/`.
 | [0035](0035-rename-to-defendable-science.md) | Rename the project to Defendable Science — repo, plugin, distribution, CLI, config dir, env vars, and docs domain; old PyPI packages dropped | accepted |
 | [0036](0036-automated-dependency-updates.md) | Automated dependency updates — Dependabot for the dev toolchain + Actions, scheduled `pre-commit autoupdate`, no auto-merge | accepted |
 | [0037](0037-literature-asset-acquisition.md) | Literature asset acquisition — substrate spine under CSL `custom`, three-way match gate with an author hard gate | accepted |
+| [0038](0038-venue-resolvers-trusted-not-gated.md) | Rung 6 (`venue_resolvers`) is *trusted*, not gated — the audit trail records that no verification was performed instead of a fabricated three-axis `accept` | accepted |
 
 Format: MADR (Markdown Any Decision Records). Deciders: Davor Runje (with Claude).

--- a/defendable-science/defendable_science/literature/acquire.py
+++ b/defendable-science/defendable_science/literature/acquire.py
@@ -111,13 +111,21 @@ RUNG_MANUAL = "manual"
 
 #: Rungs whose candidates come from a *search* and therefore must pass the gate.
 #: Rungs 1-3 are identity-derived — their URLs come from the OpenAlex work the
-#: citekey already resolves to, so there is nothing to verify.
-GATED_RUNGS = frozenset({RUNG_SIBLING, RUNG_ARXIV_SEARCH, RUNG_VENUE})
+#: citekey already resolves to, so there is nothing to verify. Rung 6 is
+#: *trusted*, not gated: its candidate URL is built from a consumer's own
+#: template, and nothing OpenAlex holds says what that URL serves, so there is
+#: no match to make (ADR-0038 and :data:`TRUSTED`).
+GATED_RUNGS = frozenset({RUNG_SIBLING, RUNG_ARXIV_SEARCH})
 
 # --- verdicts ---------------------------------------------------------------
 
 #: An ungated rung: identity was established by resolution, not by matching.
 IDENTITY = "identity"
+#: A consumer-configured rung: admitted on the operator's word. Distinct from
+#: :data:`ACCEPT`, which means a gate compared the candidate against the entry
+#: and it passed — reporting that here would be a verification never performed
+#: (ADR-0038).
+TRUSTED = "trusted"
 #: Gated and passed — bind the bytes.
 ACCEPT = "accept"
 #: Gated and plausible — land in quarantine, await a human ``confirm``.
@@ -179,8 +187,8 @@ class Candidate:
 class MatchRecord:
     """The gate's verdict, per axis, so a refusal is explainable.
 
-    :param verdict: :data:`IDENTITY` | :data:`ACCEPT` | :data:`QUARANTINE` |
-        :data:`REFUSE`.
+    :param verdict: :data:`IDENTITY` | :data:`TRUSTED` | :data:`ACCEPT` |
+        :data:`QUARANTINE` | :data:`REFUSE`.
     :param title: ``exact`` | ``containment`` | ``mismatch``, or ``None`` when the
         axis was not evaluated.
     :param author: ``exact`` | ``mismatch``, or ``None``.
@@ -588,24 +596,51 @@ def _location_pdf_urls(work: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]
     return _location_urls(work, "pdf_url", lambda url: bool(url.strip()))
 
 
+#: How many *suffix-less* landing pages the ladder will fetch and sniff per work.
+#: A ``.pdf`` suffix is a strong hint but not a requirement — arXiv serves PDFs
+#: from ``/pdf/2409.11078`` with no suffix at all — so a bounded tail of the
+#: remaining landing pages is tried and judged by :func:`looks_like_pdf`. The cap
+#: keeps a work with a long ``locations[]`` array from becoming N round-trips.
+LANDING_SNIFF_LIMIT = 3
+
+
+def _is_pdf_shaped(url: str) -> bool:
+    """Return whether `url` looks like a direct PDF link by suffix."""
+    return url.strip().lower().endswith(".pdf")
+
+
 def _landing_locations(work: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
-    """Return PDF-shaped landing URLs with the location records they came from.
+    """Return landing URLs worth trying, with the location records they came from.
+
+    ``.pdf``-shaped URLs come first and are unbounded — they are the cheap, likely
+    wins. Then up to :data:`LANDING_SNIFF_LIMIT` suffix-less landing pages, so a
+    publisher that serves a PDF from an extension-less path is still reachable
+    without fetching every HTML abstract page in the record.
 
     :param work: The OpenAlex work.
-    :returns: ``(url, location)`` pairs, in record order.
+    :returns: ``(url, location)`` pairs, PDF-shaped first, then the sniff tail.
     """
-    return _location_urls(
-        work, "landing_page_url", lambda url: url.strip().lower().endswith(".pdf")
+    shaped = _location_urls(work, "landing_page_url", _is_pdf_shaped)
+    rest = _location_urls(
+        work,
+        "landing_page_url",
+        lambda url: bool(url.strip()) and not _is_pdf_shaped(url),
     )
+    return shaped + rest[:LANDING_SNIFF_LIMIT]
 
 
 def landing_urls(work: dict[str, Any]) -> list[str]:
-    """Return landing-page URLs that are shaped like a direct PDF link.
+    """Return landing-page URLs the ladder will try as direct PDF links.
 
     OpenAlex marks a work ``closed`` when it has no ``pdf_url``, yet the landing
     page can *be* the PDF — Sill 1997's NeurIPS proceedings link is exactly this.
-    Only ``.pdf``-suffixed links are offered, so the ladder does not download
-    every HTML abstract page in the record.
+    A ``.pdf`` suffix is the strong signal and those are offered first, but it is
+    not required: up to :data:`LANDING_SNIFF_LIMIT` suffix-less landing pages
+    follow, judged on their bytes by :func:`looks_like_pdf` rather than dropped
+    unseen. Failing to offer them cost recall, not correctness — a missed PDF
+    lands in :data:`BUCKET_MANUAL` for a human to click — but the bound is what
+    keeps recovering it from turning the ladder into a crawl of every abstract
+    page in the record.
 
     :param work: The OpenAlex work.
     :returns: Candidate landing URLs, in record order.
@@ -767,13 +802,16 @@ def venue_candidates(
     ``{doi}`` and ``{year}``.
 
     .. warning::
-       **The gate provides no protection on this rung.** These candidates are
-       built from the *anchor work* — the one the citekey already resolves to —
-       so :func:`evaluate_match` compares the registry entry against itself and
-       cannot do anything but accept. What the URL actually serves is
-       unconstrained by anything OpenAlex said, and the only real check standing
-       between a consumer's template and a citekey is the ``%PDF-`` magic-byte
-       test. A consumer configuring a resolver is vouching for the template.
+       **This rung is trusted, not verified.** Its candidates are built from the
+       *anchor work* — the one the citekey already resolves to — so there is
+       nothing to match the URL against: what it serves is unconstrained by
+       anything OpenAlex said, and the only real check standing between a
+       consumer's template and a citekey is the ``%PDF-`` magic-byte test. A
+       consumer configuring a resolver is vouching for the template. The ladder
+       therefore records :data:`TRUSTED` rather than running the gate, so the
+       audit trail states that no verification was performed instead of
+       reporting a three-axis ``accept`` against the entry itself
+       (``decisions/0038-venue-resolvers-trusted-not-gated.md``).
 
     :param entry: The registry entry (supplies ``{doi}``).
     :param work: The anchor work (supplies the venue name, ``{openalex}``, ``{year}``).
@@ -1348,16 +1386,30 @@ def _note(tried: list[str], rung: str) -> None:
 def _gate(entry: Entry, candidate: Candidate, state: _Ladder) -> MatchRecord | None:
     """Adjudicate a candidate, or ``None`` to skip it.
 
-    Rungs 1-3 are identity-derived and carry no match to make. Every other rung
-    goes through :func:`evaluate_match` with no exceptions — that gate stands
-    where ``dataset`` has a pre-known hash, so a rung that bypassed it would be
-    binding unverified bytes to a citekey.
+    Rungs 1-3 are identity-derived and carry no match to make. Rungs 4-5 are
+    search-derived and go through :func:`evaluate_match` with no exceptions —
+    that gate stands where ``dataset`` has a pre-known hash, so a rung that
+    bypassed it would be binding unverified bytes to a citekey.
+
+    Rung 6 is reported :data:`TRUSTED`. Its URL comes from a consumer's own
+    template and its metadata from the anchor work, so running the gate would
+    compare the entry against itself and emit an ``accept`` with three exact
+    axes — a verification that never happened. Saying so is the point: an
+    integrity tool must not launder configuration into evidence (ADR-0038).
 
     :param entry: The registry entry.
     :param candidate: The candidate under consideration.
     :param state: The ladder state, which remembers the first refusal.
     :returns: The match record, or ``None`` when the candidate is refused.
     """
+    if candidate.rung == RUNG_VENUE:
+        return MatchRecord(
+            verdict=TRUSTED,
+            reason=(
+                "admitted on a consumer-configured venue resolver; not verified "
+                "against the URL's own record — the %PDF- check is the only gate"
+            ),
+        )
     if candidate.rung not in GATED_RUNGS:
         return MatchRecord(verdict=IDENTITY)
     record = evaluate_match(entry, candidate)

--- a/defendable-science/tests/test_acquire.py
+++ b/defendable-science/tests/test_acquire.py
@@ -288,9 +288,14 @@ def test_identity_rungs_are_not_gated() -> None:
 
 
 def test_search_rungs_are_gated() -> None:
-    assert (
-        frozenset({a.RUNG_SIBLING, a.RUNG_ARXIV_SEARCH, a.RUNG_VENUE}) == a.GATED_RUNGS
-    )
+    assert frozenset({a.RUNG_SIBLING, a.RUNG_ARXIV_SEARCH}) == a.GATED_RUNGS
+
+
+def test_the_venue_rung_is_trusted_not_gated() -> None:
+    # Its candidate is built from the anchor work, so evaluate_match would be
+    # comparing the entry against itself: an "accept" there is a verification
+    # that never happened (ADR-0038).
+    assert a.RUNG_VENUE not in a.GATED_RUNGS
 
 
 def test_match_record_as_json_is_serializable() -> None:
@@ -433,8 +438,11 @@ def test_identity_candidates_carry_the_works_own_metadata() -> None:
     assert cand.openalex == "W2293093810"
 
 
-def test_no_candidates_when_nothing_is_available() -> None:
-    assert a.identity_candidates(_work("monokan_journal")) == []
+def test_a_closed_work_still_offers_its_landing_pages_to_the_sniff_tail() -> None:
+    # No pdf_url anywhere, so rungs 1-2 are empty; the landing pages are offered
+    # because a suffix is a hint, not a requirement. looks_like_pdf disposes.
+    candidates = a.identity_candidates(_work("monokan_journal"))
+    assert {c.rung for c in candidates} == {a.RUNG_OA_LANDING}
 
 
 def test_candidates_are_deduplicated_by_url() -> None:
@@ -452,7 +460,7 @@ def test_candidates_are_deduplicated_by_url() -> None:
     assert [c.url for c in a.identity_candidates(work)] == ["http://x/p.pdf"]
 
 
-def test_landing_urls_only_returns_pdf_shaped_links() -> None:
+def test_landing_urls_puts_pdf_shaped_links_first() -> None:
     work = {
         "locations": [
             {"landing_page_url": "http://x/abs/1"},
@@ -462,7 +470,22 @@ def test_landing_urls_only_returns_pdf_shaped_links() -> None:
             "junk",
         ]
     }
-    assert a.landing_urls(work) == ["http://x/paper.pdf"]
+    assert a.landing_urls(work) == ["http://x/paper.pdf", "http://x/abs/1"]
+
+
+def test_the_sniff_tail_is_bounded_but_pdf_shaped_links_are_not() -> None:
+    # A work with a long locations[] array must not become one round-trip per
+    # entry; the cap applies only to the suffix-less tail.
+    extra = a.LANDING_SNIFF_LIMIT + 2
+    work = {
+        "locations": [
+            *({"landing_page_url": f"http://x/p{i}.pdf"} for i in range(extra)),
+            *({"landing_page_url": f"http://x/abs/{i}"} for i in range(extra)),
+        ]
+    }
+    urls = a.landing_urls(work)
+    assert urls[:extra] == [f"http://x/p{i}.pdf" for i in range(extra)]
+    assert urls[extra:] == [f"http://x/abs/{i}" for i in range(a.LANDING_SNIFF_LIMIT)]
 
 
 def test_family_name_is_the_last_token_of_a_display_name() -> None:
@@ -839,6 +862,15 @@ OTHER_PDF = b"%PDF-1.4 a different body"
 OTHER_SHA = hashlib.sha256(OTHER_PDF).hexdigest()
 
 
+HTML = b"<html>an abstract page, not a PDF</html>"
+
+#: Fixture URLs that stand for an HTML abstract page. The landing rung sniffs
+#: suffix-less URLs up to ``LANDING_SNIFF_LIMIT`` rather than dropping them on
+#: their suffix, so a decoy must actually serve non-PDF bytes to be rejected —
+#: which is precisely what ``looks_like_pdf`` is there to decide.
+DECOY_BODIES: dict[str, bytes | Exception] = {"http://x/abstract": HTML}
+
+
 class FakeFetcher:
     """A ``BytesFetcher`` that serves canned bodies (or raises) per URL."""
 
@@ -847,7 +879,7 @@ class FakeFetcher:
         bodies: dict[str, bytes | Exception] | None = None,
         default: bytes | Exception | None = PDF,
     ) -> None:
-        self.bodies = bodies or {}
+        self.bodies = {**DECOY_BODIES, **(bodies or {})}
         self.default = default
         self.calls: list[str] = []
 
@@ -1316,12 +1348,15 @@ def test_all_rungs_exhausted_is_manual_with_landing_urls(tmp_path: Path) -> None
     outcome = a.acquire_one(entry, _ctx(tmp_path, client, fetcher))
     assert outcome.bucket == a.BUCKET_MANUAL
     assert outcome.landing_urls == ["http://x/abstract"]
-    assert outcome.tried == [a.RUNG_OA_BEST, a.RUNG_SIBLING]
+    # The landing page is fetched and sniffed now, not dropped on its suffix, so
+    # it is a rung the ladder really did try.
+    assert outcome.tried == [a.RUNG_OA_BEST, a.RUNG_OA_LANDING, a.RUNG_SIBLING]
 
 
 def test_a_ladder_with_no_candidates_at_all_is_manual(tmp_path: Path) -> None:
     _path, entry = _registry(tmp_path)
-    anchor = _oa(pdf=None, landing="http://x/abstract")
+    # No landing page either: this ladder really has nothing to offer.
+    anchor = _oa(pdf=None, landing=None)
     client = FakeClient(
         {
             "/works/": anchor,
@@ -1333,7 +1368,7 @@ def test_a_ladder_with_no_candidates_at_all_is_manual(tmp_path: Path) -> None:
     assert outcome.bucket == a.BUCKET_MANUAL
     assert outcome.tried == []
     assert outcome.match is None
-    assert outcome.landing_urls == ["http://x/abstract"]
+    assert outcome.landing_urls == []
 
 
 # --- the gate, in the ladder ------------------------------------------------
@@ -1364,7 +1399,8 @@ def test_gated_refusal_is_manual_with_the_axes_recorded(tmp_path: Path) -> None:
     """The Sill-1997-vs-Igel-2023 shape, walked through the whole ladder."""
     path, entry = _registry(tmp_path)
     before = path.read_bytes()
-    anchor = _oa(pdf=None, landing="http://x/abstract")
+    # No landing page, so the ladder reaches the gated rung untouched.
+    anchor = _oa(pdf=None, landing=None)
     sibling = _oa(wid="W2", family="Igel", pdf="http://x/sib.pdf")
     client = FakeClient(
         {
@@ -1383,10 +1419,12 @@ def test_gated_refusal_is_manual_with_the_axes_recorded(tmp_path: Path) -> None:
     assert path.read_bytes() == before
 
 
-def test_a_venue_resolver_candidate_still_passes_the_gate(tmp_path: Path) -> None:
-    """Rung 6 is gated like any other search rung; a match binds the bytes."""
+def test_a_venue_resolver_candidate_is_trusted_not_gate_verified(
+    tmp_path: Path,
+) -> None:
+    """Rung 6 binds the bytes, but says it was trusted, not verified (ADR-0038)."""
     _path, entry = _registry(tmp_path)
-    anchor = _oa(pdf=None, landing="http://x/abstract")
+    anchor = _oa(pdf=None, landing=None)
     client = FakeClient(
         {
             "/works/": anchor,
@@ -1406,7 +1444,12 @@ def test_a_venue_resolver_candidate_still_passes_the_gate(tmp_path: Path) -> Non
     assert outcome.bucket == a.BUCKET_FETCHED
     assert outcome.rung == a.RUNG_VENUE
     assert outcome.match is not None
-    assert outcome.match["verdict"] == a.ACCEPT
+    assert outcome.match["verdict"] == a.TRUSTED
+    # No axis is claimed, because none was compared.
+    assert outcome.match["title"] is None
+    assert outcome.match["author"] is None
+    assert outcome.match["year"] is None
+    assert "not verified" in outcome.match["reason"]
 
 
 # --- refetch and drift ------------------------------------------------------
@@ -1585,7 +1628,8 @@ def test_dry_run_reports_a_permissive_license_as_committable(tmp_path: Path) -> 
 
 def test_dry_run_reports_a_quarantine_as_a_quarantine(tmp_path: Path) -> None:
     _path, entry = _registry(tmp_path)
-    anchor = _oa(pdf=None, landing="http://x/abstract")
+    # No landing page, so the sibling is the first candidate a dry run reports.
+    anchor = _oa(pdf=None, landing=None)
     sibling = _oa(wid="W2", year=2002, pdf="http://x/sib.pdf")
     client = FakeClient({"/works/": anchor, "/works": {"results": [sibling]}})
     outcome = a.acquire_one(entry, _ctx(tmp_path, client, NeverFetcher()), dry_run=True)
@@ -1748,7 +1792,7 @@ def test_a_rung_is_listed_once_however_many_candidates_it_offered(
         _ctx(tmp_path, client, FakeFetcher(default=DownloadError("gone", status=404))),
     )
     assert outcome.bucket == a.BUCKET_MANUAL
-    assert outcome.tried == [a.RUNG_OA_BEST, a.RUNG_OA_LOCATIONS]
+    assert outcome.tried == [a.RUNG_OA_BEST, a.RUNG_OA_LOCATIONS, a.RUNG_OA_LANDING]
 
 
 def test_a_corrupt_cache_blob_with_no_mirror_says_so_and_discards_it(
@@ -2819,3 +2863,71 @@ def test_bytes_that_land_after_a_block_are_a_plain_success(tmp_path: Path) -> No
     assert outcome.bucket == a.BUCKET_FETCHED
     assert outcome.url == "http://x/good.pdf"
     assert outcome.failures == []
+
+
+# --- the landing sniff tail, end to end (#104) --------------------------------
+
+
+def test_a_suffixless_landing_page_that_serves_a_pdf_is_recovered(
+    tmp_path: Path,
+) -> None:
+    """The rung's point: a publisher can serve a PDF from an extension-less path."""
+    _path, entry = _registry(tmp_path)
+    anchor = _oa(pdf=None, landing="http://x/content/1358")
+    client = FakeClient({"/works/": anchor})
+    fetcher = FakeFetcher({"http://x/content/1358": PDF}, default=None)
+    outcome = a.acquire_one(entry, _ctx(tmp_path, client, fetcher))
+    assert outcome.bucket == a.BUCKET_FETCHED
+    assert outcome.rung == a.RUNG_OA_LANDING
+    assert outcome.url == "http://x/content/1358"
+    assert outcome.sha256 == PDF_SHA
+    # Identity-derived: no gate ran, and none was claimed to have run.
+    assert outcome.match is not None
+    assert outcome.match["verdict"] == a.IDENTITY
+
+
+def test_a_suffixless_landing_page_serving_html_is_rejected(tmp_path: Path) -> None:
+    """Sniffing costs a round-trip; %PDF- is what keeps an abstract page out."""
+    _path, entry = _registry(tmp_path)
+    anchor = _oa(pdf=None, landing="http://x/content/1358")
+    client = FakeClient(
+        {"/works/": anchor, "/works": {"results": []}, "export.arxiv.org": "<feed/>"}
+    )
+    fetcher = FakeFetcher({"http://x/content/1358": HTML}, default=None)
+    outcome = a.acquire_one(entry, _ctx(tmp_path, client, fetcher))
+    assert outcome.bucket == a.BUCKET_MANUAL
+    assert fetcher.calls == ["http://x/content/1358"]  # tried once, then moved on
+    assert outcome.landing_urls == ["http://x/content/1358"]
+
+
+# --- rung 6 is trusted, not gated (#105) --------------------------------------
+
+
+def test_a_venue_resolver_is_admitted_for_a_thin_entry(tmp_path: Path) -> None:
+    """The gate refused thin *entries*; that never said anything about the URL.
+
+    ``evaluate_match`` refuses when the entry lacks title/year/author, which used
+    to block rung 6 as a side effect. The refusal was about the registry entry's
+    own metadata, not about the consumer's template, so it is gone with the gate.
+    """
+    _path, entry = _registry(tmp_path, title=None, year=None, family=None)
+    anchor = _oa(pdf=None, landing=None)
+    client = FakeClient({"/works/": anchor, "/works": {"results": []}})
+    ctx = _ctx(
+        tmp_path,
+        client,
+        FakeFetcher(),
+        resolvers=[{"match": "Neural", "url_template": "http://v/{openalex}.pdf"}],
+    )
+    outcome = a.acquire_one(entry, ctx)
+    assert outcome.bucket == a.BUCKET_FETCHED
+    assert outcome.rung == a.RUNG_VENUE
+    assert outcome.match is not None
+    assert outcome.match["verdict"] == a.TRUSTED
+
+
+def test_the_trusted_verdict_is_not_an_accept() -> None:
+    # A reader of the audit trail must be able to tell "we checked and it
+    # matched" from "we took the operator's word for it".
+    assert a.TRUSTED != a.ACCEPT
+    assert a.TRUSTED != a.IDENTITY

--- a/docs/design/proposals/literature-asset-acquisition.md
+++ b/docs/design/proposals/literature-asset-acquisition.md
@@ -78,20 +78,28 @@ Rungs 1–3 are identity-derived from the OpenAlex work the citekey already
 resolves to (`best_oa_location`, every `locations[].pdf_url`, then every
 `locations[].landing_page_url` that serves PDF bytes — checked by magic bytes,
 because `Content-Type` lies). No gate needed; the URL already belongs to the
-anchor's own record.
+anchor's own record. A `.pdf` suffix orders the landing rung but does not gate
+it: suffix-less landing pages follow, capped at `LANDING_SNIFF_LIMIT`, because a
+publisher serving a PDF from an extension-less path is a real shape and dropping
+it unseen cost recall (#104).
 
-Rungs 4–6 are search-derived and every candidate passes the gate: a
+Rungs 4–5 are search-derived and every candidate passes the gate: a
 sibling-version title search (word-prefix or equal, same relation the gate
-itself uses — a rung's pre-filter must never be stricter than the gate),
-an arXiv title+author query, and a config-driven `venue_resolvers` list that
-ships **empty** — the generic rungs already recover the concrete cases that
-motivated the feature, so no ML-venue logic enters the plugin. Rung 7 is
-manual: report the landing URLs, adopt by hand via `confirm --file`.
+itself uses — a rung's pre-filter must never be stricter than the gate) and an
+arXiv title+author query. Rung 6 is the config-driven `venue_resolvers` list,
+which ships **empty** — the generic rungs already recover the concrete cases
+that motivated the feature, so no ML-venue logic enters the plugin. It is
+*trusted*, not gated: its candidate URL comes from a consumer's template and
+there is nothing in OpenAlex to match it against, so the record says `trusted`
+rather than claiming an `accept` it did not earn (ADR-0038). Rung 7 is manual:
+report the landing URLs, adopt by hand via `confirm --file`.
 
 ### The match gate
 
 Three axes — title (normalized), first-author family name, year — combine
-into `accept` / `quarantine` / `refuse`. First-author family name is a hard
+into `accept` / `quarantine` / `refuse`. Two verdicts sit outside the gate
+because no comparison was made: `identity` (rungs 1–3, the URL is the anchor's
+own) and `trusted` (rung 6, the operator vouched — ADR-0038). First-author family name is a hard
 gate: no candidate is ever accepted or quarantined across a mismatch. Title
 agreement is normalized-equality or **word-prefix containment** (not
 substring — substring isn't word-aware). Quarantine lands bytes plus the

--- a/docs/guides/literature.md
+++ b/docs/guides/literature.md
@@ -67,6 +67,14 @@ literature:
 Every key is optional. A missing `literature:` block means "all of the above
 defaults".
 
+`venue_resolvers` ships empty and is the one setting that buys you less safety
+than the rest. A `{match, url_template}` pair you add there is applied as-is:
+the tool has no way to check what your template resolves to, so the acquisition
+report marks those candidates `verdict: "trusted"` — you vouched for it — rather
+than `"accept"`, which is reserved for candidates a gate actually compared
+against your registry entry. The `%PDF-` byte check is the only thing standing
+behind a template. See ADR-0038.
+
 **`references.json` is CSL-JSON, and it is the source of truth.** JSON, because
 the skills append rows, join by key, and build comparison matrices
 programmatically, and a `.bib` file is a miserable thing to do that to. **BibTeX

--- a/skills/literature/SKILL.md
+++ b/skills/literature/SKILL.md
@@ -175,9 +175,10 @@ gate below, rather than verifying against one already recorded.
 
 `literature fetch <citekey>` walks a ladder: identity-derived rungs read the
 anchor's own OpenAlex record (`best_oa_location`, every `locations[].pdf_url`,
-then any `locations[].landing_page_url` that actually serves PDF bytes); if
-none yield bytes, search-derived rungs try (a sibling-version title search, an
-arXiv query, and an empty-by-default, config-driven `venue_resolvers` list).
+then its `locations[].landing_page_url`s — `.pdf`-suffixed ones first, then a
+capped few without a suffix, since a publisher can serve a PDF from an
+extension-less path and only the bytes settle it); if none yield bytes,
+search-derived rungs try (a sibling-version title search and an arXiv query).
 Every search-derived candidate passes a **match gate** — title, first-author
 family name, and year, compared against the registry entry — that returns
 `accept`, `quarantine`, or `refuse`. **First-author family name is a hard
@@ -186,6 +187,13 @@ mismatch.** This is what lets the gate accept a genuine preprint/journal
 sibling pair one year apart while refusing a same-topic, different-author
 paper a loose title search would otherwise bind to the wrong citekey. See
 ADR-0037 for the full rationale.
+
+The last rung is the empty-by-default, config-driven `venue_resolvers` list.
+It is **trusted, not gated**: the candidate URL comes from your own template
+and there is nothing in OpenAlex to check it against, so the report records
+`verdict: "trusted"` with no axes — the `%PDF-` check is the only constraint,
+and configuring a resolver means vouching for it. Read `trusted` as "you told
+us this was right," never as "we verified it" (ADR-0038).
 
 A `quarantine` verdict lands bytes + the candidate record on disk without
 touching `references.json`; nothing is ever auto-promoted. Review it, then


### PR DESCRIPTION
## What

Two rungs of the acquisition ladder reported something stronger than they knew.
Rung 6 emitted a **fabricated verification record**; rung 3 dropped real PDFs
unseen. Both are in `literature/acquire.py`, so one PR.

## Details

### #105 — rung 6 claimed a match it never made

`RUNG_VENUE` was in `GATED_RUNGS`, so every consumer-configured venue candidate
ran through `evaluate_match`. But `venue_candidates` builds its candidate from
the **anchor work** — the same OpenAlex record the citekey already resolved to —
so the gate compared the registry entry against itself and could not do anything
but pass. The problem was not a missing check but a false record:

```json
"match": {"verdict": "accept", "title": "exact", "author": "exact", "year": "exact"}
```

`MatchRecord` is per-axis precisely so a reader can trust those axes (ADR-0037:
"a refusal is explainable"). Three exact axes for a URL nothing had checked is
the sharpest form of the failure-honesty rule this repo runs on. A `.. warning::`
in `venue_candidates`' docstring already said so — which does not reach the
person reading a JSON report.

Rung 6 now leaves `GATED_RUNGS` and is recorded with a new `trusted` verdict
carrying a reason, all three axes `null` because none was compared:

```json
"match": {"verdict": "trusted", "title": null, "author": null, "year": null,
          "reason": "admitted on a consumer-configured venue resolver; not
                     verified against the URL's own record — the %PDF- check
                     is the only gate"}
```

The audit trail now distinguishes three provenances instead of conflating two:
`identity` (URL from the anchor's own record), `trusted` (the operator vouched),
`accept` (a gate compared and it passed).

**Real verification was considered and rejected** — a rung-6 URL *is* the PDF, so
verifying it means extracting text from PDF bytes: a new capability, a new
dependency on a deliberately light wheel, and unreliable — for an opt-in rung
that ships empty. ADR-0038 records that and supersedes the design spec's
"gated: yes" for this rung (spec left unedited as the historical record).

**Behaviour change, called out in the ADR and CHANGELOG:** rung 6 no longer
inherits `evaluate_match`'s thin-metadata refusal. That refusal was about the
*entry's* metadata and said nothing about the consumer's template, so it was
incidental protection, not principled. Pinned by a test.

### #104 — suffix-less landing pages were dropped before the byte check

The landing rung kept only `landing_page_url`s ending in `.pdf`, so a publisher
serving a PDF from an extension-less path — arXiv's `/pdf/2409.11078` is the
shape the issue documents — was filtered out before `looks_like_pdf`'s magic-byte
check could accept it, and the paper went to `manual[]` for a human to click.

`.pdf`-shaped URLs still come first and stay unbounded; up to
`LANDING_SNIFF_LIMIT` (3) suffix-less ones now follow and are judged on their
bytes. The cap is what keeps a work with a long `locations[]` array from becoming
one round-trip per entry — tested explicitly, since a silent cap would be its own
kind of dishonesty.

### On the test churn

14 existing tests changed. Every one was a real consequence, reviewed
individually rather than blanket-updated:

- Fixtures using `http://x/abstract` as a decoy landing page now serve HTML from
  `FakeFetcher`'s defaults, so the decoy is rejected by `looks_like_pdf` the way
  a real abstract page is. This makes those tests **stronger** — they now prove
  the sniff tail rejects HTML — rather than merely green.
- Tests whose subject is a *later* rung were given no landing page at all, rather
  than a decoy the ladder must now walk past to reach the thing under test.
- Assertions on `outcome.tried` gained `openalex-landing` where the ladder now
  genuinely does try that rung.

6 tests added covering both new behaviours end-to-end: a suffix-less landing page
that serves a PDF is recovered, one that serves HTML is rejected after exactly
one fetch, the cap holds while `.pdf`-shaped links stay unbounded, and rung 6
reports `trusted` with no axes. 701 pass, 100% statement+branch coverage held.

Closes #104
Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
