### PR TITLE
fix(backlog): seed the scaffolded pitch.md with status frontmatter (closes #96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A promoted paper is tracked from the moment it is scaffolded.**
+  `scaffold_paper` wrote a two-line `pitch.md` with no status frontmatter, while
+  `scaffold_hypothesis` one level down wrote the full status block. Since
+  `progress dashboard` is a *pure projection* of that frontmatter, a freshly
+  promoted paper was registered in `papers.md`, had a root and a pitch, and
+  contributed nothing to the dashboard until someone hand-wrote the block —
+  registered but untracked. The pitch is now seeded from a `_PAPER_TEMPLATE`
+  mirroring `resources/templates/paper/pitch.md`, carrying the backlog row's
+  one-line and provenance and today's date; the prose stays the template's
+  comment prompts, because a tracked *stub* is the goal and seeding prose the
+  author did not write would cut against the agency principle. The plugin's
+  `resources/` is not readable from the package — the wheel ships only
+  `defendable_science` and the two artifacts release on separate cadences
+  (ADR-0026) — so the duplication is deliberate and a test fails on any drift in
+  the status block, for the hypothesis pair as well as the new paper one.
+  `resources/templates/paper/pitch.md` gained the `## Provenance` section its
+  hypothesis counterpart already had. (#96)
 - **Rung 6 (`venue_resolvers`) no longer reports a verification it never
   performed.** `RUNG_VENUE` was in `GATED_RUNGS`, so every consumer-configured
   venue candidate ran through `evaluate_match` — but `venue_candidates` builds

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -1435,7 +1435,12 @@ def _scaffold_promoted(
         )
         return {"hypothesis": str(target)}
     root = backlog_mod.scaffold_paper(
-        research, row["id"], row["one-line"], backend=backend
+        research,
+        row["id"],
+        row["one-line"],
+        backend=backend,
+        provenance=row["provenance"],
+        today=today,
     )
     return {
         "paper_root": str(root),

--- a/defendable-science/defendable_science/exploration/backlog.py
+++ b/defendable-science/defendable_science/exploration/backlog.py
@@ -528,6 +528,59 @@ status:
 """
 
 
+#: Mirrors ``resources/templates/paper/pitch.md``. The **status block must stay
+#: byte-identical** to that template's (inline comments aside): ``progress``
+#: projects it, so a drift makes a promoted paper misread or vanish from the
+#: dashboard. The plugin's ``resources/`` is not importable from here — the two
+#: artifacts ship on separate cadences (ADR-0026) and the wheel contains only
+#: ``defendable_science`` — so the constant is duplicated deliberately and
+#: ``tests/test_backlog.py`` fails on divergence. Prose is condensed; the shipped
+#: template stays the fuller authoring skeleton.
+_PAPER_TEMPLATE = """\
+---
+status:
+  level: paper
+  id: {paper_id}
+  verdict: null
+  readiness: drafting
+  signed-off-by: null
+  signed-off-date: null
+  evidence: []
+  covers: []
+  load-bearing: null
+  understanding: {{status: pending, unresolved: []}}
+  blockers: []
+  last-updated: {today}
+---
+
+# Pitch: {one_line}
+
+## Central claim
+
+*{one_line}*
+
+## Contribution
+
+<!-- What is new here — the delta this paper adds to the record. Defended in
+     detail in positioning.md against prior work. -->
+
+## Target venue + bar
+
+<!-- Intended venue and the standard it holds contributions to (rigor, novelty,
+     baselines expected). Shapes scope and positioning. -->
+
+## Load-bearing hypotheses
+
+<!-- Which hypotheses under hypotheses/* must resolve for this claim to hold. A
+     refuted load-bearing hypothesis blocks the paper (progress surfaces it) —
+     that is honest, not failure. -->
+
+## Provenance
+
+{provenance}
+"""
+
+
 def scaffold_hypothesis(
     paper_root: str | Path,
     slug: str,
@@ -625,17 +678,31 @@ def scaffold_paper(
     one_line: str,
     *,
     backend: str = "",
+    provenance: str = "",
+    today: str | None = None,
 ) -> Path:
     """Scaffold a promoted paper root and register it in ``papers.md``.
 
     Creates ``<research_root>/<paper_id>/{hypotheses,paper}/`` with an empty
-    ``backlog.md`` and a ``paper/pitch.md`` seeded from the row, then appends the
-    ``papers.md`` registry row.
+    ``backlog.md`` and a ``paper/pitch.md`` seeded from :data:`_PAPER_TEMPLATE`,
+    then appends the ``papers.md`` registry row.
+
+    The pitch carries the **status frontmatter** ``progress`` projects, exactly as
+    :func:`scaffold_hypothesis` does one level down. Without it a promoted paper
+    is registered, has a root, and contributes nothing to the dashboard until
+    someone hand-writes the block — registered but untracked.
+
+    Only the frontmatter and the two fields carried from the backlog row are
+    filled. The prose stays the template's comment prompts: the goal is a
+    *tracked stub*, not a drafted pitch, and seeding prose the author did not
+    write would cut against the agency principle (meta-spec §2.1).
 
     :param research_root: The ``docs/research`` directory.
     :param paper_id: The stable paper id.
     :param one_line: The pitch line carried from the portfolio-backlog row.
     :param backend: The experiment-backend binding to record.
+    :param provenance: The verbatim provenance carried from the backlog row.
+    :param today: ISO date for ``last-updated`` (defaults to today).
     :returns: The paper root directory.
     :raises BacklogError: If the paper root already exists.
     """
@@ -649,7 +716,13 @@ def scaffold_paper(
         Backlog(level="hypothesis").dumps(), encoding="utf-8"
     )
     (root / "paper" / "pitch.md").write_text(
-        f"# Pitch: {paper_id}\n\n{one_line}\n", encoding="utf-8"
+        _PAPER_TEMPLATE.format(
+            paper_id=paper_id,
+            one_line=one_line,
+            provenance=provenance,
+            today=today or today_iso(),
+        ),
+        encoding="utf-8",
     )
     append_papers_registry(
         research / "papers.md", paper_id, _registry_root(root, research), backend

--- a/defendable-science/tests/test_backlog.py
+++ b/defendable-science/tests/test_backlog.py
@@ -3,16 +3,24 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+import re
+from datetime import date
+from pathlib import Path
 
 import pytest
+import yaml
 from typer.testing import CliRunner
 
 from defendable_science.cli import app
 from defendable_science.exploration import backlog as b
 
-if TYPE_CHECKING:
-    from pathlib import Path
+
+def _split_frontmatter(text: str) -> str:
+    """Return the YAML frontmatter source of a markdown document."""
+    match = re.search(r"\A---\n(.*?)^---\n", text, re.S | re.M)
+    assert match is not None, "no terminated YAML frontmatter"
+    return match.group(1)
+
 
 runner = CliRunner()
 
@@ -813,3 +821,144 @@ def test_promote_without_scaffold_still_emits_the_bare_row(tmp_path: Path) -> No
     payload = json.loads(result.stdout)
     assert payload["status"] == "promoted"
     assert "artifacts" not in payload
+
+
+# --- the scaffolded pitch carries status frontmatter (#96) --------------------
+
+#: The repo root, reachable from the test tree. The plugin's ``resources/`` is
+#: *not* importable from the package — the wheel ships only ``defendable_science``
+#: and the two artifacts release on separate cadences (ADR-0026) — so the drift
+#: guards below are the only thing keeping the code templates and the shipped
+#: authoring skeletons in agreement.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _status_block(text: str) -> list[str]:
+    """Return the frontmatter's status lines, inline comments and blanks stripped."""
+    match = re.search(r"\A---\n(.*?)^---\n", text, re.S | re.M)
+    assert match is not None, "no terminated YAML frontmatter"
+    out = []
+    for line in match.group(1).splitlines():
+        stripped = re.sub(r"\s+#.*$", "", line).rstrip()
+        if stripped:
+            out.append(stripped)
+    return out
+
+
+def _placeholderless(lines: list[str]) -> list[str]:
+    """Blank out the two fields that legitimately differ (id, date)."""
+    return [re.sub(r"^(  (?:id|last-updated)): .*", r"\1: <X>", ln) for ln in lines]
+
+
+@pytest.mark.parametrize(
+    ("template_path", "constant"),
+    [
+        ("resources/templates/hypothesis/hypothesis.md", "_HYPOTHESIS_TEMPLATE"),
+        ("resources/templates/paper/pitch.md", "_PAPER_TEMPLATE"),
+    ],
+)
+def test_code_template_status_block_matches_the_shipped_template(
+    template_path: str, constant: str
+) -> None:
+    """The status block is what `progress` projects; a drift makes a paper vanish.
+
+    The prose deliberately differs — the shipped template is the fuller authoring
+    skeleton — but the frontmatter must not, and nothing at runtime can enforce
+    that because the package cannot read the plugin's ``resources/``.
+    """
+    shipped = _REPO_ROOT / template_path
+    assert shipped.is_file(), (
+        f"{shipped} is missing; the drift guard cannot run. These tests are meant "
+        "to run from a repo checkout, which has both artifacts."
+    )
+    from_file = _placeholderless(_status_block(shipped.read_text(encoding="utf-8")))
+    raw = getattr(b, constant).replace("{{", "{").replace("}}", "}")
+    from_code = _placeholderless(_status_block(raw))
+    assert from_code == from_file
+
+
+def test_scaffolded_pitch_has_status_frontmatter(tmp_path: Path) -> None:
+    research = tmp_path / "docs" / "research"
+    research.mkdir(parents=True)
+    root = b.scaffold_paper(
+        research,
+        "depth-collapse",
+        "Depth collapse explains the OOD gap",
+        backend="bench",
+        provenance="limitation-driven, from aug-policy-robustness §6",
+        today="2026-03-04",
+    )
+    text = (root / "paper" / "pitch.md").read_text(encoding="utf-8")
+
+    status = yaml.safe_load(_split_frontmatter(text))["status"]
+    assert status["level"] == "paper"
+    assert status["id"] == "depth-collapse"
+    assert status["verdict"] is None
+    assert status["readiness"] == "drafting"
+    assert status["signed-off-by"] is None
+    assert status["signed-off-date"] is None
+    assert status["evidence"] == []
+    assert status["blockers"] == []
+    assert status["covers"] == []
+    assert status["understanding"] == {"status": "pending", "unresolved": []}
+    # YAML types an unquoted ISO date as a date, which is what `progress` sees.
+    assert status["last-updated"] == date(2026, 3, 4)
+
+    # Both fields carried from the backlog row are present, verbatim.
+    assert "Depth collapse explains the OOD gap" in text
+    assert "limitation-driven, from aug-policy-robustness §6" in text
+
+
+def test_scaffolded_pitch_drafts_no_prose_for_the_author(tmp_path: Path) -> None:
+    # A tracked stub, not a drafted pitch: seeding prose the author did not write
+    # would cut against the agency principle (meta-spec 2.1).
+    research = tmp_path / "docs" / "research"
+    research.mkdir(parents=True)
+    root = b.scaffold_paper(research, "p1", "a claim", backend="bench")
+    text = (root / "paper" / "pitch.md").read_text(encoding="utf-8")
+    for section in ("Contribution", "Target venue + bar", "Load-bearing hypotheses"):
+        assert f"## {section}\n\n<!--" in text
+
+
+def test_scaffolded_pitch_defaults_the_date_to_today(tmp_path: Path) -> None:
+    research = tmp_path / "docs" / "research"
+    research.mkdir(parents=True)
+    root = b.scaffold_paper(research, "p1", "a claim")
+    text = (root / "paper" / "pitch.md").read_text(encoding="utf-8")
+    assert f"last-updated: {b.today_iso()}" in text
+
+
+def test_promote_scaffold_pitch_is_tracked_end_to_end(tmp_path: Path) -> None:
+    """The CLI path carries the row's provenance into the frontmatter'd pitch."""
+    path = tmp_path / "portfolio-backlog.md"
+    board = b.Backlog(level="paper")
+    board.add("Depth collapse explains the OOD gap", "own reading", row_id="dc")
+    board.rank("dc", feas="high", interest="high")
+    board.save(path)
+    research = tmp_path / "docs" / "research"
+    research.mkdir(parents=True)
+    result = runner.invoke(
+        app,
+        [
+            "backlog",
+            "promote",
+            "dc",
+            "--backlog",
+            str(path),
+            "--level",
+            "paper",
+            "--scaffold",
+            "--research-root",
+            str(research),
+            "--backend",
+            "bench",
+            "--date",
+            "2026-03-04",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    pitch = Path(json.loads(result.stdout)["artifacts"]["pitch"])
+    status = yaml.safe_load(_split_frontmatter(pitch.read_text(encoding="utf-8")))
+    assert status["status"]["id"] == "dc"
+    assert status["status"]["last-updated"] == date(2026, 3, 4)
+    assert "own reading" in pitch.read_text(encoding="utf-8")

--- a/resources/templates/README.md
+++ b/resources/templates/README.md
@@ -19,7 +19,7 @@ you add, not in prose the template ships with.
 | `hypothesis/strategy.md` | `hypothesis-testing` · strategy (rigor kit + defend) | `.../<slug>/strategy.md` |
 | `hypothesis/design-plan-README.md` | *pointer only* — design/plan are **delegated to the bound engineering backend** | `.../<slug>/{design,plan}.md` |
 | `hypothesis/findings.md` | `hypothesis-testing` · findings (**material decision**) | `.../<slug>/findings.md` |
-| `paper/pitch.md` | `paper-synthesis` · pitch | `docs/research/<paper>/paper/pitch.md` |
+| `paper/pitch.md` | `paper-exploration` · promote scaffolds the stub (status frontmatter + the backlog row's one-line and provenance); `paper-synthesis` · pitch develops it | `docs/research/<paper>/paper/pitch.md` |
 | `paper/positioning.md` | `paper-synthesis` · positioning | `.../paper/positioning.md` |
 | `paper/ledger.md` | `paper-synthesis` · sections (Toulmin-sextet claim→evidence ledger) | `.../paper/ledger.md` |
 | `paper/decision.md` | `paper-synthesis` · decision (**material decision**) | `.../paper/decision.md` |

--- a/resources/templates/paper/pitch.md
+++ b/resources/templates/paper/pitch.md
@@ -40,3 +40,9 @@ status:
      surfaces it) — that is honest, not failure. -->
 
 - `<YYYY-MM-DD-slug>` — *<role in the claim>* — load-bearing: *<yes/no>*
+
+## Provenance
+
+<!-- Carried from the portfolio-backlog row: the generation lens it came from
+     (mechanism-transfer / limitation-driven / result-driven) + the verbatim
+     origin — which resolved paper, limitation, or result prompted it. -->

--- a/skills/paper-exploration/SKILL.md
+++ b/skills/paper-exploration/SKILL.md
@@ -58,7 +58,9 @@ explicit human pick — the exploration/resolution firewall
 > operating on `portfolio-backlog.md` at the paper level. `add` realizes the
 > `generate` verb's row-append; `list` is a read-only inspection command. The
 > `promote --scaffold --level paper --research-root <docs/research> --backend
-> <name>` scaffolds the paper root and writes the `papers.md` registry row in the
+> <name>` scaffolds the paper root, seeds `paper/pitch.md` with its status
+> frontmatter (so the paper is visible to `progress` immediately, not after
+> someone hand-writes the block) and writes the `papers.md` registry row in the
 > same call, reporting the created paths as JSON; `--backend` is required there
 > because the plugin bundles no default. Scaffolding runs before the backlog is
 > written, so a refused scaffold leaves the row `ranked` and retryable. The


### PR DESCRIPTION
## What

A promoted paper is now tracked from the moment it is scaffolded. `scaffold_paper`
wrote a two-line `pitch.md` with no status frontmatter, while `scaffold_hypothesis`
one level down wrote the full block — so since `progress dashboard` is a *pure
projection* of that frontmatter, a freshly promoted paper was registered in
`papers.md`, had a root and a pitch, and contributed nothing to the dashboard
until someone hand-wrote the block. Registered but untracked, and it looked fine.

Combined with #114, `promote --scaffold` is now the whole handoff with no
hand-edits left:

```yaml
---
status:
  level: paper
  id: depth-collapse
  verdict: null
  readiness: drafting
  signed-off-by: null
  ...
  last-updated: 2026-08-27
---

# Pitch: Depth collapse explains the OOD gap
...
## Provenance

limitation-driven, from aug-policy-robustness §6
```

## The duplication the issue wanted removed cannot be removed

The issue's preferred approach was to "load `resources/templates/paper/pitch.md`
and format it — the latter avoids the template existing in two places, which is
the current inconsistency's root cause."

**The package cannot read that file.** `[tool.hatch.build.targets.wheel]
include = ["defendable_science"]` — the wheel ships the Python package only, and
`resources/` is plugin content distributed via the git self-marketplace on a
*separate release cadence*. A consumer's `uv tool install defendable-science` has
no `resources/` anywhere near it. Generating one from the other at build time
would couple the two cadences, which is the one thing the two-artifact split
exists to prevent (ADR-0026).

So I inverted it: the constant is duplicated deliberately, and the drift is
**caught** rather than prevented. A parametrized test compares each code
template's status block against the shipped template's, with comments and the two
placeholder fields (`id`, `last-updated`) normalised away — prose is allowed to
differ, since the shipped template is the fuller authoring skeleton, but the
frontmatter `progress` projects is not.

That guard covers the **hypothesis** pair too, which has had exactly this exposure
since it was written with no guard at all. They happen to agree today; now they
have to.

## Verification

The guard fails on a real drift, not merely passes — flipping `readiness:
drafting` to `pending` in the shipped template:

```
E  At index 4 diff: '  readiness: drafting' != '  readiness: pending'
FAILED test_code_template_status_block_matches_the_shipped_template[...pitch.md-_PAPER_TEMPLATE]
```

Also verified end-to-end outside pytest: `backlog add` → `rank` →
`promote --scaffold` on a real repo yields a pitch whose frontmatter parses as
YAML with `level: paper`, the right `id`, null verdict/sign-offs, empty
`evidence`/`blockers`/`covers`, and the row's one-line and provenance verbatim.

6 tests added; 707 pass, 100% statement+branch coverage held, all 10 pre-commit
hooks green.

## Notes

- The prose stays the template's comment prompts, and a test asserts that. A
  tracked *stub* is the goal — seeding prose the author did not write would cut
  against the agency principle (meta-spec §2.1).
- `resources/templates/paper/pitch.md` gained the `## Provenance` section its
  hypothesis counterpart already had, so the row's provenance has somewhere to
  land in both the skeleton and the scaffolded stub.
- **Out of scope**, per the issue's own note: `positioning.md` / `decision.md` /
  `ledger.md` have no scaffolder, so they stay skill-drafted. The drift test is
  parametrized and takes another pair in one line if that changes.
- YAML types an unquoted ISO date as a `datetime.date`, so that is what `progress`
  sees for `last-updated` — the assertions say so rather than comparing strings.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)
