### PR TITLE
feat(core): confine a relative cache_dir to the repository (refs #123)

### DIFF
--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -42,6 +42,11 @@ if TYPE_CHECKING:
 
     from defendable_science.core.http import HttpClient
 
+
+class CacheDirError(ValueError):
+    """Raised on an invalid ``cache_dir:`` configuration."""
+
+
 app = typer.Typer(
     name="defendable-science",
     help="Supporting tooling for the defendable-science research-workflow plugin.",
@@ -176,7 +181,7 @@ def _layout_or_exit(root: Path | None = None) -> tuple[dict[str, Any], Layout]:
 
 
 def _repo_relative(value: str | Path, root: Path | None = None) -> Path:
-    """Anchor a configured path to the repository root.
+    """Anchor a configured path to the repository root, confining relative values.
 
     A path written in ``config.yml`` describes a location in the *repository*,
     not one relative to wherever the author happens to be standing. Resolving it
@@ -185,15 +190,34 @@ def _repo_relative(value: str | Path, root: Path | None = None) -> Path:
     cache's case into a directory ``research-init`` never gitignored. An
     absolute value is honoured as given.
 
+    A **relative** path that escapes the repository (e.g. ``../../elsewhere``) is
+    confined: such a path is almost certainly a typo. An integrity tool must not
+    write outside the work tree by accident. An **absolute** path is honoured
+    without restriction: a deliberately shared cache on a large disk is a real
+    need, and that is exactly how it is expressed.
+
     :param value: The configured path.
     :param root: The repository root to anchor to; discovered from the cwd when
         omitted.
     :returns: The absolute path it names.
+    :raises CacheDirError: If a relative path escapes the repository.
     """
     from defendable_science.core.config import find_repo_root
 
     path = Path(value)
-    return path if path.is_absolute() else (root or find_repo_root()) / path
+    if path.is_absolute():
+        return path
+    repo_root = (root or find_repo_root()).resolve()
+    resolved = (repo_root / path).resolve()
+    # Same containment rule as `_relative` in scaffold/layout.py: a relative
+    # value must stay inside the repository.
+    if resolved != repo_root and repo_root not in resolved.parents:
+        msg = (
+            f"cache_dir must stay inside the repository: {value!r} escapes it. "
+            "Use an absolute path for a deliberately external cache."
+        )
+        raise CacheDirError(msg)
+    return resolved
 
 
 def _cache_root(config: dict[str, Any] | None = None, root: Path | None = None) -> Path:
@@ -206,13 +230,16 @@ def _cache_root(config: dict[str, Any] | None = None, root: Path | None = None) 
     and the runtime cache location from drifting apart (defendable-science#65).
     A relative value is anchored to the repo root (see :func:`_repo_relative`),
     so the cache does not move when a command is run from a subdirectory.
+    A relative value that escapes the repository is confined to prevent
+    accidental writes outside the work tree.
 
     :param config: A pre-loaded config mapping; loaded fresh when omitted.
     :param root: The repository root a relative ``cache_dir`` is anchored to;
         discovered from the cwd when omitted.
     :returns: The absolute cache root — the configured ``cache_dir``, or
         :data:`_DEFAULT_CACHE_ROOT` when it is unset.
-    :raises typer.Exit: Code 1 if ``cache_dir`` is present but not a string.
+    :raises typer.Exit: Code 1 if ``cache_dir`` is present but not a string,
+        or if a relative ``cache_dir`` escapes the repository.
     """
     if config is None:
         config = _load_config_or_exit(root)
@@ -225,7 +252,11 @@ def _cache_root(config: dict[str, Any] | None = None, root: Path | None = None) 
             err=True,
         )
         raise typer.Exit(code=1)
-    return _repo_relative(cache_dir, root)
+    try:
+        return _repo_relative(cache_dir, root)
+    except CacheDirError as exc:
+        typer.echo(f"invalid .defendable-science/config.yml: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
 
 
 # --- init (defendable-science#123) ----------------------------------------------------

--- a/defendable-science/tests/test_cache_config.py
+++ b/defendable-science/tests/test_cache_config.py
@@ -87,3 +87,68 @@ def test_load_config_or_exit_surfaces_invalid_yaml(
     with pytest.raises(typer.Exit) as exc:
         cli._load_config_or_exit()
     assert exc.value.exit_code == 1
+
+
+def test_repo_relative_accepts_absolute_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    absolute = Path("/tmp/external-cache")
+    assert cli._repo_relative(absolute) == absolute
+
+
+def test_repo_relative_anchors_relative_path_to_repo_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    relative = ".local-cache"
+    assert cli._repo_relative(relative) == tmp_path / relative
+
+
+def test_repo_relative_confines_relative_paths_with_parent_refs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(cli.CacheDirError) as exc:
+        cli._repo_relative("../../elsewhere")
+    assert "escapes it" in str(exc.value)
+    assert "../../elsewhere" in str(exc.value)
+
+
+def test_repo_relative_error_message_is_actionable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(cli.CacheDirError) as exc:
+        cli._repo_relative("../sibling")
+    error_msg = str(exc.value)
+    assert "absolute path" in error_msg
+    assert "deliberately external cache" in error_msg
+
+
+def test_cache_root_confines_relative_cache_dir_that_escapes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _write_config(tmp_path, "cache_dir: ../../elsewhere\n")
+    with pytest.raises(typer.Exit) as exc:
+        cli._cache_root()
+    assert exc.value.exit_code == 1
+
+
+def test_cache_root_accepts_absolute_cache_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    absolute_cache = Path("/tmp/shared-cache")
+    _write_config(tmp_path, f"cache_dir: {absolute_cache}\n")
+    assert cli._cache_root() == absolute_cache
+
+
+def test_cache_root_accepts_safe_relative_cache_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    safe_relative = ".custom/cache"
+    _write_config(tmp_path, f"cache_dir: {safe_relative}\n")
+    assert cli._cache_root() == tmp_path / safe_relative


### PR DESCRIPTION
## What

Makes a **relative** `cache_dir` that escapes the repository an error, closing the asymmetry
issue #123 recorded: `layout:` keys were confined to the work tree while `cache_dir` was only
anchored to it, so `cache_dir: ../../elsewhere` still escaped.

## The decision

**Confine relative values; keep absolute values allowed.**

- A **relative** `cache_dir` that escapes the repo is almost certainly a typo, and an
  integrity tool should not read or write outside the work tree by accident.
- An **absolute** `cache_dir` keeps working untouched. A deliberately shared cache on a large
  disk is a real need, and that is exactly how it is expressed — confining everything would
  have closed a legitimate use case to fix an accident.

Both halves are now documented in `_repo_relative`'s docstring, so the next reader does not
have to infer why the two config keys differ.

## Details

- The containment check mirrors `_relative` in `scaffold/layout.py` rather than inventing a
  second rule, and lives at `_repo_relative` in `cli.py` — the single choke point every
  consumer of `cache_dir` already passes through, so it cannot be bypassed.
- `CacheDirError` follows the codebase's existing domain-error pattern (`LayoutError`,
  `BacklogError`, `RegistryError`, `ManifestError` are all `ValueError` subclasses).
- The failure surfaces as a clean CLI message and exit 1, never a traceback:

```console
invalid .defendable-science/config.yml: cache_dir must stay inside the repository:
'../../elsewhere' escapes it. Use an absolute path for a deliberately external cache.
```

Verified directly: `../../elsewhere` refused; `/mnt/bigdisk/cache` allowed; both
`.defendable-science/cache/` and `sub/../cache` (relative but staying inside) allowed.

789 tests, 100% statement + branch coverage, mypy / ruff / ruff format all green.

## One half deliberately deferred

Issue #123 also asks for the asymmetry to be documented in the `cache_dir` comment that
`render_config` writes into every scaffolded `config.yml`. That renderer arrives with #127
and does not exist on `main` yet, so this PR cannot touch it. **When #127 merges, that comment
should gain the same note** — the issue is left open for it rather than closed here.

Refs #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)
