### PR TITLE
fix(literature): free exit code 2, use 3 for resolve's transport failure

### DIFF
--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -277,9 +277,15 @@ def resolve(identifier: str) -> None:
     """Resolve an identifier (DOI, arXiv id, OpenAlex/S2 id) to a canonical work.
 
     The exit code follows the result so a caller need not parse JSON to tell
-    the three outcomes apart: ``0`` on a resolution, ``1`` on a genuine miss
-    (no such paper), ``2`` on a transport failure (``transport_error: true``
-    in the JSON) — never reported as a clean "no result".
+    the outcomes apart — and never mistake a network failure for a clean
+    "no result":
+
+    :raises typer.Exit: Code ``0`` on a resolution. Code ``1`` on a genuine
+        miss (no such paper). Code ``2`` on a Click/Typer usage error (bad
+        flags, missing argument) — untouched, not raised by this body. Code
+        ``3`` on a transport failure (``transport_error: true`` in the JSON) —
+        deliberately distinct from ``2`` so a caller can never confuse "you
+        typed it wrong" with "the network failed".
 
     :param identifier: The identifier to resolve.
     """
@@ -290,7 +296,7 @@ def resolve(identifier: str) -> None:
         if record.get("resolved"):
             raise typer.Exit(code=0)
         if record.get("transport_error"):
-            raise typer.Exit(code=2)
+            raise typer.Exit(code=3)
         raise typer.Exit(code=1)
 
 

--- a/defendable-science/tests/test_literature.py
+++ b/defendable-science/tests/test_literature.py
@@ -308,19 +308,33 @@ def test_cli_resolve_miss_exits_1_with_resolved_false(
     assert "transport_error" not in body
 
 
-def test_cli_resolve_transport_error_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cli_resolve_transport_error_exits_3(monkeypatch: pytest.MonkeyPatch) -> None:
     # A 502 exhausts the retry budget as a plain HttpError (not a rate limit,
-    # not a 404) — this must surface as a distinguishable failure, exit 2, not
-    # a clean "no such paper" (exit 1) nor a false success (exit 0).
+    # not a 404) — this must surface as a distinguishable failure, exit 3, not
+    # a clean "no such paper" (exit 1), a false success (exit 0), or a usage
+    # error (exit 2 — Click/Typer's code, reserved for bad flags/arguments).
     client = _client(
         {"https://api.openalex.org/works/W1": FakeResponse(502, {})}, max_retries=2
     )
     monkeypatch.setattr(cli, "_lit_client", lambda: client)
     result = runner.invoke(app, ["literature", "resolve", "W1"])
-    assert result.exit_code == 2
+    assert result.exit_code == 3
     body = json.loads(result.stdout)
     assert body["resolved"] is False
     assert body["transport_error"] is True
+
+
+def test_cli_resolve_usage_error_still_exits_2_not_3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The negative that matters here: a usage error (missing argument) must
+    # keep Click/Typer's exit code 2 and must never be, or emit, a
+    # transport_error — that collision is exactly what would let someone
+    # later "simplify" the two codes back together without noticing.
+    monkeypatch.setattr(cli, "_lit_client", lambda: _client({}))
+    result = runner.invoke(app, ["literature", "resolve"])  # missing IDENTIFIER
+    assert result.exit_code == 2
+    assert "transport_error" not in result.stdout
 
 
 def test_cli_refs_unresolved_exits_1(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What

Restores the half of #110 that never landed. `literature resolve` returns exit
**3** on a transport failure instead of **2**, leaving 2 exclusively to
Click/Typer's usage errors.

#110 merged at its first commit (`46ea3a4`); the follow-up fix (`471ef3d`) was
pushed to the branch after the merge and was lost. The `transport_error` field
in the JSON landed correctly and is untouched here — only the exit code was
wrong.

## Why it matters

2 is Click's usage-error code, and the rest of the `literature` group already
uses it for argument misuse (`cli.py:601`, `:725` — "give exactly one of
CITEKEY or --all"). So on `main` today:

```
$ defendable-science literature resolve --bogus ; echo $?
2
```

returns the same code as a network failure. A caller cannot distinguish "I
invoked it wrong" from "the lookup failed", which defeats the distinction #106
was filed to create.

## Details

- `literature resolve` exit mapping is now `0` resolved / `1` genuine miss /
  `2` usage error (Click's, untouched) / `3` transport failure. Each code has
  exactly one meaning across the whole `literature` group.
- The command's `:raises typer.Exit:` docstring spells out all four, since this
  is the only command in the group with a three-way outcome.
- Adds the negative assertion: a *usage* error on `resolve` still exits 2 and
  emits no `transport_error`. That is what would catch someone later collapsing
  the two codes back together.

Cherry-picked verbatim from the lost commit; no new work. Gate green locally:
702 passed / 14 skipped, 100% coverage, ruff + mypy + `validate-plugin.sh` +
all pre-commit hooks.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
