### PR TITLE
docs(docs): restructure the user guide around the Guides nav group (closes #103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`docs/USER-GUIDE.md` restructured around the `Guides` nav group.** The single
+  page carried a paragraph per capability and nothing deeper; five new
+  per-capability guides now hold the depth it implied, following
+  `docs/guides/literature.md`'s conventions:
+  [`dataset`](docs/guides/dataset.md) (tiers as a license question, the
+  resolution chain, the mirror, what `audit` checks beyond fixity),
+  [`experiment-backend`](docs/guides/experiment-backend.md) (the four
+  capabilities, what a minimal implementation looks like, why the plugin ships
+  none), [`defend`](docs/guides/defend.md) (the three targets and what is
+  off-limits in each, the persona levers, the evidentiary record),
+  [`progress`](docs/guides/progress.md) (the four roll-ups and the Goodhart
+  argument), and [`keys`](docs/guides/keys.md) (precedence, relocation, the
+  plaintext-at-rest caveat). The user guide keeps onboarding plus the lifecycle
+  walkthrough and links out.
+  Every page now applies the literature guide's shell-block-vs-quote-block
+  convention: `progress status`, `defend claim`, `hypothesis-exploration park`
+  and `paper-exploration generate` were shown in bare code blocks that read as
+  shell commands but are skill modes, and are now quote blocks with the real
+  `defendable-science backlog …` invocation alongside where one exists. (#103)
 - **`backlog promote --scaffold` performs the handoff both exploration skills
   already documented.** The scaffolders existed and were tested, but no CLI
   command reached them — `backlog --help` listed only

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -6,13 +6,39 @@
 
 # User Guide
 
-A hands-on guide for a researcher meeting `defendable-science` for the first time. It walks
-you from install to a signed finding to a submitted paper, using one running
-example throughout. It is practical: every step is a command you type and a file
-you fill in.
+A hands-on guide for a researcher meeting `defendable-science` for the first time.
+It walks you from install to a signed finding to a submitted paper, using one
+running example throughout, and hands off to a **per-capability guide** whenever
+you need the depth.
 
-For the *why* behind the design, read [`README.md`](../README.md) and the specs
-under [`docs/design/`](design/); this guide is the *how*.
+Read this page front to back once. After that, the guides are where the work
+happens:
+
+| Guide | When you need it |
+|---|---|
+| [Literature](guides/literature.md) | mining the citation graph, the registry, getting PDFs with byte-level provenance |
+| [Datasets](guides/dataset.md) | registering data, tiers and licenses, the resolution chain, the mirror |
+| [Experiment backend](guides/experiment-backend.md) | the one part you implement; how a run becomes citable evidence |
+| [`defend`](guides/defend.md) | the examination before every sign-off; targets, personas, what gets recorded |
+| [`progress`](guides/progress.md) | coverage and blockers, the dashboard, and why there is no score |
+| [API keys](guides/keys.md) | what each key buys and where credentials are kept |
+
+**Two kinds of instruction appear throughout, and mixing them up is the fastest
+way to get stuck.** A shell block is a real command you type:
+
+```bash
+defendable-science dataset fetch imagenet-c
+```
+
+A quote block is something you *ask the assistant*, in prose — a skill mode, not a
+command:
+
+> **Ask the assistant.** Scout the citation graph for research leads at hypothesis
+> level (`literature` in `scout` mode).
+
+Most of `defendable-science` is the second kind. For the *why* behind the design,
+read [`README.md`](../README.md) and the specs under [`docs/design/`](design/);
+this guide is the *how*.
 
 ## 1. What Defendable Science is (and the two rules it runs on)
 
@@ -142,11 +168,21 @@ hypothesis from raw idea to a signed verdict, then roll it into a paper.
 idea pipeline into the paper's `backlog.md`. Its verbs form a small state machine:
 `park → generate → rank → promote | drop`.
 
-```
-hypothesis-exploration park "learned aug policy may help OOD but hurt in-distribution"
-hypothesis-exploration generate      # from literature scout, EDA, or the generation moves
-hypothesis-exploration rank          # score by EIG, feasibility × interest; flag framing
-hypothesis-exploration promote <id>  # scaffold a hypothesis folder, hand to testing
+> **Ask the assistant.** Park this idea in the backlog: "learned aug policy may
+> help OOD but hurt in-distribution". Then generate candidates from the literature
+> scout and the EDA, rank them by EIG and feasibility × interest, and flag any
+> framing problems. I will pick what to promote.
+
+The row-level mechanics are a real CLI the skill shells out to, so you can also
+drive the table yourself:
+
+```bash
+defendable-science backlog park "learned aug policy may help OOD but hurt in-distribution" \
+    --provenance "own" --backlog docs/research/<paper>/backlog.md
+defendable-science backlog rank <id> --EIG high --feas med --interest high \
+    --backlog docs/research/<paper>/backlog.md
+defendable-science backlog promote <id> --scaffold --paper-root docs/research/<paper> \
+    --backlog docs/research/<paper>/backlog.md
 ```
 
 Every backlog row carries **mandatory provenance** (where the idea came from —
@@ -204,13 +240,17 @@ claim is false is successful science.
   > against prior work at hypothesis level (`position` mode) — feeds
   > `strategy.md`. There is no `defendable-science literature scout` or
   > `literature position` command; these are skill modes you ask the
-  > assistant for (see [`docs/guides/literature.md`](guides/literature.md)).
+  > assistant for.
 
-- [`dataset`](../skills/dataset/SKILL.md) manages the data your strategy declares:
-  verbs `init / register / fetch / verify / mirror / audit` over `datasets.yml`.
-  Each dataset gets a storage **tier** (A committed / B auto-retrievable / C
-  gated), a **SHA-256 fingerprint** (authoritative; a mismatch is a hard fail),
-  and a Gebru **datasheet**. You confirm tier and license — the skill proposes.
+  **Full guide: [Literature](guides/literature.md)** — a survey end to end, the
+  six buckets of a fetch report, licenses in practice, and why a refusal is a
+  feature.
+
+- [`dataset`](../skills/dataset/SKILL.md) manages the data your strategy declares,
+  over `datasets.yml`. Each dataset gets a storage **tier** (A committed / B
+  auto-retrievable / C gated), a **SHA-256 fingerprint** (authoritative; a
+  mismatch is a hard fail), and a Gebru **datasheet**. You confirm tier and
+  license — the skill proposes.
 
   > **Ask the assistant.** Register `imagenet-c` in the dataset manifest —
   > propose a tier and license for me to confirm. `register` is a `dataset`
@@ -219,6 +259,10 @@ claim is false is successful science.
   ```bash
   defendable-science dataset fetch imagenet-c    # materialize + verify against the registry
   ```
+
+  **Full guide: [Datasets](guides/dataset.md)** — tiers as a license question, the
+  four-step resolution chain, the mirror as link-rot insurance, and what `audit`
+  checks beyond fixity.
 
 ### 4d. How runs become evidence — the experiment-backend contract
 
@@ -238,6 +282,10 @@ reproducible and staleness is honest. You never hand-copy a number: `findings.md
 cites run-refs, and `tables` writes the figures. `is-current` reports staleness;
 **you** decide whether to re-run.
 
+**Full guide: [Experiment backend](guides/experiment-backend.md)** — what a
+minimal implementation looks like, how to bind one, and why the plugin ships
+none.
+
 ## 5. Papers: from candidate to publish decision
 
 The paper level mirrors the hypothesis level one step up.
@@ -249,9 +297,15 @@ The paper level mirrors the hypothesis level one step up.
   `promote` registers the paper in `papers.md` (assigning its `paper-id` and
   experiment-backend binding) and hands it to synthesis.
 
-  ```
-  paper-exploration generate
-  paper-exploration promote aug-policy-robustness
+  > **Ask the assistant.** Generate candidate papers from the resolved
+  > hypotheses (`paper-exploration` in `generate` mode) across all three lenses,
+  > and rank them. I will pick.
+
+  ```bash
+  # The registry/scaffold half is a real CLI:
+  defendable-science backlog promote aug-policy-robustness \
+      --backlog docs/research/portfolio-backlog.md --level paper --scaffold \
+      --research-root docs/research --backend bench
   ```
 
 - [`paper-synthesis`](../skills/paper-synthesis/SKILL.md) develops the committed
@@ -300,80 +354,62 @@ coherent through-line. Never a paper count.
 
 ## 7. Cross-cutting: progress and defend
 
-- [`progress`](../skills/progress/SKILL.md) is **read-only reporting**. `status
-  <level> [id]` rolls up state; `dashboard` regenerates `docs/research/dashboard.md`
-  as a pure projection of each artifact's status frontmatter (never hand-edit it).
+Both are skill modes — there is no `defendable-science progress` command group,
+and the examination half of `defend` is a conversation, not a command.
 
-  ```
-  progress status hypothesis            # where do all hypotheses stand?
-  progress dashboard                    # regenerate the dashboard
-  ```
-
-  Roll-up is **semantic, not arithmetic**: it surfaces coverage and blockers, never
-  a percentage. A single refuted *load-bearing* hypothesis blocks its paper — an
+- [`progress`](../skills/progress/SKILL.md) is **read-only reporting**. Roll-up is
+  **semantic, not arithmetic**: it surfaces coverage and blockers, never a
+  percentage. A single refuted *load-bearing* hypothesis blocks its paper — an
   average would hide that. **A refuted hypothesis reads as done/green.** There are
-  no scores, ever — that is a hard design invariant, not a missing feature.
+  no scores, ever — a hard design invariant, not a missing feature.
+
+  > **Ask the assistant.** Where do all our hypotheses stand (`progress` in
+  > `status hypothesis` mode)? Then regenerate the dashboard.
+
+  **Full guide: [`progress`](guides/progress.md)** — the four roll-ups, the two
+  readings that catch people out, and the Goodhart argument in full.
 
 - [`defend`](../skills/defend/SKILL.md) is the Socratic tutor-examiner. It is
-  **self-invoked** on demand (examine me on this claim / cited work / method) and
-  fires **automatically as a guardrail** before every material sign-off. It probes,
-  teaches on a gap, and re-probes; it targets `claim | cited-work | methodology`.
-  It offers author-selectable **mentor personas** — *sounding board*, *critical
-  examiner* (default), *directive editor*, opt-in *devil's advocate* — chosen by
-  you or suggested by the stage, **never inferred from your personality**. It
-  teaches established knowledge freely but never supplies the answer key to your
-  novel claim.
+  **self-invoked** on demand and fires **automatically as a guardrail** before
+  every material sign-off. It probes, teaches on a gap, and re-probes; it targets
+  `claim | cited-work | methodology`. It offers author-selectable **mentor
+  personas** — *sounding board*, *critical examiner* (default), *directive
+  editor*, opt-in *devil's advocate* — chosen by you or suggested by the stage,
+  **never inferred from your personality**. It teaches established knowledge
+  freely but never supplies the answer key to your novel claim.
 
-  ```
-  defend claim <hypothesis-id>          # rehearse before you sign
-  ```
+  > **Ask the assistant.** Examine me on the claim in `findings.md` before I sign
+  > it — critical examiner, and push on the rival explanations.
+
+  **Full guide: [`defend`](guides/defend.md)** — the three targets and what is
+  off-limits in each, the persona levers, and the evidentiary record
+  `defend record` writes.
 
 ## 8. API keys & credentials
 
-Some services the tooling reaches key-gate their *useful* rate limits. Providing
-a key is optional — everything degrades gracefully without one — but it removes
+Some services the tooling reaches key-gate their *useful* rate limits. Providing a
+key is **optional** — everything degrades gracefully without one — but it removes
 the throttling that otherwise stalls citation-graph work.
 
-| Key | Service | What it buys | How to obtain |
-|---|---|---|---|
-| `S2_API_KEY` | Semantic Scholar | Raises the rate limit far above the shared keyless pool (which throttles hard). | <https://www.semanticscholar.org/product/api#api-key> |
-| `OPENALEX_MAILTO` | OpenAlex | Joins the "polite pool" (a contact email) for faster, more reliable responses. | <https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication> |
-| `RCLONE_CONFIG_<REMOTE>_*` | Private dataset mirror | rclone remote credentials, handed to rclone as scoped env vars (no config file needed). | Per your rclone remote (see `rclone config`). |
+| Key | Service | What it buys |
+|---|---|---|
+| `S2_API_KEY` | Semantic Scholar | raises the rate limit far above the shared keyless pool |
+| `OPENALEX_MAILTO` | OpenAlex | joins the "polite pool" — just a contact email |
+| `RCLONE_CONFIG_<REMOTE>_*` | private mirror | rclone credentials as scoped env vars |
 
-Defendable Science keeps keys in a **CLI-managed JSON store** — never a `.env` — at
-an XDG config path **outside any repo's work tree**:
-`$XDG_CONFIG_HOME/defendable-science/keys.json`, falling back to
-`~/.config/defendable-science/keys.json` (ADR-0032). A stored key can therefore
-never be committed by accident. Keys are read with **`os.environ` > store >
-unset** precedence, so an environment variable always wins (CI / secrets
-injection is unaffected) and an unset key just degrades the service. Manage
-the store with the `keys` command group:
+Keys live in a **CLI-managed JSON store — never a `.env`** — at an XDG config path
+**outside any repo's work tree**, so a stored key cannot be committed by accident
+(ADR-0032). The value is never taken from the command line, only from a hidden
+prompt or stdin.
 
-```
-defendable-science keys set S2_API_KEY        # prompts hidden, or reads piped stdin
-echo "$MY_KEY" | defendable-science keys set S2_API_KEY
-defendable-science keys set < keys.json       # a JSON object sets many at once
-defendable-science keys list                  # metadata + presence + source (never values)
-defendable-science keys check                 # compact presence/source report
-defendable-science keys unset S2_API_KEY
-defendable-science keys path                  # print the resolved store path
+```bash
+defendable-science keys set S2_API_KEY     # hidden prompt, or reads piped stdin
+defendable-science keys check              # presence + source, never values
 ```
 
-The value is **never** taken from the command line — only from stdin or a hidden
-prompt — so a secret never lands in your shell history or the process list.
-`keys list`/`check` and `doctor` report only **presence and source**, never a
-value.
-
-Set `DEFENDABLE_SCIENCE_KEYS_PATH` to opt into a different location, e.g. the
-legacy in-repo `.defendable-science/keys.json` — `research-init` still gitignores
-that path for anyone who does — but the store then warns (never silently) if
-the resolved path sits in a git work tree and is not confirmed gitignored.
-
-> **Honesty caveat — plaintext at rest.** The store is **not encrypted**.
-> Living outside the repo (or being gitignored + `0600` file permissions when
-> opted in) limits exposure, but anyone who can read the file reads the keys.
-> Treat it as convenience storage, not a secret vault. OS-keychain backing
-> behind the same `keys` interface is a planned follow-up (issue #49).
+**Full guide: [API keys](guides/keys.md)** — what each key buys, the
+`os.environ > store > unset` precedence, opting into a different location, and the
+plaintext-at-rest caveat.
 
 ## 9. Everyday tips
 

--- a/docs/guides/dataset.md
+++ b/docs/guides/dataset.md
@@ -1,0 +1,201 @@
+# Datasets: a manifest you can cite, and bytes you can prove
+
+A task-oriented guide to the whole `dataset` capability — registering data, giving
+every file a fingerprint, materializing it through the resolution chain, and
+keeping a private mirror so link rot cannot quietly break your reproducibility.
+
+If you have not met `defendable-science` yet, read the
+[User Guide](../USER-GUIDE.md) first — this page assumes you know what a skill is
+and what the agency principle asks of you.
+
+## 1. Two kinds of instruction, and how to tell them apart
+
+Like `literature`, the `dataset` capability is half assistant and half
+command-line tool, and mixing the two up is the fastest way to get stuck.
+
+- **`init` and `register` are skill *modes*.** You *ask the assistant* for them,
+  in prose. They involve judgement — proposing a storage tier, reading a license,
+  writing a datasheet — and end in a decision that is yours to confirm. There is
+  no `defendable-science dataset register` command.
+- **`defendable-science dataset …` is a CLI.** Seven commands, each printing
+  JSON: `validate | ingest | emit` over the manifest, and
+  `fetch | verify | mirror | audit` over the bytes. These run in a terminal, and
+  the skill shells out to them.
+
+So this page can never be misread, it uses exactly two conventions:
+
+> **Ask the assistant.** Anything you say to the agent appears in a quote block
+> like this one, in plain language. You are not meant to type it into a shell.
+
+```bash
+# Anything in a shell block is a real command, verbatim.
+defendable-science dataset verify --manifest datasets.yml
+```
+
+Note the asymmetry with the skill's verb table in
+[`skills/dataset/SKILL.md`](../../skills/dataset/SKILL.md): the skill's `export`
+verb is the CLI's `dataset emit`, and the skill's `register` is what *produces*
+manifest entries that `dataset validate` then gates. The verb names are the
+methodology's; the command names are the tool's.
+
+## 2. The manifest: one file, checked into git
+
+`datasets.yml` is the registry and the source of truth. It is committed, public,
+and holds **no secrets and no blobs above Tier A** — metadata, checksums, tiers,
+licenses, retrieval recipes, and datasheet links.
+
+> **Ask the assistant.** Scaffold the dataset registry for this repo
+> (`dataset` in `init` mode) — I want `datasets.yml`, the gitignored cache dir,
+> and the committed `rclone.conf.example` template.
+
+Then, per dataset:
+
+> **Ask the assistant.** Register `imagenet-c` in the dataset manifest — ingest
+> its published Croissant metadata if there is one, propose a storage tier and
+> read me the license, and draft the datasheet. I will confirm the tier and the
+> license.
+
+Two things in that request are load-bearing. **The tier and the license are
+yours to confirm**, never the skill's to decide — they determine whether bytes may
+be committed or redistributed, which is a legal question about your project, not
+a technical one. And the **datasheet** is not paperwork: it is a `defend`
+methodology target, so expect to be asked "what are this dataset's known
+collection limits?" before you sign a finding that rests on it.
+
+If the dataset publishes Croissant JSON-LD, bootstrap from it rather than
+hand-typing:
+
+```bash
+defendable-science dataset ingest path/to/croissant.json
+```
+
+and validate the manifest whenever you have hand-edited it:
+
+```bash
+defendable-science dataset validate
+```
+
+`validate` is the gate `register` and `audit` both run behind. A manifest that
+does not validate is a manifest whose checksums you cannot trust.
+
+## 3. Tiers: a license question, not a size question
+
+The tier is `f(redistribution license × access automation)`, and **redistribution
+dominates**. Size only decides Tier A once redistribution is already permitted.
+
+| Tier | Condition | What you get |
+|---|---|---|
+| **A — committed** | small **and** the license permits redistribution | bytes in git/LFS; zero-setup reproducibility. A mirror is redundant. |
+| **B — auto-retrievable** | public and fetchable from a stable URL/API, but large or non-redistributable | a `retrieval` recipe plus a `sha256` in the manifest; bytes land in the gitignored cache. **The mirror is link-rot insurance**, populated on first fetch. |
+| **C — manual / gated** | login, EULA, registration, or no stable source | metadata, datasheet, acquisition instructions and `sha256` only. The tooling **verifies presence and integrity but never fetches**. Mirror only if the DUA permits a private copy. |
+
+The common mistake is filing a large public dataset as Tier C because it is
+awkward to download. If there is a stable URL and a checksum, it is Tier B, and
+the difference matters: Tier B is reproducible by anyone who clones your repo,
+Tier C needs a human with credentials.
+
+## 4. Getting the bytes: the resolution chain
+
+`fetch` never just downloads. It walks a chain, verifying SHA-256 at every hop,
+and **a file that fails verification is treated as absent** so the chain
+continues rather than handing you bad bytes:
+
+```
+1  LOCAL CACHE     exists and sha256 == manifest → return; else discard if corrupt
+2  PRIVATE MIRROR  rclone copy mirror:base/sha256/<hash> → re-hash → return; else fall through
+3  PUBLIC SOURCE   Tier A: git/LFS · Tier B: pooch (http/ftp/sftp/doi:)
+                   → assert sha256 == manifest (HARD FAIL) → populate mirror → return
+4  GATED / MANUAL  print acquisition instructions → wait for your drop → verify → populate mirror
+```
+
+```bash
+defendable-science dataset fetch imagenet-c
+```
+
+Three properties of that chain are worth understanding, because they are what
+make a cited number defensible:
+
+- **The manifest's SHA-256 is authoritative.** Integrity *is* identity *is*
+  citation-verifiability. A mismatch at step 3 is a hard failure, not a warning —
+  the tool will not bind unverified bytes to a dataset id you are citing.
+- **rclone's own hash is only a transport check.** Backends often report MD5
+  (Drive, S3). Local bytes are always **re-hashed against the manifest** after any
+  transfer, so verification does not depend on which backend you mirror to.
+- **The cache is content-addressed on the wire** (`sha256/<hash>` keys) and
+  name-addressed for use. That gives deduplication for free and makes integrity
+  and identity the same fact.
+
+To check what you already have, offline and without touching the network:
+
+```bash
+defendable-science dataset verify --manifest datasets.yml
+```
+
+`verify` never downloads. That is the point: it answers "do the bytes on this
+machine still match what I published?" — the question you want answered before a
+paper deadline, not during one.
+
+## 5. The mirror: link-rot insurance
+
+A Tier B dataset is only reproducible for as long as its URL resolves. The
+private mirror is the answer, populated automatically on first successful
+acquisition and refreshable on demand:
+
+```bash
+defendable-science dataset mirror imagenet-c
+```
+
+**Credentials never enter the repo.** `rclone.conf` is gitignored; you point at it
+with `RCLONE_CONFIG=$PWD/.defendable-science/rclone.conf`, and commit only
+`rclone.conf.example` (remote name and type, nothing else). CI uses env-var
+remotes from secrets. And `rclone obscure` is **not** encryption — never commit
+its output and never treat it as a secret store.
+
+rclone itself is an optional external binary the wrappers shell out to, not a
+Python dependency. If it is absent, mirror steps degrade with an explicit signal
+rather than silently reporting "not mirrored".
+
+## 6. `audit`: the one command to run before you publish
+
+```bash
+defendable-science dataset audit --manifest datasets.yml
+```
+
+`audit` is the whole-manifest sweep, and it checks more than fixity:
+
+- **fixity** — every on-disk file against its manifest checksum;
+- **presence** — is each entry actually retrievable, including from the mirror;
+- **completeness** — is there a license and a datasheet for every entry;
+- **tier ↔ (access, redistributable) consistency** — this is the one people miss.
+  A Tier A entry whose license forbids redistribution is a licensing problem
+  sitting in your git history. A Tier C entry with a perfectly good public URL is
+  a reproducibility problem you have imposed on your readers.
+
+It reports gaps; it does not fix them. Closing a gap is a decision (relicense,
+re-tier, write the datasheet), and decisions are yours.
+
+## 7. Quick reference
+
+| You want to… | How |
+|---|---|
+| scaffold the registry | ask the assistant (`init` mode) |
+| add a dataset | ask the assistant (`register` mode) — you confirm tier + license |
+| bootstrap from published Croissant | `dataset ingest <file>` |
+| check a hand-edited manifest | `dataset validate` |
+| materialize a dataset | `dataset fetch <id>` |
+| check on-disk bytes, offline | `dataset verify` |
+| refresh the private mirror | `dataset mirror <id>` |
+| pre-publication sweep | `dataset audit` |
+| emit Croissant for a venue | `dataset emit <id>` (or `--all`) |
+
+## Where to go next
+
+- [`skills/dataset/SKILL.md`](../../skills/dataset/SKILL.md) — the capability in
+  the plugin's own words, including the full manifest schema and the guardrails.
+- [`docs/guides/literature.md`](literature.md) — the other front-end over the same
+  substrate; the same cache → mirror → source chain, for PDFs.
+- [`docs/design/03-dataset.md`](../design/03-dataset.md) — the design, and
+  [`docs/design/04-substrate-and-contract.md`](../design/04-substrate-and-contract.md)
+  §2.4 for the shared resolution chain.
+- [ADR-0010](../../decisions/0010-storage-tiers.md) — why tiers are a license
+  question first and a size question second.

--- a/docs/guides/defend.md
+++ b/docs/guides/defend.md
@@ -1,0 +1,151 @@
+# `defend`: the examination you have to pass before you sign
+
+A task-oriented guide to the guardrail that makes the *understanding* principle
+mechanical. `defend` probes whether you can actually defend a claim, a citation,
+or a method — Socratically, one question at a time — teaches when it finds a gap,
+and records what happened as evidence.
+
+If you have not met `defendable-science` yet, read the
+[User Guide](../USER-GUIDE.md) first.
+
+## 1. Two kinds of instruction, and how to tell them apart
+
+- **The examination is a skill.** You *ask the assistant* for it, in prose, and it
+  is a conversation. There is no `defendable-science defend claim <id>` command,
+  and there cannot be — the whole thing is dialogue.
+- **`defendable-science defend record` is a CLI**, with exactly one command. It
+  writes the *outcome* of an examination into the artifact's frontmatter and
+  appends the evidentiary record to the accountability log. The skill calls it for
+  you at the end of a session.
+
+> **Ask the assistant.** Examine me on the claim in
+> `docs/research/aug-policy-robustness/hypotheses/2026-03-04-aug-ood/strategy.md`
+> before I sign it — critical examiner, and push on the rival explanations.
+
+```bash
+# The CLI half: recording what the examination found.
+defendable-science defend record \
+    --artifact docs/research/.../strategy.md --target claim --signed-off-by "Your Name"
+```
+
+## 2. Two ways it fires
+
+**Self-invoked, on demand.** Any time you want to rehearse — before a supervisor
+meeting, before a submission, when you suspect you are hand-waving. This is the
+cheap, no-stakes use, and it is the one most people under-use.
+
+**Automatically, as a guardrail.** Before *every* material sign-off, `defend`
+fires whether you asked for it or not: the strategy in `hypothesis-testing`, the
+verdict in `findings.md`, the publish/no-go in `decision.md`, and — escalated to a
+full mock viva — the defensibility gate in `thesis`.
+
+The guardrail **surfaces gaps; it does not block you.** You may override and sign
+anyway. But the override is logged, with the gap it overrode. That is the whole
+design: the tool cannot and should not stop a researcher from making a call, but
+it can make sure the call is on the record as having been made knowingly.
+
+At the thesis gate the escalation is per-gap: you acknowledge *each* surfaced gap
+in writing, not one blanket override.
+
+## 3. Three targets, and what is off-limits in each
+
+| Target | What it probes | What it may teach |
+|---|---|---|
+| `claim` | your own scientific claim — entailments, assumptions, rivals, falsifiers, limitations | *how to reason and defend*, only — **never the answer key** |
+| `cited-work` | do the cited works actually support the claim; what each source really says | your citations plus the source texts |
+| `methodology` | the *why* behind a rigor-kit choice, not the ritual | the methodology digests and authoritative references |
+
+The asymmetry in that last column is the most important thing on this page.
+
+`defend` **teaches established knowledge freely.** If you cannot say why a
+paired test is appropriate here, or what a TOST bound is for, it will explain,
+with sources, and then re-ask. That is not cheating; it is what a good supervisor
+does.
+
+`defend` **never supplies the answer key to your novel claim.** It will ask you
+what would falsify your hypothesis. It will not tell you. It does not grade the
+substance of your contribution — that is your science, and a tool that supplied
+it would be making the contribution instead of you.
+
+So a `claim` examination can feel harder than a `methodology` one, and that is
+correct.
+
+## 4. Mentor personas: chosen, never inferred
+
+The examination voice has four settings, derived from supervision typologies
+(Lee × Gatfield) — **not** from personality theory:
+
+- **Sounding board** — high autonomy-support, exploratory. Early stage.
+- **Critical examiner** — **the default**. Calibrated difficulty.
+- **Directive editor** — concrete, process-level feedback. Deadline-driven.
+- **Devil's advocate** — *opt-in*, time-boxed, explicit challenge to the argument.
+
+Three levers pick one, all of them yours:
+
+1. **You choose** (the default).
+2. **The stage suggests** one — early draft → sounding board, near-submission →
+   examiner — always overridable, and keyed to the *work*, never to you.
+3. **Your feedback calibrates** it: "too harsh", "push harder".
+
+**Inferring a persona from your personality is forbidden.** It is unsupported (the
+learning-styles myth) and it is an agency violation — the tool does not get to
+decide what kind of person you are. Autonomy-support is constant across all four;
+only directiveness and challenge intensity vary. Feedback targets the argument and
+the process, never you.
+
+> **Ask the assistant.** Switch to devil's advocate for ten minutes on the
+> positioning section — I want the strongest version of the objection a reviewer
+> would raise.
+
+## 5. What gets recorded, and why it is not a score
+
+An examination ends in an **evidentiary point record** (ADR-0033), not a mark.
+Per point: what was asked, what was observed, whether a gap remains. The
+`status.understanding` block in the artifact's frontmatter carries the summary —
+`{status, unresolved: [...]}` — and the full record is appended to
+`docs/research/defend-log/`.
+
+```bash
+defendable-science defend record \
+    --artifact docs/research/.../findings.md \
+    --target claim \
+    --points points.json \
+    --signed-off-by "Your Name" \
+    --transcript -
+```
+
+The flags that matter:
+
+- `--points` — the point records, as a JSON array file or on stdin.
+- `--override` with `--acks 'gap::name||gap::other'` — sign despite named gaps.
+  Each gap is acknowledged individually; there is no way to wave at all of them
+  at once.
+- `--transcript` — the session transcript, file or stdin, so the record is
+  auditable rather than a summary you have to trust.
+- `--log-dir` — defaults to `docs/research/defend-log`.
+
+**Records observed facts only — never a verdict, a score, or an answer key.** The
+`understanding` block feeds the [`progress`](progress.md) roll-up as coverage and
+named gaps, which is the only thing it is allowed to become.
+
+## 6. `digest` is the same machinery, pointed inward
+
+`defend` verifies you understand *your own* work before you sign it. Its inbound
+counterpart, [`digest`](../../skills/digest/SKILL.md), verifies you understand a
+paper *someone else* wrote before you cite it — same evidentiary record, via
+`defend record --target paper-comprehension`.
+
+That is why `progress status literature` can report "digested and understood"
+versus "gaps unresolved" per paper, rather than a count of papers read.
+
+## Where to go next
+
+- [`skills/defend/SKILL.md`](../../skills/defend/SKILL.md) — the capability in the
+  plugin's own words, including the worked methodology probe and the hard
+  constraints.
+- [`docs/guides/progress.md`](progress.md) — where the `understanding` block
+  surfaces, and why it never becomes a number.
+- [ADR-0033](../../decisions/0033-evidentiary-point-records.md) — why per-point
+  records rather than a pass/fail.
+- [`resources/references/mentor-personas.md`](../../resources/references/mentor-personas.md)
+  — the supervision-typology sources behind the four personas.

--- a/docs/guides/experiment-backend.md
+++ b/docs/guides/experiment-backend.md
@@ -1,0 +1,163 @@
+# The experiment backend: how a run becomes citable evidence
+
+A task-oriented guide to the one part of `defendable-science` **you** have to
+supply. The plugin defines a four-capability contract and ships no
+implementation; this page is what to build, why each capability exists, and how
+to bind it so the pipeline skills can find it.
+
+If you have not met `defendable-science` yet, read the
+[User Guide](../USER-GUIDE.md) first.
+
+## 1. Why the plugin ships no backend
+
+Every other capability here is domain-neutral by construction. Running an
+experiment is not: it means your scheduler, your cluster or laptop, your config
+format, your result layout. Bundling one would either be useless to most projects
+or would smuggle a particular ML stack into a plugin that is supposed to work for
+any empirical science.
+
+So the plugin ships the **contract** and nothing else, and `backend:` in
+`docs/research/papers.md` is a **required** field with no default (ADR-0013). A
+paper with no backend binding is a paper whose numbers have no traceable origin,
+which is precisely the state this tool exists to prevent — so it refuses to
+pretend otherwise rather than silently defaulting to something.
+
+There is no CLI here. The contract is implemented in your repo and invoked by the
+pipeline skills, so everything on this page is either something you write or
+something you ask the assistant for.
+
+## 2. The four capabilities
+
+| Capability | Purpose | Returns |
+|---|---|---|
+| **`run`** | execute (or resume) an experiment for a given config | a **run-ref** — an opaque, stable handle |
+| **`evidence`** | fetch results for a run-ref | structured results + a **provenance stamp** |
+| **`tables`** | render results into the doc-facing blocks a hypothesis or paper cites | rendered artifacts (managed blocks) |
+| **`is-current`** | is this run-ref's evidence still valid given current code, config and data? | `current` \| `stale(reasons)` |
+
+Nothing in that table mentions a scheduler, and that is deliberate: a shell script
+that runs one model on a laptop and a GPU orchestrator fanning out a thousand
+trials are equally valid implementations.
+
+### The run-ref is the whole idea
+
+A **run-ref is the citable unit of evidence.** `findings.md` at the hypothesis
+level, and `ledger.md` / `decision.md` at the paper level, reference run-refs —
+**never raw numbers copied by hand**. If a number cannot be traced to a run-ref,
+it does not belong in a findings doc or a paper section.
+
+This is not bookkeeping fussiness. Hand-copied numbers are the single most common
+way an honest researcher publishes a wrong table: the run is re-done, the config
+drifts, the number in the draft is from two weeks ago and nothing in the document
+knows that. Citing a run-ref makes the staleness *detectable*, which is what
+`is-current` is for.
+
+### `tables` is the only writer of numbers
+
+The `tables` capability writes result numbers into your documents as **managed,
+regenerable blocks**. Nothing else does — not you, not the assistant. Regenerating
+is therefore always safe, and a number in a paper section is always exactly what
+the backend most recently rendered from a run-ref.
+
+### The provenance stamp must carry the dataset fingerprint
+
+`evidence` returns results *plus* a stamp: config hash, code/symbol provenance,
+timestamps, hardware, and the dataset `id + version + sha256` from the
+[`dataset`](dataset.md) manifest. That last one is what closes the loop — a
+reported result resolves to exact bytes, so "which data was this?" has an answer
+you can verify with `defendable-science dataset verify` rather than a
+recollection.
+
+### `is-current` makes selective re-execution honest
+
+Without it, you have two bad options: re-run everything before every deadline, or
+trust that nothing has drifted. `is-current` lets a hypothesis or paper ask "is my
+evidence stale?" without knowing how the backend computes staleness — a
+provenance or closure hash is the usual answer.
+
+**It reports; it does not decide.** A `stale(reasons)` answer is information for
+you. Whether to re-run is a research judgement — cost, deadline, whether the drift
+could plausibly change the verdict — and the tool does not make it.
+
+## 3. Binding a backend
+
+One field, in the paper registry:
+
+```
+| paper-id | root | backend |
+|---|---|---|
+| aug-policy-robustness | docs/research/aug-policy-robustness | bench |
+```
+
+`promote` writes that row when you promote a candidate paper:
+
+```bash
+defendable-science backlog promote aug-policy-robustness \
+    --backlog docs/research/portfolio-backlog.md --level paper --scaffold \
+    --research-root docs/research --backend bench
+```
+
+`--backend` is required with `--scaffold` at the paper level, for the reason
+above: a registry row with an empty binding is not a usable paper.
+
+The repo-wide default lives in `.defendable-science/config.yml`; the per-paper row
+in `papers.md` is what the pipeline skills actually resolve. Different papers in
+one portfolio may bind different backends, and no pipeline skill changes as a
+result — that is the payoff for the contract being abstract.
+
+## 4. What a minimal implementation looks like
+
+You do not need a platform. A typical mapping onto tooling a project already has:
+
+| Capability | A plausible minimal implementation |
+|---|---|
+| `run` | the script you already use to train/evaluate, returning a directory name or hash as the run-ref |
+| `evidence` | the committed results file plus a provenance sidecar you write alongside it |
+| `tables` | a small renderer that replaces a marked block in a markdown file |
+| `is-current` | hash of (config + code revision + dataset sha256s), compared against the stamp |
+
+The discipline that matters is not sophistication, it is that **`evidence` stamps
+the dataset fingerprint** and **`tables` is the only writer**. Those two make the
+rest of the guarantees hold.
+
+## 5. Where the boundary sits
+
+The backend produces and stamps evidence. It **never adjudicates** it.
+
+Whether the evidence confirms or refutes a hypothesis, and whether a body of work
+supports publication, are material decisions recorded with a named human sign-off
+and a date. A backend that returned a verdict would be making your call for you,
+and the pipeline skills would have nowhere to put your signature.
+
+The same line runs through `is-current`: it tells you the evidence is stale, and
+stops.
+
+## 6. Engineering is delegated, too
+
+The backend contract is about *running* experiments. The adjacent question —
+designing them and writing the code — is also not the plugin's job: `design.md`
+and `plan.md` are produced by a bound **engineering backend** via the
+engineering-delegation contract (ADR-0023). `defendable-science` stores the
+results in the hypothesis folder and reasons about them, but does not design
+experiments or write code itself.
+
+So a fully wired repo binds two things: an engineering backend for design/plan,
+and an experiment backend for run/evidence/tables/is-current.
+
+> **Ask the assistant.** Walk me through what our experiment backend has to
+> implement for `docs/research/aug-policy-robustness`, and check whether our
+> current runner already covers `is-current` — I want to know what is missing
+> before I bind it in `papers.md`.
+
+## Where to go next
+
+- [`docs/design/04-substrate-and-contract.md`](../design/04-substrate-and-contract.md)
+  §3 — the contract in full, including the open question about run-ref format.
+- [ADR-0013](../../decisions/0013-experiment-backend-contract.md) — why a
+  contract with no bundled default, and the alternatives rejected.
+- [ADR-0023](../../decisions/0023-engineering-delegation-contract.md) — the
+  engineering-delegation contract, the other half of the delegation story.
+- [`docs/guides/dataset.md`](dataset.md) — where the `id + version + sha256` in
+  the provenance stamp comes from.
+- [`skills/hypothesis-testing/SKILL.md`](../../skills/hypothesis-testing/SKILL.md)
+  — the skill that consumes run-refs into a signed verdict.

--- a/docs/guides/keys.md
+++ b/docs/guides/keys.md
@@ -1,0 +1,119 @@
+# API keys: what they buy, and where they are kept
+
+A task-oriented guide to credentials. Every key here is **optional** —
+`defendable-science` degrades gracefully without any of them — but the citation
+graph in particular is much less painful with one, and knowing which key does what
+saves you from setting up things you do not need.
+
+If you have not met `defendable-science` yet, read the
+[User Guide](../USER-GUIDE.md) first.
+
+## 1. This one is nearly all CLI
+
+Unlike most capabilities here, key handling is a real command group with no skill
+mode: `defendable-science keys set | list | check | unset | path`. Everything on
+this page is a command you type.
+
+## 2. What each key buys
+
+| Key | Service | What it buys | Where to get it |
+|---|---|---|---|
+| `S2_API_KEY` | Semantic Scholar | Raises the rate limit far above the shared keyless pool, which throttles hard. | <https://www.semanticscholar.org/product/api#api-key> |
+| `OPENALEX_MAILTO` | OpenAlex | Joins the "polite pool" — it is just a contact email — for faster, more reliable responses. | <https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication> |
+| `RCLONE_CONFIG_<REMOTE>_*` | private dataset/PDF mirror | rclone remote credentials, handed to rclone as scoped env vars so no config file is needed. | per your remote (`rclone config`) |
+
+`OPENALEX_MAILTO` is the cheapest win in the list: it is an email address, not a
+credential, and it moves you out of the throttled anonymous pool. Set it first.
+
+Without `S2_API_KEY`, snowballing a survey to saturation will stall on rate
+limits — and it will *say* it stalled rather than reporting a short result as
+complete. A throttle is an error, never a legitimately empty answer.
+
+## 3. Where keys live: a JSON store outside your repo
+
+`defendable-science` keeps keys in a **CLI-managed JSON store — never a `.env`** —
+at an XDG config path **outside any repo's work tree**:
+
+```
+$XDG_CONFIG_HOME/defendable-science/keys.json
+# falling back to
+~/.config/defendable-science/keys.json
+```
+
+That location is the point (ADR-0032): a stored key cannot be committed by
+accident, because it is not in the repo at all.
+
+```bash
+defendable-science keys path      # print the resolved store path
+```
+
+## 4. Setting and inspecting keys
+
+```bash
+defendable-science keys set S2_API_KEY          # hidden prompt
+echo "$MY_KEY" | defendable-science keys set S2_API_KEY
+defendable-science keys set < keys.json         # a JSON object sets many at once
+defendable-science keys list                    # metadata + presence + source
+defendable-science keys check                   # compact presence/source report
+defendable-science keys unset S2_API_KEY
+```
+
+**The value is never taken from the command line** — only from a hidden prompt or
+stdin. So a secret never lands in your shell history or in the process list where
+any other user on the machine could read it. There is deliberately no
+`keys set S2_API_KEY <value>` form.
+
+`keys list`, `keys check` and `doctor` report **presence and source only, never a
+value**. If you need to see a key, read the store file yourself; the tool will not
+print it for you.
+
+## 5. Precedence: the environment always wins
+
+Keys resolve as **`os.environ` > store > unset**.
+
+- An environment variable always wins, so CI and secret-injection setups work
+  untouched — you do not need the store in CI.
+- The store is the convenience layer for your laptop.
+- An unset key does not fail; it degrades the service, visibly.
+
+```bash
+defendable-science keys check     # tells you which source each key came from
+```
+
+That `source` column is the one to read when something behaves unexpectedly: a
+stale environment variable shadowing a freshly-set store entry looks exactly like
+"the store did not save", and `check` distinguishes them.
+
+## 6. Opting into a different location
+
+Set `DEFENDABLE_SCIENCE_KEYS_PATH` to move the store — for example to the legacy
+in-repo `.defendable-science/keys.json`, which `research-init` still gitignores
+for anyone who wants it there.
+
+If you do, the store **warns — never silently** — when the resolved path sits
+inside a git work tree and is not confirmed gitignored. That warning is the
+guardrail for the one configuration that can leak a key into a commit.
+
+## 7. Honesty caveat: plaintext at rest
+
+**The store is not encrypted.**
+
+Living outside the repo limits exposure, and an opted-in in-repo store is
+gitignored with `0600` permissions — but anyone who can read the file reads the
+keys. Treat it as convenience storage, not a secret vault. If your threat model
+includes other users on the machine, or a stolen laptop, use your OS keychain or
+an env-var injection setup instead.
+
+OS-keychain backing behind this same `keys` interface is a planned follow-up
+(issue [#49](https://github.com/davorrunje/defendable-science/issues/49)).
+
+## Where to go next
+
+- [`docs/guides/literature.md`](literature.md) — what `S2_API_KEY` and
+  `OPENALEX_MAILTO` are actually for.
+- [`docs/guides/dataset.md`](dataset.md) §5 — the rclone side, and why
+  `rclone obscure` is not encryption.
+- [ADR-0029](../../decisions/0029-api-key-handling.md) — a CLI-managed store
+  rather than `.env`, and the alternatives rejected.
+- [ADR-0032](../../decisions/0032-keys-store-outside-repo-by-default.md) — why the
+  default lives outside the repo.

--- a/docs/guides/progress.md
+++ b/docs/guides/progress.md
@@ -1,0 +1,124 @@
+# `progress`: coverage and blockers, and deliberately no score
+
+A task-oriented guide to the reporting side of `defendable-science`. `progress`
+reads the status frontmatter every other skill writes and tells you where the work
+actually stands — what is covered, what is blocked, what has gone stale. It will
+never tell you that you are 73% done, and this page explains why that is a feature.
+
+If you have not met `defendable-science` yet, read the
+[User Guide](../USER-GUIDE.md) first.
+
+## 1. It is all skill modes — there is no `progress` CLI
+
+`status` and `dashboard` are things you **ask the assistant for**. There is no
+`defendable-science progress` command group; the roll-up is a semantic reading of
+frontmatter, which is agent work.
+
+> **Ask the assistant.** Where do all our hypotheses stand (`progress` in
+> `status hypothesis` mode)? Call out anything blocked or stale.
+
+> **Ask the assistant.** Regenerate the dashboard (`progress` in `dashboard`
+> mode).
+
+`dashboard` is the **only** file `progress` writes:
+`docs/research/dashboard.md`, as a **pure projection** of status frontmatter. It
+is machine-owned — **never hand-edit it**, because the next regeneration silently
+discards whatever you typed. If something in the dashboard is wrong, the
+frontmatter it projects is wrong; fix that.
+
+## 2. Four roll-ups
+
+`status <level> [id]` reads one artifact when given an id, or every artifact at a
+level when not. Levels: `hypothesis`, `paper`, `thesis`, `literature`.
+
+**hypothesis → paper.** Done means "all constituent hypotheses *resolved* AND the
+claim is written." A single **refuted `load-bearing: true`** hypothesis is a
+**blocker** on its paper — it invalidates the claim no matter how many siblings
+resolved cleanly. So the report reads:
+
+```
+covered: 4/5 resolved; BLOCKED by aug-ood-transfer (load-bearing, refuted)
+```
+
+and not `80%`. An average would hide exactly the one thing you need to know.
+
+**paper → thesis.** Done means "all aims covered by ≥1 paper AND the kappa states
+the through-line." The roll-up is **uncovered aims** plus **through-line stated?**
+— the two things an examiner actually checks. Paper *count* is never the target;
+there is no universal N, and the binding norm is scope.
+
+**literature.** Independent of the hierarchy above: it reads the `understanding`
+block in `docs/research/literature/digests/*.md` — written by
+[`digest`](../../skills/digest/SKILL.md) via `defend record --target
+paper-comprehension` — and reports, per digested paper, `{digested & understood /
+gaps unresolved}`, joined against `triage.yml` by citekey for role and
+disposition. Not a count of "papers read".
+
+**staleness is orthogonal.** An artifact whose evidence the backend reports as
+not-current (`is-current`, see [the experiment-backend
+guide](experiment-backend.md)) is flagged stale regardless of its verdict.
+`progress` surfaces it; **you** decide whether to re-run.
+
+The output shape is the same everywhere: `{covered / total by state}` +
+`{explicit blockers}` + `{stale?}`. No rolled-up number leaves this skill.
+
+## 3. Two readings that catch people out
+
+**A refuted hypothesis reads as done and green.** Verdict and readiness are
+distinct axes, and refutation is successful science. A dashboard that showed
+refuted work in red would be punishing honest negative results — a modelling
+error, and one that quietly incentivises not looking too hard.
+
+**A resolved hypothesis can still block its paper.** See the load-bearing rule
+above. "All my hypotheses are resolved" and "my paper is unblocked" are different
+statements.
+
+## 4. Why there is no progress number
+
+This is a hard design invariant (ADR-0014), documented so it cannot later be
+"improved" into a score by someone who thinks it is a missing feature.
+
+A self-tracking research tool is *especially* Goodhart-prone, because the same
+person sets and games the metric. So `progress` surfaces state, gaps and
+staleness — open hypotheses, uncovered aims, stale evidence, unresolved
+understanding gaps — and never a single number.
+
+It does **not** count or compute: word counts, paper counts, citation or impact
+proxies, commit counts, %-complete on unresolved work, or a hypothesis "success
+rate."
+
+The grounding is cited so it stays honest: Goodhart's law and Campbell's law (a
+measure that becomes a target stops measuring), and the DORA (2012) / Leiden
+Manifesto (Hicks & Wouters et al., 2015) principle that metrics *support* rather
+than *replace* qualitative judgement. See
+[`resources/references/thesis-and-progress-tracking.md`](../../resources/references/thesis-and-progress-tracking.md)
+Part B.
+
+If you want a number for a supervisor meeting, the honest answer is the coverage
+line plus the blockers — which is more informative than a percentage anyway, and
+takes the same breath to say.
+
+## 5. Keeping the frontmatter true
+
+`progress` is only as good as what it reads, and it reads what the other skills
+wrote. Two habits keep it accurate:
+
+- **Never hand-edit `dashboard.md`.** It is generated. Fix the source frontmatter.
+- **A verdict is real only once `signed-off-by` + `signed-off-date` are set.** An
+  unsigned `findings.md` with a verdict typed in is not resolved, and `progress`
+  is right to report it as open.
+
+> **Ask the assistant.** Read the status frontmatter across
+> `docs/research/aug-policy-robustness` and tell me which hypotheses are
+> unsigned, which are stale, and which single one is blocking the paper.
+
+## Where to go next
+
+- [`skills/progress/SKILL.md`](../../skills/progress/SKILL.md) — the capability in
+  the plugin's own words, including the full status-frontmatter schema.
+- [ADR-0014](../../decisions/0014-progress-cross-cutting.md) — the anti-Goodhart
+  decision and the alternatives rejected.
+- [`docs/guides/defend.md`](defend.md) — where the `understanding` block comes
+  from.
+- [`docs/design/01-lifecycle.md`](../design/01-lifecycle.md) §5 — status in
+  frontmatter, and the dashboard as a pure projection.

--- a/tools/build_docs_site.py
+++ b/tools/build_docs_site.py
@@ -131,7 +131,28 @@ def plan() -> tuple[dict[str, str | None], dict[str, object]]:
     reg("index", "README.md")
     reg("get-started/user-guide", "docs/USER-GUIDE.md")
 
-    guide_pages = [reg("guides/literature", "docs/guides/literature.md")]
+    # Ordered as a learning path, not alphabetically: the two capability guides a
+    # reader needs first, then the part they have to implement, then the
+    # cross-cutting skills, then credentials. A glob would sort these wrongly.
+    # Ordered as a learning path, not alphabetically: the two capability guides a
+    # reader needs first, then the part they have to implement, then the
+    # cross-cutting skills, then credentials. A directory glob would sort these
+    # wrongly, so the list is explicit — and checked, so a renamed or deleted
+    # guide fails the build instead of shipping a dead nav entry.
+    guide_names = (
+        "literature",
+        "dataset",
+        "experiment-backend",
+        "defend",
+        "progress",
+        "keys",
+    )
+    missing = [
+        n for n in guide_names if not (REPO_ROOT / f"docs/guides/{n}.md").is_file()
+    ]
+    if missing:
+        raise BuildError(f"guide pages have no source markdown: {sorted(missing)}")
+    guide_pages = [reg(f"guides/{n}", f"docs/guides/{n}.md") for n in guide_names]
 
     skills_dir = REPO_ROOT / "skills"
     skills_pages = [


### PR DESCRIPTION
## What

Fills out the `Guides` nav group that `docs/guides/literature.md` established with
exactly one page, and trims `docs/USER-GUIDE.md` to onboarding + the lifecycle
walkthrough + links out.

**An honest note on the shape of this change.** `USER-GUIDE.md` was never really a
monolith with depth to extract — it carried a paragraph per capability and no
more. So the diff is less "split a big page" than "the depth that page implied now
exists": ~840 lines of new guide content, and the user guide roughly the same
length with an index up front instead of shallow per-capability sections.

## The five new guides

Each follows `literature.md`'s conventions (task-oriented, shell blocks vs.
"Ask the assistant" quote blocks, a "Where to go next" footer):

- **[`dataset`](docs/guides/dataset.md)** — tiers as a *license* question rather
  than a size question, the four-step resolution chain, the mirror as link-rot
  insurance, and what `audit` checks beyond fixity (the tier↔license consistency
  check people miss).
- **[`experiment-backend`](docs/guides/experiment-backend.md)** — the four
  capabilities, why the run-ref is the whole idea, what a minimal implementation
  looks like, and why the plugin ships none.
- **[`defend`](docs/guides/defend.md)** — the three targets and the asymmetry that
  matters (teaches established knowledge freely, never the answer key to your own
  claim), the persona levers, and what `defend record` actually writes.
- **[`progress`](docs/guides/progress.md)** — the four roll-ups, the two readings
  that catch people out (refuted reads green; resolved can still block), and the
  Goodhart argument in full.
- **[`keys`](docs/guides/keys.md)** — what each key buys,
  `os.environ > store > unset` precedence, relocating the store, and the
  plaintext-at-rest caveat.

## A real doc/CLI mismatch this surfaced

Same class as commit `0912d5c` ("stop presenting literature/dataset skill modes as
shell commands"), which fixed two capabilities and left the rest. Still shown in
bare code blocks that read as shell commands:

```
progress status hypothesis        # there is no `progress` CLI group at all
progress dashboard
defend claim <hypothesis-id>      # defend's only command is `record`
hypothesis-exploration park "…"
paper-exploration generate
```

All are skill modes. They are now quote blocks in the "Ask the assistant"
convention, with the real `defendable-science backlog …` invocation alongside
where one exists (`backlog park | rank | promote --scaffold`). The user guide
states the two conventions up front, as the literature guide does.

## Nav registration

`tools/build_docs_site.py`'s `guide_pages` stays an explicit ordered list — it is
a learning path, and an alphabetical directory glob would order it wrongly — but
it is now **checked**: a renamed or deleted guide raises `BuildError` instead of
shipping a dead nav entry.

## Verification

Real site build, not just the plugin validator:

```
built defendable-science docs site → /tmp/ds-site
  82 pages across 6 top-level nav groups; 72 intra-site links verified;
  docs.json valid; 7 brand assets copied.
```

Also: every relative link in `docs/guides/*.md` checked to resolve on disk,
`pre-commit run --all-files` green (all 10 hooks), `./tools/validate-plugin.sh`
passes, ruff/mypy clean on `tools/`.

## Deliberately not included

**A `digest` guide**, which the issue lists as a candidate. There is nothing in
`USER-GUIDE.md` to restructure for it (digest has no section), so it would be
wholly net-new content — and #100 is currently rewriting digest's extraction mode
against the literature registry layer in another session. Writing a guide for
behaviour that is mid-change would need rewriting on merge. Worth a follow-up
issue once #100 lands; say the word and I'll file it.

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)
