### PR TITLE
build: author the codespell/detect-secrets versions in one place (closes #79)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,17 @@ repos:
         stages: [pre-commit, pre-merge-commit, manual]
         args: [--py311-plus]
 
--   repo: https://github.com/codespell-project/codespell
-    rev: v2.4.3
+# codespell and detect-secrets run as `repo: local` hooks, not remote ones, so
+# each tool's version is authored only in `defendable-science/pyproject.toml`'s
+# `lint` group. A remote `rev:` here would be a second pin on a second
+# Dependabot schedule (issue #79, ADR-0036).
+-   repo: local
     hooks:
     -   id: codespell
+        name: Spell check (codespell)
         stages: [pre-commit, pre-merge-commit, manual]
-        args: [--ignore-words=.codespell-whitelist.txt]
+        entry: "tools/codespell.sh"
+        language: system
         exclude: |
             (?x)^(
                 defendable-science/uv.lock
@@ -66,12 +71,11 @@ repos:
         require_serial: true
         verbose: true
 
--   repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
+-   repo: local
     hooks:
     -   id: detect-secrets
-        args: [
-            '--baseline', '.secrets.baseline',
-        ]
-        exclude: defendable-science/uv.lock
+        name: Detect secrets
         stages: [pre-commit, pre-merge-commit, manual]
+        entry: "tools/detect-secrets.sh"
+        language: system
+        exclude: defendable-science/uv.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   concept-matrix generator that was never implemented; the CSL-JSON registry
   loader/patcher and triage sidecar reader it also claimed are real as of
   this release.
+- **`codespell` and `detect-secrets` versions are authored in one place.** Each
+  was pinned twice — a remote hook `rev:` in `.pre-commit-config.yaml` and a `==`
+  pin in `defendable-science/pyproject.toml`'s `lint` group — on two independent
+  Dependabot schedules (`pre-commit` and `uv`), which had already drifted once.
+  Both now run as `repo: local` hooks via `tools/codespell.sh` /
+  `tools/detect-secrets.sh`, leaving the `lint` group's pins as the single source
+  of truth; `pre-commit-hooks` and `pyupgrade` are the only remote `rev:`s left.
+  Hook behaviour is unchanged (same `args`, same `exclude`). (#79)
 
 ## [0.2.0] - 2026-07-28
 

--- a/decisions/0036-automated-dependency-updates.md
+++ b/decisions/0036-automated-dependency-updates.md
@@ -91,7 +91,11 @@ Option 1.
 - `codespell` and `detect-secrets` remain pinned in two places, now bumped by
   two independent Dependabot ecosystems (`uv` for the `==` pin, `pre-commit`
   for the `rev:`); the durable fix (making the `lint` pins the single source)
-  is tracked as issue #79.
+  is tracked as issue #79. **Resolved (#79):** both are now `repo: local` hooks
+  running `tools/codespell.sh` / `tools/detect-secrets.sh`, so the `lint` group's
+  `==` pins are the only place either version is authored and the `pre-commit`
+  ecosystem has nothing to propose for them. `pre-commit-hooks` and `pyupgrade`
+  are the only remote `rev:`s left.
 - Dependabot PRs deviate from the house `<area>/<slug>` branch and
   commit-attribution conventions. Accepted: those govern human PRs.
 

--- a/docs/superpowers/specs/2026-08-25-dependabot-design.md
+++ b/docs/superpowers/specs/2026-08-25-dependabot-design.md
@@ -193,6 +193,11 @@ alternatives for the full comparison.
 
 ## Known duplication (deliberately not fixed here)
 
+> **Since resolved.** Issue #79 converted both tools to `repo: local` hooks, so
+> the duplication this section describes no longer exists. The section is left as
+> written because it records the state at the time of this design; see ADR-0036
+> § Consequences for the resolution.
+
 `codespell` and `detect-secrets` are each pinned twice — a hook `rev:` and a
 `lint` group `==` — and after this change two independent Dependabot
 ecosystems (`uv` and `pre-commit`) bump them. The two locations currently

--- a/tools/codespell.sh
+++ b/tools/codespell.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Spell-check the files pre-commit hands us, using the `codespell` pinned in
+# `defendable-science/pyproject.toml`'s `lint` group.
+#
+# This is a `repo: local` hook rather than the upstream remote hook so the
+# version is authored in exactly one place. As a remote hook it carried its own
+# `rev:`, which Dependabot's `pre-commit` ecosystem bumped independently of the
+# `uv` ecosystem bumping the `==` pin — two schedules for one version, which
+# drifted once already (see issue #79, ADR-0036).
+#
+# Run from the repo root and *do not* cd: pre-commit passes file paths relative
+# to it, and `--ignore-words` resolves against it too. `uv run --project` gets
+# the pinned tool without moving.
+cd "$(dirname "$0")/.."
+
+exec uv run --project defendable-science codespell \
+    --ignore-words=.codespell-whitelist.txt "$@"

--- a/tools/detect-secrets.sh
+++ b/tools/detect-secrets.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Scan the files pre-commit hands us for secrets, using the `detect-secrets`
+# pinned in `defendable-science/pyproject.toml`'s `lint` group.
+#
+# A `repo: local` hook for the same single-source-of-truth reason as
+# `codespell.sh` (issue #79, ADR-0036). `detect-secrets-hook` — not
+# `detect-secrets` — is the entry point the upstream hook uses; the bare CLI
+# scans and prints rather than failing on a new finding.
+#
+# Run from the repo root and *do not* cd: pre-commit passes file paths relative
+# to it, and `--baseline` resolves against it too.
+cd "$(dirname "$0")/.."
+
+exec uv run --project defendable-science detect-secrets-hook \
+    --baseline .secrets.baseline "$@"


### PR DESCRIPTION
## What

`codespell` and `detect-secrets` were each pinned twice — a remote hook `rev:` in
`.pre-commit-config.yaml` and a `==` pin in `defendable-science/pyproject.toml`'s
`lint` group — on two independent Dependabot schedules (`pre-commit` for the rev,
`uv` for the pin). They land in either order, so the two locations drift whenever
they bump on different weeks; that already happened once and was reconciled by
hand in PR #78. Both are now `repo: local` hooks, leaving the `lint` group's pins
as the single source of truth.

## Details

- New `tools/codespell.sh` and `tools/detect-secrets.sh`, following the existing
  `lint` / `typecheck` / `plugin-validate` local-hook pattern.
- **They deliberately do not `cd` into `defendable-science/`** the way
  `tools/lint.sh` does. Unlike the existing local hooks these run with
  `pass_filenames`, and pre-commit passes paths relative to the repo root — as do
  `--ignore-words=.codespell-whitelist.txt` and `--baseline .secrets.baseline`.
  `uv run --project defendable-science` gets the pinned tool without moving.
- `detect-secrets-hook` is the entry point, not the bare `detect-secrets` CLI —
  the latter scans and prints rather than failing on a new finding, which would
  have made the hook silently useless.
- Hook behaviour unchanged: same `args`, same `exclude`.
- ADR-0036 § Consequences and `docs/superpowers/specs/2026-08-25-dependabot-design.md`
  § "Known duplication" both recorded this as an open follow-up; each now points
  at the resolution instead of describing a state that no longer holds. The spec
  text is left as written (it records the state at design time) with a "since
  resolved" note.

## Verification

`pre-commit run --all-files` passes all 10 hooks. More importantly, I checked the
converted hooks still **fail** on their target rather than only that they pass:

```
$ echo 'A deliberate typo: recieve.' > typo-probe.md
Spell check (codespell)...........................................Failed
typo-probe.md:1: recieve ==> receive

$ echo 'aws_secret_access_key = "wJalrXUtnFEMI/..."' > secret-probe.txt
Detect secrets....................................................Failed
```

`grep -n "rev:" .pre-commit-config.yaml` now returns only `pre-commit-hooks`
(`v6.0.0`) and `pyupgrade` (`v3.21.2`), as the issue's fourth acceptance
criterion requires.

The last acceptance criterion — that a subsequent Dependabot run on the
`pre-commit` ecosystem no longer proposes rev bumps for these two — can only be
observed after merge, but follows structurally: neither is a remote hook anymore.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)
