### PR TITLE
feat(digest): extraction mode for survey-scale reading (closes #100)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,16 @@
 # NOTE: gitignore has no trailing comments — a mid-line '#' is part of the
 # pattern. Keep every comment on its own line. A leading '**/' is required so
 # these also match when the CLI runs from the defendable-science/ subdirectory.
+# Both forms of each path are kept on purpose: the bare ones are what the
+# literal matchers in check/checks.py and scaffold/render.py look for, the
+# '**/' ones are what make the ignore actually take effect from a subdirectory.
 # http + dataset caches (cli.py writes here)
+.defendable-science/cache/
 **/.defendable-science/cache/
 # CLI-owned API-key store (0600; ADR-0029)
+.defendable-science/keys.json
 **/.defendable-science/keys.json
+.defendable-science/rclone.conf
 **/.defendable-science/rclone.conf
 *.rclone.conf
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 # defendable-science plugin — consumers create these in THEIR repos, never here
-.defendable-science/cache/          # http + dataset caches (cli.py writes here)
-.defendable-science/keys.json       # CLI-owned API-key store (0600; ADR-0029)
-.defendable-science/rclone.conf
+# NOTE: gitignore has no trailing comments — a mid-line '#' is part of the
+# pattern. Keep every comment on its own line. A leading '**/' is required so
+# these also match when the CLI runs from the defendable-science/ subdirectory.
+# http + dataset caches (cli.py writes here)
+**/.defendable-science/cache/
+# CLI-owned API-key store (0600; ADR-0029)
+**/.defendable-science/keys.json
+**/.defendable-science/rclone.conf
 *.rclone.conf
 
 # OS / editor

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,9 +133,9 @@
         "filename": "docs/guides/literature.md",
         "hashed_secret": "aee0a7bd78ec2f13647c0990b6644f2ddf9ab2ff",
         "is_verified": false,
-        "line_number": 287
+        "line_number": 292
       }
     ]
   },
-  "generated_at": "2026-08-27T15:18:20Z"
+  "generated_at": "2026-08-28T11:59:18Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`digest` gains an extraction mode — breadth reading for a survey**
-  (`digest extract axes | record | sample | render`). Depth mode costs an hour
+  (`digest extract axes | record | sample | render`;
+  [ADR-0040](decisions/0040-digest-extraction-mode.md)). Depth mode costs an hour
   or two per paper, which makes it unusable for the forty-paper set its sibling
   skill triages, so extraction reads each paper against exactly the axes
   `literature position --level paper` already put in the concept matrix, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`digest` gains an extraction mode — breadth reading for a survey**
+  (`digest extract axes | record | sample | render`). Depth mode costs an hour
+  or two per paper, which makes it unusable for the forty-paper set its sibling
+  skill triages, so extraction reads each paper against exactly the axes
+  `literature position --level paper` already put in the concept matrix, and
+  stops. `axes` prints the question set and refuses a matrix that is not ready
+  to be extracted against — unreplaced `<attr N>` placeholders, no table, a
+  duplicated heading, more than one table in the section, a duplicate column
+  name — rather than letting forty papers be read against `<attr 1>`. `record`
+  is the *only* writer and validates inseparably: every cell carries a
+  shape-checked locator, or the distinguished value `not-addressed` with a
+  justification; every header axis must be accounted for, so an axis an agent
+  found hard cannot simply be omitted; an invented axis is refused; and
+  rejection is per paper, so one bad cell does not abort a forty-paper sweep.
+  The `not-addressed` count is reported per paper and in aggregate as the
+  anti-gaming signal. `sample` draws a deterministic sample — seeded from the
+  sorted batch, so nobody can re-roll until an easy draw comes up — and records
+  the **human's** verdict; the agent never checks its own extraction. `render`
+  merges the cells into the positioning document's concept matrix, inserting
+  and updating only, never deleting.
+  **The claim is deliberately weaker than depth mode's, and is kept separate in
+  the data**: extraction writes `status.extraction`, never
+  `status.understanding`, and `progress` reports `extracted N / digested M` as
+  two rows that are never summed — a paper with cells extracted has not been
+  read. A failed sample is evidence about the *batch*: `batch-check: failed`
+  lands on every artifact in the run, sampled or not, and the caught cell is
+  not quietly repaired. A `verified` verdict is refused outright when a drawn
+  paper's cells could not be read, and `--all` aborts before drawing when
+  membership cannot be determined, because the draw is a function of membership
+  and a silently dropped member re-rolls the sample. On the triage sidecar,
+  `record` writes exactly `extracted` and `extraction-cells` — never
+  `disposition`, which stays the human's decision.
 - **`literature fetch | confirm | verify | mirror`** — the literature registry
   now closes the same PDF-provenance loop `dataset` already had: `fetch`
   acquires a paper's PDF through a generic acquisition ladder (OpenAlex

--- a/decisions/0040-digest-extraction-mode.md
+++ b/decisions/0040-digest-extraction-mode.md
@@ -55,7 +55,7 @@ one. #97 filed that as the harm, not as a theoretical risk.
 
 ## Considered options
 
-Five axes, each with a genuinely plausible alternative. Chosen options marked;
+Six axes, each with a genuinely plausible alternative. Chosen options marked;
 each rejection is argued in *Rejected alternatives* below.
 
 **Where extraction lives.**

--- a/decisions/0040-digest-extraction-mode.md
+++ b/decisions/0040-digest-extraction-mode.md
@@ -1,0 +1,239 @@
+# ADR-0040: `digest` extraction mode — a second, weaker claim, kept structurally separate from comprehension
+
+- Status: accepted · Date: 2026-08-28 · Deciders: Davor Runje
+
+## Context
+
+`digest` is depth-first by construction: probe → detect gap → teach → re-probe,
+per load-bearing point, per paper. It is the right instrument for a paper whose
+claims the author will *assert*, and it costs on the order of an hour or two
+each.
+
+A survey has a different need, and #97 (Gap 2, refiled as #100) named it from a
+real run: 73 works resolved, 40 proposed for inclusion. At depth-mode cost that
+is a semester. But the survey does not need comprehension of 40 papers — it
+needs, for each one, the cells of the concept-centric matrix that `literature
+position --level paper` has *already defined*. Eight specific questions, then
+stop.
+
+So the plugin's only reading skill was unusable for the exact task its sibling
+skill sets up, while `position`'s own output already specified the question set
+a breadth mode would ask.
+
+Two things made this tractable now rather than earlier. Gap 1 (ADR-0037) built
+the registry layer — `load_registry`, `patch_asset`, `load_triage`,
+`patch_triage`, `Asset.files` — so extraction has real interfaces to resolve
+PDFs and write back through. And #94/#95 replaced the markdown-table machinery
+with a host-preserving, header-driven reader, which is what makes writing into
+an author's hand-written `positioning.md` safe rather than reckless.
+
+The hazard the whole design is organized against is **guarantee inflation**.
+Extraction's honest claim is strictly weaker than depth mode's, and every place
+the two can blur — a shared field name, a summed count, a UX question, a
+"helpful" repair — is a place the weaker claim silently becomes the stronger
+one. #97 filed that as the harm, not as a theoretical risk.
+
+## Decision drivers
+
+- **Failure honesty** (repo-wide). "The agent extracted these cells" and "the
+  reader understands this paper" are different claims; a design in which the
+  first can be read as the second is dishonest by construction, not merely
+  imprecise.
+- **Agency** (meta-spec §2.1). Every material decision stays the human's. A
+  machine may record facts about a run; it may not advance a human's decision
+  state machine, and it may not certify its own work.
+- **Anti-Goodhart.** An agent asked for 320 cells will find the cheapest legal
+  way to produce 320 cells. Every affordance has to be priced accordingly.
+- **Enforcement over documentation.** #100 asks for enforced locators. A
+  SKILL.md sentence saying "you must include a locator" enforces nothing on the
+  agent following it.
+- **Domain-neutrality.** A locator pattern set built around `§`, `Eq.`, `Thm.`
+  encodes a maths-and-CS citation culture; a survey of clinical trials or case
+  law locates claims differently.
+- **Never lose an author's work.** `positioning.md` is hand-written prose with a
+  table in it. #94 is a live reminder of how a table writer loses work quietly.
+
+## Decision
+
+Five material decisions, each recorded with its rejected alternative because
+each had a plausible one.
+
+### 1. Extraction is a second **mode of `digest`**, not a third `literature` mode
+
+`literature` is deliberately a graph-and-metadata capability: its entire surface
+is OpenAlex/S2 plus the registry, and it never opens a PDF. Extraction is
+*reading a paper and producing claims about it*, which is `digest`'s domain, and
+the sampled check reuses `digest`'s probe mechanic. #97's own framing agrees.
+
+Consequence handled: `digest` had no CLI group, borrowing `defend record`. The
+commands land as a new `digest extract` group — `axes | record | sample |
+render` — keeping skill and namespace aligned.
+
+### 2. A separate `status.extraction` key and a separate `progress` row
+
+`progress status literature` reported each paper as `{digested & understood /
+gaps unresolved}` from its `understanding` block. A paper with eight cells
+extracted and never read would have counted as "digested & understood" — the
+guarantee inflation, concretely.
+
+Extraction writes `status.extraction`, **never** `status.understanding`, and
+`progress` gains a second, clearly-labelled row so a survey author sees
+`extracted 40 / digested 3` rather than one blended number. The two rows are
+never summed, and neither is the other's subset.
+
+Within the block, `in-sample` (*a human checked **this** paper's cells*) and
+`batch-check` (`pending | verified | failed`, the verdict on the **run**) are
+two fields rather than one, because they answer different questions.
+
+### 3. The **human** checks the sample; the agent never checks its own work
+
+In depth mode the human reads and the agent probes them. In extraction the agent
+reads — that is the premise. So if the agent also checked the sample, extraction
+would certify *nothing*: it is self-attestation, which `digest`'s "verified,
+never self-attested" guardrail forbids and agency rules out.
+
+The check asks one question per cell: *does the source at that locator actually
+say this?* Deliberately **not** "do you understand this paper" — extraction never
+claimed that, and asking it would smuggle depth mode's guarantee back in through
+the UX. The CLI therefore does not prompt: the draw reports the cells, the
+questioning is the skill's job, and a second invocation records the verdict.
+
+### 4. The sample is **deterministic**, seeded from the sorted membership set
+
+Sort the batch's citekeys, SHA-256 that list to seed the PRNG, draw
+`max(3, 10%)` (adjustable, and a convention rather than a statistical
+guarantee). The same batch draws the same papers, in this process and every
+future one.
+
+Two refusals fall directly out of this, both from one asymmetry — `failed` is a
+**finding** and must land whatever else went wrong, while `verified` is a
+**claim** and may only be written for what was actually established:
+
+- **A `verified` verdict is refused** — nothing written, exit 1 — when any drawn
+  paper's cells could not be read. Otherwise the durable record says
+  `batch-check: verified` with no paper marked checked, a self-contradictory
+  state whose only honest signal is a transient exit code no later reader sees.
+- **`--all` aborts before drawing** when membership cannot be fully determined.
+  Since the draw is a function of membership, dropping an unreadable member
+  *re-rolls the sample* — sample-shopping through a route that looks like a
+  routine file problem. `--citekey` needs no such guard: membership is explicit
+  there, and a missing member is reported against its own citekey.
+
+### 5. A failed sample condemns the **batch**, not the paper
+
+If the human finds a cell that misrepresents its source, the honest inference is
+not "fix that cell": a process that produced one confidently-wrong cell in a
+sample of three probably produced more in the other thirty-seven. Every artifact
+in the run — sampled or not — gets `batch-check: failed`, and there is
+deliberately **no route** to repair the one caught cell.
+
+Two further mechanisms follow the same logic and are recorded here because they
+are what make the above enforceable rather than aspirational:
+
+- **Validation and writing are one command.** The validating command is the
+  *only* writer; there is no code path that records an unvalidated cell. Same
+  move that made `_bind` the single writer of an asset spine in ADR-0037.
+  Rules: a shape-checked locator, or the distinguished value `not-addressed`
+  with a justification; **every** header axis accounted for per paper; no
+  invented axes; rejection per paper, not per batch. `not-addressed` is counted
+  per paper and in aggregate — that count is the anti-gaming signal, and it is
+  cheaper and more honest than asking a checker to adjudicate whether an absence
+  is real, which it cannot do without reading the paper.
+- **`record` writes exactly two triage fields** — `extracted` and
+  `extraction-cells` — and **never `disposition`**. The disposition state
+  machine is the human's decision; a machine advancing it is precisely the
+  agency violation this plugin exists to prevent. Where the sidecar carries YAML
+  comments and `patch_triage` refuses (its rationales *are* the PRISMA log), the
+  cells still land, the refusal is reported apart from write errors and carries
+  a `kind` of `refused` or `failed`, and the run exits 1.
+
+## Consequences
+
+- The two claims coexist visibly on one artifact and cannot be conflated by
+  anything reading the frontmatter, including a reader who has never heard of
+  extraction: an absent key says "not read", which is true.
+- A survey can fill a 40-paper comparison matrix in hours rather than a
+  semester, without either paying depth mode's cost or pretending it did.
+- Extraction's guarantee is bounded and stated: cells were recorded with
+  locators, and a human checked a deterministic sample of them. It says nothing
+  about the unsampled cells, nothing about comprehension, and nothing about
+  whether a locator points where it claims — that last is `defend --target
+  cited-work`'s job, which is *why* the locator is mandatory.
+- The cells are the durable record and the matrix row is a projection of them,
+  so `defend --target cited-work` has something exact to check later without
+  parsing a table out of the author's prose.
+- Costs the author carries, stated up front rather than discovered: the matrix
+  is re-emitted canonically (column padding collapses, GFM alignment specifiers
+  are dropped), and because row lookup is exact label equality, a hand-edited
+  row label is not overwritten — it stops matching, and the next render adds a
+  *second* row. Nothing is lost; the remedy is to restore the label.
+- Render never deletes a row. A paper leaving the survey is removed by hand.
+- A locked-open failure mode is accepted deliberately: a batch whose human is
+  unavailable stays `batch-check: pending` forever. `pending` is honest, and
+  there is no route to make it `verified` without a human.
+
+## Rejected alternatives
+
+- **A third `literature` mode.** Would make `literature` open a PDF for the
+  first time and sits badly against its "propose and surface, never adjudicate"
+  guardrail.
+- **A new fourth skill.** Cleanest contract separation, but adds a
+  reading-adjacent surface to a plugin whose value depends on a researcher
+  holding the whole shape in their head.
+- **One status key with a `mode:` discriminator.** The two contracts would share
+  a field name, and anything reading it without knowing about `mode` silently
+  inflates the weaker claim into the stronger one — the exact harm.
+- **A single `sampled:` field** instead of `in-sample` + `batch-check`. It would
+  have to read `failed` for a paper that was never checked, which parses as a
+  finding about *that paper*. Misleading status is what this design exists to
+  avoid.
+- **A freshly-random sample per run.** Lets anyone re-roll until an easy draw
+  comes up, and the run looks identical from the outside — the check hollowed
+  out while appearing intact. (Seeding with Python's `hash()` was rejected for
+  the same reason at implementation time: it is salted per interpreter, so the
+  draw would change on every invocation while passing every same-process test.)
+- **The agent checking its own extraction.** Self-attestation; certifies
+  nothing.
+- **An interactive CLI prompt for the verdict.** Puts the agent between the
+  human and the sources, and makes the command unscriptable and untestable.
+- **`--batch FILE|-` as the sample's membership input** (the original sketch).
+  A caller-supplied membership file *is* the sample, since the draw is a
+  deterministic function of membership — the anti-gaming property defeated by
+  its own input.
+- **Silently repairing the one caught cell.** The worst outcome available: it
+  converts a signal about the population into a tidy-looking local fix.
+- **Extending `defend record` with an extraction target.** Maximum reuse, but
+  that command's job is certifying understanding, and it would then also write
+  a key that deliberately means something weaker.
+- **A separate validator the skill is told to run.** The skill could write
+  without validating, which returns the constraint to documented-as-expected —
+  exactly what #100 asked to move past.
+- **A non-empty-string locator check.** Satisfied by `"see paper"`, which an
+  agent filling 320 cells discovers immediately.
+- **A fixed locator pattern set.** A domain assumption in a plugin that forbids
+  them; the set ships as a default and is replaceable via
+  `literature.extraction.locator_patterns`, for the same reason
+  `venue_resolvers` is (ADR-0038).
+- **Making `not-addressed` simply locator-exempt.** 8 axes × 40 papers is 320
+  chances to write "not addressed" and skip the hard part. A justification plus
+  a visible count prices it instead.
+- **Allowing an axis to be omitted.** Without the completeness rule,
+  `not-addressed` is unnecessary: an agent finding an axis hard just omits the
+  cell, and a short row looks like a clean row.
+- **Automatic deletion of matrix rows.** The one operation here with no safe
+  failure mode — a bug that drops rows loses the author's work silently.
+- **PDF parsing in the CLI.** The agent reads PDFs natively; a parser would
+  breach the light-dependency posture for nothing (same reasoning as ADR-0037).
+
+## Links
+
+`docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md` (the full
+design; note the `*Amended during implementation*` blocks in §3.1, §5, §8 and
+§9 — the amendment is what shipped); `skills/digest/SKILL.md`;
+`skills/progress/SKILL.md`; `skills/literature/SKILL.md`;
+`defendable-science/defendable_science/digest/{extraction,artifact,sampling,render}.py`;
+`defendable-science/defendable_science/core/mdtable.py`;
+ADR-0033 (evidentiary point records, the shared accountability log), ADR-0034
+(`digest` as a dedicated skill), ADR-0014 (`progress` anti-Goodhart),
+ADR-0037 (the registry layer this builds on), ADR-0039 (recorded consumer
+layout); #97 (Gap 2), #100, #101 (Gap 3, survey-shaped templates — separate).

--- a/decisions/0040-digest-extraction-mode.md
+++ b/decisions/0040-digest-extraction-mode.md
@@ -190,10 +190,12 @@ the five decisions above are aspirational rather than enforced:
 - **`record` writes exactly two triage fields** — `extracted` and
   `extraction-cells` — and **never `disposition`**. The disposition state
   machine is the human's decision; a machine advancing it is precisely the
-  agency violation this plugin exists to prevent. Where the sidecar carries YAML
-  comments and `patch_triage` refuses (its rationales *are* the PRISMA log), the
-  cells still land, the refusal is reported apart from write errors and carries
-  a `kind` of `refused` or `failed`, and the run exits 1.
+  agency violation this plugin exists to prevent. Where `patch_triage` refuses —
+  the sidecar carries YAML comments (its rationales *are* the PRISMA log), holds
+  a non-mapping row, or joins two citekeys to one anchored mapping, where a
+  single patch would record work never done on the others — the cells still
+  land, the refusal is reported apart from write errors and carries a `kind` of
+  `refused` or `failed`, and the run exits 1.
 
 ## Consequences
 

--- a/decisions/0040-digest-extraction-mode.md
+++ b/decisions/0040-digest-extraction-mode.md
@@ -53,6 +53,52 @@ one. #97 filed that as the harm, not as a theoretical risk.
 - **Never lose an author's work.** `positioning.md` is hand-written prose with a
   table in it. #94 is a live reminder of how a table writer loses work quietly.
 
+## Considered options
+
+Five axes, each with a genuinely plausible alternative. Chosen options marked;
+each rejection is argued in *Rejected alternatives* below.
+
+**Where extraction lives.**
+
+1. A third `literature` mode.
+2. A new, fourth skill.
+3. **A second mode of the existing `digest` skill.** *(chosen)*
+
+**How the weaker claim is represented.**
+
+1. One `status.understanding` key with a `mode:` discriminator.
+2. A separate `status.extraction` key with a single `sampled:` field.
+3. **A separate `status.extraction` key with `in-sample` and `batch-check` as
+   two fields, plus a second, never-summed `progress` row.** *(chosen)*
+
+**Who checks the sample.**
+
+1. The agent re-reads its own extraction and checks it.
+2. Nobody — record the cells and rely on the mandatory locator alone.
+3. **The human, asked per cell whether the source at that locator says this.**
+   *(chosen)*
+
+**How the sample is drawn, and how the verdict is given.**
+
+1. A fresh random draw per run, with an interactive CLI prompt for the verdict.
+2. A caller-supplied membership file (`--batch FILE|-`) seeding the draw.
+3. **A draw seeded from the sorted membership set, with the verdict as a second
+   invocation of the same command.** *(chosen)*
+
+**What a failed sample means.**
+
+1. A finding about the caught cell: repair it and continue.
+2. A finding about the sampled papers only.
+3. **A finding about the batch: `batch-check: failed` on every artifact in the
+   run, with no route to repair the caught cell.** *(chosen)*
+
+**How the rules are enforced** (the mechanisms recorded under decision 5).
+
+1. A SKILL.md instruction the agent is asked to follow.
+2. A separate validator the skill is told to run before writing.
+3. **Validation fused to the only writer, with a locator pattern set that is
+   extensible but not replaceable.** *(chosen)*
+
 ## Decision
 
 Five material decisions, each recorded with its rejected alternative because
@@ -127,8 +173,10 @@ sample of three probably produced more in the other thirty-seven. Every artifact
 in the run — sampled or not — gets `batch-check: failed`, and there is
 deliberately **no route** to repair the one caught cell.
 
-Two further mechanisms follow the same logic and are recorded here because they
-are what make the above enforceable rather than aspirational:
+Two further mechanisms are recorded here — not because they follow from
+batch-condemnation, which they do not, but because they are what answer the
+*enforcement over documentation* and *agency* drivers, and because without them
+the five decisions above are aspirational rather than enforced:
 
 - **Validation and writing are one command.** The validating command is the
   *only* writer; there is no code path that records an unvalidated cell. Same
@@ -194,6 +242,19 @@ are what make the above enforceable rather than aspirational:
   draw would change on every invocation while passing every same-process test.)
 - **The agent checking its own extraction.** Self-attestation; certifies
   nothing.
+- **No check at all — the mandatory locator as the whole guarantee.** A locator
+  is shape-checked, not resolved: nothing in the pipeline opens the paper to see
+  whether the cell's claim is at `§3`. Without a human check, extraction's claim
+  collapses to "an agent wrote some strings in a well-formed shape", which is
+  not worth a status key.
+- **Treating a failed sample as a finding about the sampled papers only.**
+  Splits the batch into checked-and-failed and unchecked-and-unmarked, which is
+  the same misleading state a single `sampled:` field produces, one level up: a
+  reader sees thirty-seven papers carrying no failure and infers they are fine,
+  when the sample is precisely the evidence that they are not.
+- **A SKILL.md instruction to include a locator, with no enforcement.** What
+  #100 was filed against. It constrains nothing about what actually gets
+  written, and the constraint's absence is invisible in the artifact.
 - **An interactive CLI prompt for the verdict.** Puts the agent between the
   human and the sources, and makes the command unscriptable and untestable.
 - **`--batch FILE|-` as the sample's membership input** (the original sketch).
@@ -210,10 +271,15 @@ are what make the above enforceable rather than aspirational:
   exactly what #100 asked to move past.
 - **A non-empty-string locator check.** Satisfied by `"see paper"`, which an
   agent filling 320 cells discovers immediately.
-- **A fixed locator pattern set.** A domain assumption in a plugin that forbids
-  them; the set ships as a default and is replaceable via
+- **A closed locator pattern set.** A domain assumption in a plugin that forbids
+  them; the set ships as a default and is **extensible** via
   `literature.extraction.locator_patterns`, for the same reason
-  `venue_resolvers` is (ADR-0038).
+  `venue_resolvers` is (ADR-0038). Extension is additive only — configured
+  patterns are appended, and there is deliberately no way to *drop* a default.
+  Widening the accepted set can only admit a shape that would otherwise have
+  been rejected; letting a consumer remove `§` or `Eq.` would let a
+  misconfiguration reject locators their own authors wrote, which is the
+  costlier direction of the two.
 - **Making `not-addressed` simply locator-exempt.** 8 axes × 40 papers is 320
   chances to write "not addressed" and skip the hard part. A justification plus
   a visible count prices it instead.

--- a/decisions/0040-digest-extraction-mode.md
+++ b/decisions/0040-digest-extraction-mode.md
@@ -183,7 +183,9 @@ the five decisions above are aspirational rather than enforced:
   move that made `_bind` the single writer of an asset spine in ADR-0037.
   Rules: a shape-checked locator, or the distinguished value `not-addressed`
   with a justification; **every** header axis accounted for per paper; no
-  invented axes; rejection per paper, not per batch. `not-addressed` is counted
+  invented axes; the `**This paper**` self-reference row refused as a citekey,
+  since it is the author's own delta rather than an extracted paper; rejection
+  per paper, not per batch. `not-addressed` is counted
   per paper and in aggregate — that count is the anti-gaming signal, and it is
   cheaper and more honest than asking a checker to adjudicate whether an absence
   is real, which it cannot do without reading the paper.

--- a/decisions/README.md
+++ b/decisions/README.md
@@ -51,5 +51,6 @@ Migrates to the plugin's `decisions/` alongside `resources/references/`.
 | [0037](0037-literature-asset-acquisition.md) | Literature asset acquisition — substrate spine under CSL `custom`, three-way match gate with an author hard gate | accepted |
 | [0038](0038-venue-resolvers-trusted-not-gated.md) | Rung 6 (`venue_resolvers`) is *trusted*, not gated — the audit trail records that no verification was performed instead of a fabricated three-axis `accept` | accepted |
 | [0039](0039-recorded-consumer-layout.md) | Consumer layout = a bounded `layout:` block of four recordable roots (rejecting one `research_root` override and a full per-file map); inside a paper is derived, thesis-ness is a fact on disk | accepted |
+| [0040](0040-digest-extraction-mode.md) | `digest` extraction mode — a second, weaker claim kept structurally separate from comprehension (`status.extraction` never `status.understanding`; two `progress` rows, never summed); the human checks a deterministic sample; a failed sample condemns the batch, not the paper | accepted |
 
 Format: MADR (Markdown Any Decision Records). Deciders: Davor Runje (with Claude).

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -18,7 +18,7 @@ import sys
 from contextlib import contextmanager
 from datetime import date as date_cls
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, NoReturn
 
 import typer
 
@@ -2233,15 +2233,30 @@ def extract_axes(paper: _PaperOpt = None, positioning: _PositioningOpt = None) -
         resolved.
     """
     _config, _layout, path = _positioning_context(paper, positioning)
+    axes: list[str] | None = None
+    error: str | None = None
     try:
         axes = extraction_mod.axes_from_positioning(path)
     except extraction_mod.ExtractionError as exc:
         typer.echo(f"digest extract axes failed: {exc}", err=True)
-        raise typer.Exit(code=1) from exc
-    # Reported absolute whichever branch resolved it: a consumer keying or
-    # diffing runs must not see two shapes for one document.
-    typer.echo(json.dumps({"positioning": str(path.resolve()), "axes": axes}, indent=2))
-    raise typer.Exit(code=0)
+        error = str(exc)
+    # Emitted on the refusal too, and `axes` is then `null` rather than `[]`:
+    # all four verbs report the same way, and a caller must never be able to
+    # read a matrix this run could not parse as a matrix with no axes.
+    # `positioning` is reported absolute whichever branch resolved it: a
+    # consumer keying or diffing runs must not see two shapes for one document.
+    typer.echo(
+        json.dumps(
+            {
+                "ok": error is None,
+                "positioning": str(path.resolve()),
+                "axes": axes,
+                "error": error,
+            },
+            indent=2,
+        )
+    )
+    raise typer.Exit(code=0 if error is None else 1)
 
 
 def _parse_cells(raw: str) -> list[extraction_mod.Cell]:
@@ -2285,6 +2300,60 @@ def _parse_cells(raw: str) -> list[extraction_mod.Cell]:
                 f"--cells item {index}: {exc}"
             ) from exc
     return cells
+
+
+def _emit_record_report(
+    positioning: Path,
+    *,
+    axes: list[str] | None,
+    error: str | None = None,
+    recorded: list[dict[str, Any]] | None = None,
+    rejected: list[extraction_mod.Rejection] | None = None,
+    errors: list[dict[str, str]] | None = None,
+    triage_not_updated: list[dict[str, str]] | None = None,
+) -> NoReturn:
+    """Print ``record``'s JSON report and exit.
+
+    Emitted on every outcome, the unusable-input one included — a caller
+    scripting the four ``extract`` verbs must not have to special-case a run
+    that produced no JSON at all. ``error`` carries the whole-run failure that
+    stopped the command before it could validate anything; the per-paper
+    failures stay in their own three buckets, which mean different things and
+    must not be conflated. ``axes`` is ``null``, never ``[]``, when the matrix
+    could not be read: a matrix with no axes is a different fact.
+
+    :param positioning: The positioning document, reported absolute.
+    :param axes: The matrix's axes, or ``None`` if they could not be read.
+    :param error: The whole-run failure, if any.
+    :param recorded: The papers whose cells landed.
+    :param rejected: The validation refusals.
+    :param errors: The papers whose artifact write failed.
+    :param triage_not_updated: The papers whose cells landed but whose triage
+        row did not.
+    :raises typer.Exit: Code 0 when everything landed; code 1 otherwise.
+    """
+    recorded = recorded or []
+    rejected = rejected or []
+    errors = errors or []
+    triage_not_updated = triage_not_updated or []
+    ok = not (error or rejected or errors or triage_not_updated)
+    typer.echo(
+        json.dumps(
+            {
+                "ok": ok,
+                "positioning": str(positioning.resolve()),
+                "axes": axes,
+                "recorded": recorded,
+                "rejected": [dataclasses.asdict(r) for r in rejected],
+                "errors": errors,
+                "triage_not_updated": triage_not_updated,
+                "not_addressed": sum(r["not_addressed"] for r in recorded),
+                "error": error,
+            },
+            indent=2,
+        )
+    )
+    raise typer.Exit(code=0 if ok else 1)
 
 
 @extract.command(name="record")
@@ -2354,7 +2423,7 @@ def extract_record(
         parsed = _parse_cells(raw)
     except (extraction_mod.ExtractionError, OSError) as exc:
         typer.echo(f"digest extract record failed: {exc}", err=True)
-        raise typer.Exit(code=1) from exc
+        _emit_record_report(path, axes=None, error=str(exc))
 
     accepted, rejections = extraction_mod.validate(parsed, axes, patterns)
     date = date_cls.today().isoformat()
@@ -2427,22 +2496,14 @@ def extract_record(
 
     for rejection in rejections:
         typer.echo(extraction_mod.render_rejection(rejection), err=True)
-    typer.echo(
-        json.dumps(
-            {
-                "ok": not (rejections or errors or triage_not_updated),
-                "positioning": str(path.resolve()),
-                "axes": axes,
-                "recorded": recorded,
-                "rejected": [dataclasses.asdict(r) for r in rejections],
-                "errors": errors,
-                "triage_not_updated": triage_not_updated,
-                "not_addressed": sum(r["not_addressed"] for r in recorded),
-            },
-            indent=2,
-        )
+    _emit_record_report(
+        path,
+        axes=axes,
+        recorded=recorded,
+        rejected=rejections,
+        errors=errors,
+        triage_not_updated=triage_not_updated,
     )
-    raise typer.Exit(code=1 if rejections or errors or triage_not_updated else 0)
 
 
 #: The verdicts a human may record on a sampled check. Deliberately not
@@ -2593,12 +2654,13 @@ def _emit_sample_report(
     members: list[str],
     verdict: str | None,
     errors: list[dict[str, str]],
+    error: str | None = None,
     sample: list[str] | None = None,
     sampled: list[dict[str, Any]] | None = None,
     not_shown: list[str] | None = None,
     updated: list[str] | None = None,
     log_entries: list[str] | None = None,
-) -> None:
+) -> NoReturn:
     """Print the run's JSON report and exit.
 
     ``size`` counts the papers *drawn*; ``sampled`` lists the ones whose cells
@@ -2607,9 +2669,19 @@ def _emit_sample_report(
     leaving a reader to diff two lists — the report must not imply the run
     established more than it did.
 
+    ``verdict`` is what was **recorded**, not what was asked for: a run that
+    refused a ``verified`` verdict reports ``null`` there and names the request
+    under ``verdict_requested``. The two are separate keys because a key called
+    ``verdict`` reading ``verified`` on a run that wrote nothing is one careless
+    read away from being taken for the outcome — and the outcome is what a
+    verdict key will be read as, whatever the neighbouring keys say.
+
     :param members: The batch.
-    :param verdict: The verdict recorded, if any.
-    :param errors: Everything that failed.
+    :param verdict: The verdict asked for, if any; reported as recorded only
+        when it actually landed on a member.
+    :param errors: Everything that failed, per paper.
+    :param error: The whole-run failure that stopped the command, if any —
+        an unknowable batch, an empty one, or a refused ``verified`` verdict.
     :param sample: The drawn citekeys.
     :param sampled: The drawn papers whose cells were read, with those cells.
     :param not_shown: Drawn papers whose cells could not be read.
@@ -2618,7 +2690,8 @@ def _emit_sample_report(
     :raises typer.Exit: Code 0 when the batch is non-empty and nothing failed;
         code 1 otherwise.
     """
-    ok = bool(members) and not errors
+    written = updated or []
+    ok = bool(members) and not errors and error is None
     typer.echo(
         json.dumps(
             {
@@ -2626,12 +2699,16 @@ def _emit_sample_report(
                 "batch": members,
                 "size": len(sample or []),
                 "sample": sample or [],
-                "verdict": verdict,
+                # Non-null only if it landed somewhere: a verdict nobody
+                # recorded is a request, and belongs under the other key.
+                "verdict": verdict if written else None,
+                "verdict_requested": verdict,
                 "sampled": sampled or [],
                 "not_shown": not_shown or [],
-                "updated": updated or [],
+                "updated": written,
                 "log_entries": log_entries or [],
                 "errors": errors,
+                "error": error,
             },
             indent=2,
         )
@@ -2749,15 +2826,21 @@ def extract_sample(
         # feature built to prevent that. And a verdict recorded here would be a
         # statement about a population the run has just admitted it cannot
         # determine.
-        typer.echo(
+        unknowable = (
             f"digest extract sample failed: {len(errors)} artifact(s) under "
             f"{layout.digests_dir} could not be read, so the batch cannot be "
             "determined; nothing was drawn and nothing was written — repair "
-            "them, or name the batch explicitly with --citekey",
-            err=True,
+            "them, or name the batch explicitly with --citekey"
         )
-        _emit_sample_report(members=[], verdict=verdict, errors=errors)
+        typer.echo(unknowable, err=True)
+        _emit_sample_report(
+            members=[], verdict=verdict, errors=errors, error=unknowable
+        )
 
+    # The headline of a whole-run failure, reported in the JSON as well as on
+    # stderr: a caller reading only the report must not have to infer why an
+    # empty draw is empty.
+    error: str | None = None
     sample: list[str] = []
     if members:
         sample = sampling_mod.select_sample(
@@ -2767,12 +2850,12 @@ def extract_sample(
     else:
         # Not a passed sample of size zero: no paper was checked, and saying so
         # is the whole point of the command.
-        typer.echo(
+        error = (
             f"digest extract sample failed: no extracted papers under "
             f"{layout.digests_dir} — nothing was sampled and nothing was "
-            "checked; run `digest extract record` first",
-            err=True,
+            "checked; run `digest extract record` first"
         )
+        typer.echo(error, err=True)
     drawn_cells, sampled = _read_sampled_cells(layout, sample, errors)
     not_shown = [key for key in sample if key not in drawn_cells]
 
@@ -2783,14 +2866,14 @@ def extract_sample(
         # and the check it claims did not happen for these papers. Exit 1 alone
         # would not do: the exit code is transient, and the artifact is what
         # every downstream reader consults.
-        typer.echo(
+        error = (
             "digest extract sample: refusing to record a verified batch — "
             f"{len(not_shown)} of the {len(sample)} drawn papers "
             f"({', '.join(not_shown)}) could not be shown to the human, so the "
             "verification the verdict claims did not happen; repair them and "
-            "re-run, or record `failed`",
-            err=True,
+            "re-run, or record `failed`"
         )
+        typer.echo(error, err=True)
     elif verdict is not None:
         updated, log_entries = _apply_verdict(
             layout,
@@ -2805,6 +2888,7 @@ def extract_sample(
         members=members,
         sample=sample,
         verdict=verdict,
+        error=error,
         sampled=sampled,
         not_shown=not_shown,
         updated=updated,
@@ -2890,6 +2974,11 @@ def extract_render(
     """
     _config, layout, path = _positioning_context(paper, positioning)
     errors: list[dict[str, str]] = []
+    # The headline of a whole-run failure — an unknowable batch, an empty one,
+    # or a refused merge — reported in the JSON as well as on stderr, so that a
+    # caller reading only the report is never left with an unexplained
+    # ``ok: false``.
+    error: str | None = None
     if citekey:
         batch = sorted(set(citekey))
     else:
@@ -2900,24 +2989,25 @@ def extract_render(
         # "run `digest extract record`" would be the wrong repair. The headline
         # sentence has to say which of the two happened, not just the errors
         # underneath it.
-        typer.echo(
+        error = (
             f"digest extract render failed: {len(errors)} artifact(s) under "
             f"{layout.digests_dir} could not be read and none could be loaded, "
             "so whether any paper has been extracted is unknown; nothing was "
-            f"rendered and {path} was not touched — repair them and re-run",
-            err=True,
+            f"rendered and {path} was not touched — repair them and re-run"
         )
+        typer.echo(error, err=True)
     elif not batch:
         # Not "rendered zero rows": no paper was extracted, and the matrix is
         # left alone rather than rewritten to say so.
-        typer.echo(
+        error = (
             f"digest extract render failed: no extracted papers under "
             f"{layout.digests_dir} — nothing was rendered and {path} was not "
-            "touched; run `digest extract record` first",
-            err=True,
+            "touched; run `digest extract record` first"
         )
+        typer.echo(error, err=True)
     rows = _cells_to_render(layout, batch, errors)
     changed = False
+    rendered = sorted(rows)
     if rows:
         try:
             before = path.read_text(encoding="utf-8")
@@ -2926,22 +3016,28 @@ def extract_render(
                 path.write_text(merged, encoding="utf-8")
                 changed = True
         except (extraction_mod.ExtractionError, OSError) as exc:
-            typer.echo(f"digest extract render failed: {exc}", err=True)
-            raise typer.Exit(code=1) from exc
+            # The refusal leaves the document byte-identical, so no paper was
+            # merged: `rendered` is emptied rather than left naming the papers
+            # this run *would* have written.
+            error = f"digest extract render failed: {exc}"
+            typer.echo(error, err=True)
+            rendered = []
+    ok = bool(batch) and not errors and error is None
     typer.echo(
         json.dumps(
             {
-                "ok": bool(batch) and not errors,
+                "ok": ok,
                 "positioning": str(path.resolve()),
                 "batch": batch,
-                "rendered": sorted(rows),
+                "rendered": rendered,
                 "changed": changed,
                 "errors": errors,
+                "error": error,
             },
             indent=2,
         )
     )
-    raise typer.Exit(code=0 if batch and not errors else 1)
+    raise typer.Exit(code=0 if ok else 1)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -32,6 +32,7 @@ from defendable_science.dataset import retrieval as retrieval_mod
 from defendable_science.defend import record as record_mod
 from defendable_science.digest import artifact as artifact_mod
 from defendable_science.digest import extraction as extraction_mod
+from defendable_science.digest import render as render_mod
 from defendable_science.digest import sampling as sampling_mod
 from defendable_science.exploration import backlog as backlog_mod
 from defendable_science.literature import acquire as acquire_mod
@@ -2450,7 +2451,9 @@ def extract_record(
 _SAMPLE_VERDICTS = ("verified", "failed")
 
 
-def _extraction_batch(layout: Layout) -> tuple[list[str], list[dict[str, str]]]:
+def _extraction_batch(
+    layout: Layout, command: str
+) -> tuple[list[str], list[dict[str, str]]]:
     """Collect every digest artifact that records an extraction (ruling AL).
 
     A digest with no ``status.extraction`` block was never extracted — a
@@ -2460,6 +2463,8 @@ def _extraction_batch(layout: Layout) -> tuple[list[str], list[dict[str, str]]]:
     shrink the population the sample is drawn from.
 
     :param layout: The resolved layout, which owns the digests directory.
+    :param command: The calling command, for the diagnostic — a reader must not
+        be told ``sample`` failed when they ran ``render``.
     :returns: The batch's citekeys, and one error entry per unreadable artifact.
     """
     members: list[str] = []
@@ -2469,7 +2474,7 @@ def _extraction_batch(layout: Layout) -> tuple[list[str], list[dict[str, str]]]:
             if artifact_mod.has_extraction(path):
                 members.append(path.stem)
         except (extraction_mod.ExtractionError, OSError) as exc:
-            typer.echo(f"digest extract sample failed for {path.stem}: {exc}", err=True)
+            typer.echo(f"{command} failed for {path.stem}: {exc}", err=True)
             errors.append(
                 {"citekey": path.stem, "artifact": str(path), "reason": str(exc)}
             )
@@ -2727,7 +2732,7 @@ def extract_sample(
 
     _config, layout = _layout_or_exit()
     if all_papers:
-        members, errors = _extraction_batch(layout)
+        members, errors = _extraction_batch(layout, "digest extract sample")
     else:
         members, errors = sorted(set(citekey or [])), []
     log_root = (
@@ -2806,6 +2811,121 @@ def extract_sample(
         log_entries=log_entries,
         errors=errors,
     )
+
+
+def _cells_to_render(
+    layout: Layout, batch: list[str], errors: list[dict[str, str]]
+) -> dict[str, dict[str, str]]:
+    """Read each paper's recorded cells into the merge's ``rows`` argument.
+
+    A paper whose artifact cannot be read contributes **no** row rather than an
+    empty one: an empty row would overwrite the author's matrix line with
+    blanks on the strength of a file this run could not read.
+
+    :param layout: The resolved layout, which owns the artifact paths.
+    :param batch: The citekeys to render.
+    :param errors: The run's error list, appended to in place.
+    :returns: citekey → axis → value, for the papers that could be read.
+    """
+    rows: dict[str, dict[str, str]] = {}
+    for citekey in batch:
+        target = layout.digest(citekey)
+        try:
+            cells = artifact_mod.read_cells(target)
+        except (extraction_mod.ExtractionError, OSError) as exc:
+            typer.echo(f"digest extract render failed for {citekey}: {exc}", err=True)
+            errors.append(
+                {"citekey": citekey, "artifact": str(target), "reason": str(exc)}
+            )
+            continue
+        rows[citekey] = {cell.axis: cell.value for cell in cells}
+    return rows
+
+
+@extract.command(name="render")
+def extract_render(
+    citekey: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--citekey",
+            help="Render only these papers; repeatable. Every extracted paper "
+            "by default.",
+        ),
+    ] = None,
+    paper: _PaperOpt = None,
+    positioning: _PositioningOpt = None,
+) -> None:
+    """Merge the extracted cells into ``positioning.md``'s concept matrix (§9).
+
+    A merge, not a rewrite. The author's taxonomy prose, PRISMA log, per-branch
+    delta and section comments survive by construction, because only the
+    matrix table's own lines are re-emitted.
+
+    **Nothing is ever deleted.** A row in the file that this run has no cells
+    for is left exactly as it is, and a paper leaving the survey is removed by
+    hand — automatic deletion is the one operation here with no safe failure
+    mode. ``**This paper**`` is likewise never touched: it is the author's own
+    delta. Rows are keyed by citekey in the matrix's first column, so a
+    hand-edited row *label* is what a re-render overwrites; that is the price
+    of the row being a projection of the cells (spec §5).
+
+    A paper whose artifact cannot be read is reported and its row left alone —
+    the rest of the batch still lands, because skipping it changes nothing on
+    disk while refusing the whole merge would strand every other paper's cells.
+    A matrix that cannot be located unambiguously is a refusal instead: the
+    file is left byte-identical rather than written at a guess.
+
+    :param citekey: A paper to render; repeatable. Defaults to every digest
+        artifact carrying a ``status.extraction`` block.
+    :param paper: The paper id whose positioning document holds the matrix;
+        inferred from the cwd when omitted.
+    :param positioning: An explicit positioning document, overriding the layout.
+    :raises typer.Exit: Code 0 when every named paper was merged; code 1 when
+        the batch is empty, a paper's cells could not be read, the matrix is
+        not renderable, or the document could not be written; code 2 if the
+        paper cannot be resolved.
+    """
+    _config, layout, path = _positioning_context(paper, positioning)
+    errors: list[dict[str, str]] = []
+    if citekey:
+        batch = sorted(set(citekey))
+    else:
+        batch, errors = _extraction_batch(layout, "digest extract render")
+    if not batch:
+        # Not "rendered zero rows": no paper was extracted, and the matrix is
+        # left alone rather than rewritten to say so.
+        typer.echo(
+            f"digest extract render failed: no extracted papers under "
+            f"{layout.digests_dir} — nothing was rendered and {path} was not "
+            "touched; run `digest extract record` first",
+            err=True,
+        )
+    rows = _cells_to_render(layout, batch, errors)
+    changed = False
+    if rows:
+        try:
+            before = path.read_text(encoding="utf-8")
+            merged = render_mod.render_matrix(path, rows)
+            if merged != before:
+                path.write_text(merged, encoding="utf-8")
+                changed = True
+        except (extraction_mod.ExtractionError, OSError) as exc:
+            typer.echo(f"digest extract render failed: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+    typer.echo(
+        json.dumps(
+            {
+                "ok": bool(batch) and not errors,
+                "positioning": str(path.resolve()),
+                "batch": batch,
+                "rendered": sorted(rows),
+                "changed": changed,
+                "errors": errors,
+            },
+            indent=2,
+        )
+    )
+    raise typer.Exit(code=0 if batch and not errors else 1)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -2891,7 +2891,20 @@ def extract_render(
         batch = sorted(set(citekey))
     else:
         batch, errors = _extraction_batch(layout, "digest extract render")
-    if not batch:
+    if not batch and errors:
+        # An empty batch that is empty *because nothing could be read* is not
+        # an empty batch — whether anything was extracted is unknown, and
+        # "run `digest extract record`" would be the wrong repair. The headline
+        # sentence has to say which of the two happened, not just the errors
+        # underneath it.
+        typer.echo(
+            f"digest extract render failed: {len(errors)} artifact(s) under "
+            f"{layout.digests_dir} could not be read and none could be loaded, "
+            "so whether any paper has been extracted is unknown; nothing was "
+            f"rendered and {path} was not touched — repair them and re-run",
+            err=True,
+        )
+    elif not batch:
         # Not "rendered zero rows": no paper was extracted, and the matrix is
         # left alone rather than rewritten to say so.
         typer.echo(

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -2313,6 +2313,14 @@ def extract_record(
     certifies located cells checked by sample, which is a weaker claim than
     verified comprehension, and the two must not share a field (spec §3.2).
 
+    Each recorded paper then gets ``extracted`` and ``extraction-cells`` on its
+    ``triage.yml`` row — facts about the run, never ``disposition``, which is
+    the human's decision. The cells are written first, so a triage refusal (a
+    hand-annotated sidecar :func:`~.literature.registry.patch_triage` will not
+    rewrite) cannot discard an extraction that already landed; the refusal is
+    reported under ``triage_not_updated``, apart from ``errors``, and still
+    exits 1.
+
     :param cells: The cells to record — a JSON-array file path, or ``-`` for
         stdin.
     :param paper: The paper id whose concept matrix the cells are validated
@@ -2324,8 +2332,9 @@ def extract_record(
         directory, and a cwd-relative default would bury the run's evidence
         there, where no reviewer would look for it.
     :raises typer.Exit: Code 0 when every paper was recorded; code 1 when
-        anything was rejected, a write failed, or the input, matrix or config is
-        unusable; code 2 if the paper cannot be resolved.
+        anything was rejected, a write failed, a triage row could not be
+        updated, or the input, matrix or config is unusable; code 2 if the
+        paper cannot be resolved.
     """
     config, layout, path = _positioning_context(paper, positioning)
     log_root = (
@@ -2333,7 +2342,9 @@ def extract_record(
         if log_dir is not None
         else layout.research_root / artifact_mod.DEFAULT_LOG_DIR.name
     )
-    patterns = _locator_patterns(_lit_block(config))
+    lit = _lit_block(config)
+    patterns = _locator_patterns(lit)
+    _registry_path, triage_path = _lit_registry_paths(lit, layout)
     try:
         axes = extraction_mod.axes_from_positioning(path)
         raw = sys.stdin.read() if cells == "-" else Path(cells).read_text("utf-8")
@@ -2346,6 +2357,7 @@ def extract_record(
     date = date_cls.today().isoformat()
     recorded: list[dict[str, Any]] = []
     errors: list[dict[str, str]] = []
+    triage_not_updated: list[dict[str, str]] = []
     for citekey, paper_cells in sorted(accepted.items()):
         artifact = layout.digest(citekey)
         try:
@@ -2381,24 +2393,44 @@ def extract_record(
                 "log_entry": str(log_entry),
             }
         )
+        # Second, and only once the cells are on disk: a refusal here must not
+        # discard an extraction that already landed (spec §7.5). Two factual
+        # scalars, never `disposition` — the disposition state machine is the
+        # human's decision, and a machine advancing it would be exactly the
+        # agency violation this tool exists to prevent.
+        try:
+            triage_path.parent.mkdir(parents=True, exist_ok=True)
+            registry_mod.patch_triage(
+                triage_path,
+                citekey,
+                {"extracted": date, "extraction-cells": len(paper_cells)},
+            )
+        except (registry_mod.RegistryError, OSError) as exc:
+            # Not a write *failure* — `patch_triage` refuses a hand-annotated
+            # sidecar rather than destroy its PRISMA rationales. So it is
+            # reported apart from `errors`, where it would read as a lost
+            # artifact, and the message names the fields to set by hand.
+            typer.echo(f"triage not updated for {citekey}: {exc}", err=True)
+            triage_not_updated.append({"citekey": citekey, "reason": str(exc)})
 
     for rejection in rejections:
         typer.echo(extraction_mod.render_rejection(rejection), err=True)
     typer.echo(
         json.dumps(
             {
-                "ok": not (rejections or errors),
+                "ok": not (rejections or errors or triage_not_updated),
                 "positioning": str(path.resolve()),
                 "axes": axes,
                 "recorded": recorded,
                 "rejected": [dataclasses.asdict(r) for r in rejections],
                 "errors": errors,
+                "triage_not_updated": triage_not_updated,
                 "not_addressed": sum(r["not_addressed"] for r in recorded),
             },
             indent=2,
         )
     )
-    raise typer.Exit(code=1 if rejections or errors else 0)
+    raise typer.Exit(code=1 if rejections or errors or triage_not_updated else 0)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -2865,9 +2865,12 @@ def extract_render(
     for is left exactly as it is, and a paper leaving the survey is removed by
     hand — automatic deletion is the one operation here with no safe failure
     mode. ``**This paper**`` is likewise never touched: it is the author's own
-    delta. Rows are keyed by citekey in the matrix's first column, so a
-    hand-edited row *label* is what a re-render overwrites; that is the price
-    of the row being a projection of the cells (spec §5).
+    delta. Rows are keyed by citekey in the matrix's first column, matched on
+    exact equality, so a hand-edited row *label* is not overwritten — it stops
+    matching, and this command adds a **second** row for that paper. Restore
+    the label rather than re-editing it. Two smaller costs of the row being a
+    projection (spec §5): the matrix is re-emitted canonically, so hand-aligned
+    column padding is collapsed and GFM alignment specifiers are dropped.
 
     A paper whose artifact cannot be read is reported and its row left alone —
     the rest of the batch still lands, because skipping it changes nothing on

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -30,6 +30,8 @@ from defendable_science.core.mirror import Mirror
 from defendable_science.dataset import manifest as manifest_mod
 from defendable_science.dataset import retrieval as retrieval_mod
 from defendable_science.defend import record as record_mod
+from defendable_science.digest import artifact as artifact_mod
+from defendable_science.digest import extraction as extraction_mod
 from defendable_science.exploration import backlog as backlog_mod
 from defendable_science.literature import acquire as acquire_mod
 from defendable_science.literature import graph as graph_mod
@@ -38,6 +40,7 @@ from defendable_science.scaffold.init_repo import init_repo
 from defendable_science.scaffold.layout import Layout, LayoutError, resolve_layout
 
 if TYPE_CHECKING:
+    import re
     from collections.abc import Iterator
 
     from defendable_science.core.http import HttpClient
@@ -2124,6 +2127,263 @@ def path() -> None:
     """Print the resolved key-store path."""
     typer.echo(str(keys_mod.store_path()))
     raise typer.Exit(code=0)
+
+
+# --- digest extract (defendable-science#100, spec §3.1) -------------------------------
+digest = typer.Typer(help="Reading-record helpers (digest).", no_args_is_help=True)
+app.add_typer(digest, name="digest")
+extract = typer.Typer(
+    help="Extraction mode: breadth reading into located matrix cells.",
+    no_args_is_help=True,
+)
+digest.add_typer(extract, name="extract")
+
+_PaperOpt = Annotated[
+    str | None,
+    typer.Option("--paper", help="Paper id; inferred from the cwd if omitted."),
+]
+_PositioningOpt = Annotated[
+    str | None,
+    typer.Option(
+        "--positioning", help="Positioning document; from the layout if omitted."
+    ),
+]
+
+
+def _positioning_context(
+    paper: str | None, positioning: str | None
+) -> tuple[dict[str, Any], Layout, Path]:
+    """Resolve the config, the layout, and the positioning document to read.
+
+    An explicit ``--positioning`` wins and is taken as given (a path typed on the
+    command line means what it says relative to the cwd); otherwise the layout
+    supplies it from the paper id, the same order :func:`_lit_registry_paths`
+    uses. Resolution lives here rather than in
+    :mod:`defendable_science.digest.extraction`, which only ever sees a path.
+
+    :param paper: The paper id, or ``None`` to infer it from the cwd.
+    :param positioning: An explicit positioning path, which always wins.
+    :returns: The config mapping, the resolved layout, and the document path.
+    :raises typer.Exit: Code 1 on an invalid ``layout:`` block; code 2 when
+        ``--paper`` is omitted and the cwd is outside every paper.
+    """
+    config, layout = _layout_or_exit()
+    if positioning is not None:
+        return config, layout, Path(positioning)
+    paper_id = paper or _paper_dir_or_exit(layout, "--paper").name
+    return config, layout, layout.positioning(paper_id)
+
+
+def _locator_patterns(lit: dict[str, Any] | None) -> list[re.Pattern[str]]:
+    """Compile the locator pattern set, extended by config (spec §7.3).
+
+    :param lit: The parsed ``literature:`` config block, or ``None``.
+    :returns: The compiled matchers for :func:`~.extraction.is_valid_locator`.
+    :raises typer.Exit: Code 1 if ``literature.extraction`` is not a mapping, if
+        ``locator_patterns`` is not a list of strings, or if a configured
+        pattern is invalid or cannot be combined with the rest.
+    """
+    raw = lit.get("extraction") if lit is not None else None
+    if raw is not None and not isinstance(raw, dict):
+        typer.echo(
+            "invalid .defendable-science/config.yml: 'literature.extraction' "
+            "must be a mapping",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    configured = raw.get("locator_patterns") if raw is not None else None
+    if configured is not None and (
+        not isinstance(configured, list)
+        or not all(isinstance(p, str) for p in configured)
+    ):
+        typer.echo(
+            "invalid .defendable-science/config.yml: "
+            "'literature.extraction.locator_patterns' must be a list of "
+            "regular-expression strings",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    try:
+        return extraction_mod.compile_locator_patterns(configured)
+    except extraction_mod.ExtractionError as exc:
+        typer.echo(f"invalid .defendable-science/config.yml: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+@extract.command(name="axes")
+def extract_axes(paper: _PaperOpt = None, positioning: _PositioningOpt = None) -> None:
+    """Print the extraction question set — the concept matrix's axes (spec §6.1).
+
+    Run before reading anything: it is what tells the agent which cells the
+    matrix expects, and it refuses a matrix that is not ready to be extracted
+    against rather than letting 40 papers be read against ``<attr 1>``.
+
+    :param paper: The paper id whose positioning document holds the matrix;
+        inferred from the cwd when omitted.
+    :param positioning: An explicit positioning document, overriding the layout.
+    :raises typer.Exit: Code 0 with the axes as JSON; code 1 if the document is
+        missing or its matrix cannot yield axes; code 2 if the paper cannot be
+        resolved.
+    """
+    _config, _layout, path = _positioning_context(paper, positioning)
+    try:
+        axes = extraction_mod.axes_from_positioning(path)
+    except extraction_mod.ExtractionError as exc:
+        typer.echo(f"digest extract axes failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    typer.echo(json.dumps({"positioning": str(path), "axes": axes}, indent=2))
+    raise typer.Exit(code=0)
+
+
+def _parse_cells(raw: str) -> list[extraction_mod.Cell]:
+    """Parse the ``--cells`` JSON array into `Cell`s (spec §7.1).
+
+    An empty array is refused rather than treated as "nothing to do": a run that
+    recorded no cells and exited 0 would report a failed extraction as a
+    completed one.
+
+    :param raw: The JSON text read from the file or stdin.
+    :returns: The parsed cells, in file order.
+    :raises extraction_mod.ExtractionError: If the text is not a non-empty JSON
+        array of well-formed cell objects.
+    """
+    if not raw.strip():
+        raise extraction_mod.ExtractionError(
+            "--cells is empty; expected a JSON array of cell objects"
+        )
+    try:
+        data: object = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise extraction_mod.ExtractionError(
+            f"--cells is not valid JSON: {exc}"
+        ) from exc
+    if not isinstance(data, list):
+        raise extraction_mod.ExtractionError("--cells must be a JSON array")
+    if not data:
+        raise extraction_mod.ExtractionError(
+            "--cells is an empty array; there is nothing to record"
+        )
+    cells: list[extraction_mod.Cell] = []
+    for index, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise extraction_mod.ExtractionError(
+                f"--cells item {index} must be a JSON object, got {type(item).__name__}"
+            )
+        try:
+            cells.append(extraction_mod.cell_from_mapping(item))
+        except extraction_mod.ExtractionError as exc:
+            raise extraction_mod.ExtractionError(
+                f"--cells item {index}: {exc}"
+            ) from exc
+    return cells
+
+
+@extract.command(name="record")
+def extract_record(
+    cells: Annotated[
+        str,
+        typer.Option(
+            "--cells", help="Extracted cells: a JSON-array file path, or '-' for stdin."
+        ),
+    ],
+    paper: _PaperOpt = None,
+    positioning: _PositioningOpt = None,
+    log_dir: Annotated[
+        str | None,
+        typer.Option(
+            "--log-dir", help="Accountability log; from the layout if omitted."
+        ),
+    ] = None,
+) -> None:
+    """Validate extracted cells and record them — one inseparable action (§3.3).
+
+    Validation is not a separate step this command *calls first*; it is the only
+    source of the cells it writes. A paper is accepted whole or not at all, so a
+    rejected paper leaves no artifact, no log entry and no partial row, while the
+    rest of the batch is still recorded (spec §7.2 rule 4).
+
+    Writes ``status.extraction`` — never ``status.understanding``: extraction
+    certifies located cells checked by sample, which is a weaker claim than
+    verified comprehension, and the two must not share a field (spec §3.2).
+
+    :param cells: The cells to record — a JSON-array file path, or ``-`` for
+        stdin.
+    :param paper: The paper id whose concept matrix the cells are validated
+        against; inferred from the cwd when omitted.
+    :param positioning: An explicit positioning document, overriding the layout.
+    :param log_dir: Directory for the accountability log; the layout's
+        ``defend-log`` when omitted. Not a cwd-relative default: this command is
+        meant to be run from inside a paper directory, where one would put the
+        run's evidence somewhere no reviewer would look for it.
+    :raises typer.Exit: Code 0 when every paper was recorded; code 1 when
+        anything was rejected or the input, matrix or config is unusable; code 2
+        if the paper cannot be resolved.
+    """
+    config, layout, path = _positioning_context(paper, positioning)
+    log_root = (
+        Path(log_dir)
+        if log_dir is not None
+        else layout.research_root / artifact_mod.DEFAULT_LOG_DIR.name
+    )
+    patterns = _locator_patterns(_lit_block(config))
+    try:
+        axes = extraction_mod.axes_from_positioning(path)
+        raw = sys.stdin.read() if cells == "-" else Path(cells).read_text("utf-8")
+        parsed = _parse_cells(raw)
+    except (extraction_mod.ExtractionError, OSError) as exc:
+        typer.echo(f"digest extract record failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    accepted, rejections = extraction_mod.validate(parsed, axes, patterns)
+    date = date_cls.today().isoformat()
+    recorded: list[dict[str, Any]] = []
+    try:
+        for citekey, paper_cells in sorted(accepted.items()):
+            artifact = layout.digest(citekey)
+            # `init` does not scaffold literature/digests/ — the first recorded
+            # paper creates it.
+            artifact.parent.mkdir(parents=True, exist_ok=True)
+            log_entry = artifact_mod.write_extraction(
+                artifact,
+                paper_cells,
+                in_sample=False,
+                batch_check="pending",
+                log_dir=log_root,
+                date=date,
+            )
+            recorded.append(
+                {
+                    "citekey": citekey,
+                    "artifact": str(artifact),
+                    "cells": len(paper_cells),
+                    "not_addressed": sum(
+                        1
+                        for c in paper_cells
+                        if c.value == extraction_mod.NOT_ADDRESSED
+                    ),
+                    "log_entry": str(log_entry),
+                }
+            )
+    except (extraction_mod.ExtractionError, OSError) as exc:
+        typer.echo(f"digest extract record failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    for rejection in rejections:
+        typer.echo(extraction_mod.render_rejection(rejection), err=True)
+    typer.echo(
+        json.dumps(
+            {
+                "ok": not rejections,
+                "positioning": str(path),
+                "axes": axes,
+                "recorded": recorded,
+                "rejected": [dataclasses.asdict(r) for r in rejections],
+                "not_addressed": sum(r["not_addressed"] for r in recorded),
+            },
+            indent=2,
+        )
+    )
+    raise typer.Exit(code=1 if rejections else 0)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -2319,7 +2319,8 @@ def extract_record(
     hand-annotated sidecar :func:`~.literature.registry.patch_triage` will not
     rewrite) cannot discard an extraction that already landed; the refusal is
     reported under ``triage_not_updated``, apart from ``errors``, and still
-    exits 1.
+    exits 1. Each such entry carries a ``kind``: ``refused`` (the human must
+    edit the sidecar by hand) or ``failed`` (the write itself did not happen).
 
     :param cells: The cells to record — a JSON-array file path, or ``-`` for
         stdin.
@@ -2406,12 +2407,21 @@ def extract_record(
                 {"extracted": date, "extraction-cells": len(paper_cells)},
             )
         except (registry_mod.RegistryError, OSError) as exc:
-            # Not a write *failure* — `patch_triage` refuses a hand-annotated
-            # sidecar rather than destroy its PRISMA rationales. So it is
-            # reported apart from `errors`, where it would read as a lost
-            # artifact, and the message names the fields to set by hand.
+            # Not a write *failure* of the artifact — the cells landed — so this
+            # is reported apart from `errors`, where it would read as a lost
+            # artifact. But the two ways it can happen call for different human
+            # action, and a reader must not have to regex an exception message
+            # to tell them apart: `refused` is `patch_triage` declining to
+            # destroy a hand-annotated sidecar's PRISMA rationales (its message
+            # names the fields to set by hand), `failed` is the OS refusing the
+            # write at all.
+            kind = (
+                "refused" if isinstance(exc, registry_mod.RegistryError) else "failed"
+            )
             typer.echo(f"triage not updated for {citekey}: {exc}", err=True)
-            triage_not_updated.append({"citekey": citekey, "reason": str(exc)})
+            triage_not_updated.append(
+                {"citekey": citekey, "kind": kind, "reason": str(exc)}
+            )
 
     for rejection in rejections:
         typer.echo(extraction_mod.render_rejection(rejection), err=True)

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -2583,6 +2583,57 @@ def _apply_verdict(
     return updated, log_entries
 
 
+def _emit_sample_report(
+    *,
+    members: list[str],
+    verdict: str | None,
+    errors: list[dict[str, str]],
+    sample: list[str] | None = None,
+    sampled: list[dict[str, Any]] | None = None,
+    not_shown: list[str] | None = None,
+    updated: list[str] | None = None,
+    log_entries: list[str] | None = None,
+) -> None:
+    """Print the run's JSON report and exit.
+
+    ``size`` counts the papers *drawn*; ``sampled`` lists the ones whose cells
+    could actually be shown to the human. They differ exactly when a drawn
+    artifact could not be read, and ``not_shown`` names those papers rather than
+    leaving a reader to diff two lists — the report must not imply the run
+    established more than it did.
+
+    :param members: The batch.
+    :param verdict: The verdict recorded, if any.
+    :param errors: Everything that failed.
+    :param sample: The drawn citekeys.
+    :param sampled: The drawn papers whose cells were read, with those cells.
+    :param not_shown: Drawn papers whose cells could not be read.
+    :param updated: Members whose ``batch-check`` was written.
+    :param log_entries: Check-log entries written.
+    :raises typer.Exit: Code 0 when the batch is non-empty and nothing failed;
+        code 1 otherwise.
+    """
+    ok = bool(members) and not errors
+    typer.echo(
+        json.dumps(
+            {
+                "ok": ok,
+                "batch": members,
+                "size": len(sample or []),
+                "sample": sample or [],
+                "verdict": verdict,
+                "sampled": sampled or [],
+                "not_shown": not_shown or [],
+                "updated": updated or [],
+                "log_entries": log_entries or [],
+                "errors": errors,
+            },
+            indent=2,
+        )
+    )
+    raise typer.Exit(code=0 if ok else 1)
+
+
 @extract.command(name="sample")
 def extract_sample(
     citekey: Annotated[
@@ -2630,6 +2681,13 @@ def extract_sample(
     why the draw itself writes nothing: an unanswered draw has established
     nothing about any paper.
 
+    ``verified`` is refused outright — nothing written, exit 1 — if any drawn
+    paper's cells could not be read, because the human cannot have verified what
+    they were never shown. ``failed`` is a finding rather than a claim, so it
+    lands regardless. On ``--all``, an artifact that cannot be read stops the run
+    before the draw: membership is unknowable, and since the draw is a function
+    of membership, sampling around it would change which papers get checked.
+
     The verdict call re-draws over the batch it is given, so **give it the same
     batch and the same ``--size``**. Both are deterministic, so identical
     arguments mark exactly the papers the draw reported; a different membership
@@ -2651,8 +2709,8 @@ def extract_sample(
         the run's evidence lands where a reviewer looks for it.
     :raises typer.Exit: Code 0 when the sample was drawn (and, with
         ``--verdict``, recorded on every member); code 1 when the batch is
-        empty or any member could not be read or updated; code 2 on a usage
-        error.
+        empty or unknowable, when any member could not be read or updated, or
+        when a ``verified`` verdict was refused; code 2 on a usage error.
     """
     if bool(citekey) == all_papers:
         raise typer.BadParameter(
@@ -2678,6 +2736,23 @@ def extract_sample(
         else layout.research_root / artifact_mod.DEFAULT_LOG_DIR.name
     )
 
+    if all_papers and errors:
+        # Before drawing, and before writing anything. The draw is a
+        # deterministic function of the membership set, so sampling around an
+        # unreadable artifact would change *which* papers get checked — making
+        # a file unreadable would become a way to re-roll the sample, in the one
+        # feature built to prevent that. And a verdict recorded here would be a
+        # statement about a population the run has just admitted it cannot
+        # determine.
+        typer.echo(
+            f"digest extract sample failed: {len(errors)} artifact(s) under "
+            f"{layout.digests_dir} could not be read, so the batch cannot be "
+            "determined; nothing was drawn and nothing was written — repair "
+            "them, or name the batch explicitly with --citekey",
+            err=True,
+        )
+        _emit_sample_report(members=[], verdict=verdict, errors=errors)
+
     sample: list[str] = []
     if members:
         sample = sampling_mod.select_sample(
@@ -2694,10 +2769,24 @@ def extract_sample(
             err=True,
         )
     drawn_cells, sampled = _read_sampled_cells(layout, sample, errors)
+    not_shown = [key for key in sample if key not in drawn_cells]
 
     updated: list[str] = []
     log_entries: list[str] = []
-    if verdict is not None:
+    if verdict == "verified" and not_shown:
+        # `failed` is a finding and lands regardless; `verified` is a *claim*,
+        # and the check it claims did not happen for these papers. Exit 1 alone
+        # would not do: the exit code is transient, and the artifact is what
+        # every downstream reader consults.
+        typer.echo(
+            "digest extract sample: refusing to record a verified batch — "
+            f"{len(not_shown)} of the {len(sample)} drawn papers "
+            f"({', '.join(not_shown)}) could not be shown to the human, so the "
+            "verification the verdict claims did not happen; repair them and "
+            "re-run, or record `failed`",
+            err=True,
+        )
+    elif verdict is not None:
         updated, log_entries = _apply_verdict(
             layout,
             members,
@@ -2707,24 +2796,16 @@ def extract_sample(
             errors=errors,
         )
 
-    ok = bool(members) and not errors
-    typer.echo(
-        json.dumps(
-            {
-                "ok": ok,
-                "batch": members,
-                "size": len(sample),
-                "sample": sample,
-                "verdict": verdict,
-                "sampled": sampled,
-                "updated": updated,
-                "log_entries": log_entries,
-                "errors": errors,
-            },
-            indent=2,
-        )
+    _emit_sample_report(
+        members=members,
+        sample=sample,
+        verdict=verdict,
+        sampled=sampled,
+        not_shown=not_shown,
+        updated=updated,
+        log_entries=log_entries,
+        errors=errors,
     )
-    raise typer.Exit(code=0 if ok else 1)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -2155,10 +2155,15 @@ def _positioning_context(
 ) -> tuple[dict[str, Any], Layout, Path]:
     """Resolve the config, the layout, and the positioning document to read.
 
-    An explicit ``--positioning`` wins and is taken as given (a path typed on the
-    command line means what it says relative to the cwd); otherwise the layout
-    supplies it from the paper id, the same order :func:`_lit_registry_paths`
-    uses. Resolution lives here rather than in
+    The *precedence* is :func:`_lit_registry_paths`'s — an explicit value wins,
+    otherwise the layout supplies the default — but the anchoring deliberately
+    is not. A configured path in ``config.yml`` describes a location in the
+    repository, so that function anchors it to the repo root; a path typed on
+    the command line means what it says relative to the cwd, so it is taken as
+    given here. Do not "reconcile" the two: they are answering different
+    questions.
+
+    Resolution lives here rather than in
     :mod:`defendable_science.digest.extraction`, which only ever sees a path.
 
     :param paper: The paper id, or ``None`` to infer it from the cwd.
@@ -2231,7 +2236,9 @@ def extract_axes(paper: _PaperOpt = None, positioning: _PositioningOpt = None) -
     except extraction_mod.ExtractionError as exc:
         typer.echo(f"digest extract axes failed: {exc}", err=True)
         raise typer.Exit(code=1) from exc
-    typer.echo(json.dumps({"positioning": str(path), "axes": axes}, indent=2))
+    # Reported absolute whichever branch resolved it: a consumer keying or
+    # diffing runs must not see two shapes for one document.
+    typer.echo(json.dumps({"positioning": str(path.resolve()), "axes": axes}, indent=2))
     raise typer.Exit(code=0)
 
 
@@ -2312,12 +2319,13 @@ def extract_record(
         against; inferred from the cwd when omitted.
     :param positioning: An explicit positioning document, overriding the layout.
     :param log_dir: Directory for the accountability log; the layout's
-        ``defend-log`` when omitted. Not a cwd-relative default: this command is
-        meant to be run from inside a paper directory, where one would put the
-        run's evidence somewhere no reviewer would look for it.
+        ``defend-log`` when omitted. The default comes from the layout rather
+        than the cwd because this command is meant to be run from inside a paper
+        directory, and a cwd-relative default would bury the run's evidence
+        there, where no reviewer would look for it.
     :raises typer.Exit: Code 0 when every paper was recorded; code 1 when
-        anything was rejected or the input, matrix or config is unusable; code 2
-        if the paper cannot be resolved.
+        anything was rejected, a write failed, or the input, matrix or config is
+        unusable; code 2 if the paper cannot be resolved.
     """
     config, layout, path = _positioning_context(paper, positioning)
     log_root = (
@@ -2337,9 +2345,10 @@ def extract_record(
     accepted, rejections = extraction_mod.validate(parsed, axes, patterns)
     date = date_cls.today().isoformat()
     recorded: list[dict[str, Any]] = []
-    try:
-        for citekey, paper_cells in sorted(accepted.items()):
-            artifact = layout.digest(citekey)
+    errors: list[dict[str, str]] = []
+    for citekey, paper_cells in sorted(accepted.items()):
+        artifact = layout.digest(citekey)
+        try:
             # `init` does not scaffold literature/digests/ — the first recorded
             # paper creates it.
             artifact.parent.mkdir(parents=True, exist_ok=True)
@@ -2351,39 +2360,45 @@ def extract_record(
                 log_dir=log_root,
                 date=date,
             )
-            recorded.append(
-                {
-                    "citekey": citekey,
-                    "artifact": str(artifact),
-                    "cells": len(paper_cells),
-                    "not_addressed": sum(
-                        1
-                        for c in paper_cells
-                        if c.value == extraction_mod.NOT_ADDRESSED
-                    ),
-                    "log_entry": str(log_entry),
-                }
+        except (extraction_mod.ExtractionError, OSError) as exc:
+            # The sweep continues and the report is still emitted. Aborting here
+            # would leave the author knowing only that *something* failed, while
+            # some papers had already landed — and re-running the whole batch to
+            # find out would append a second log entry for each of those.
+            typer.echo(f"digest extract record failed for {citekey}: {exc}", err=True)
+            errors.append(
+                {"citekey": citekey, "artifact": str(artifact), "reason": str(exc)}
             )
-    except (extraction_mod.ExtractionError, OSError) as exc:
-        typer.echo(f"digest extract record failed: {exc}", err=True)
-        raise typer.Exit(code=1) from exc
+            continue
+        recorded.append(
+            {
+                "citekey": citekey,
+                "artifact": str(artifact),
+                "cells": len(paper_cells),
+                "not_addressed": sum(
+                    1 for c in paper_cells if c.value == extraction_mod.NOT_ADDRESSED
+                ),
+                "log_entry": str(log_entry),
+            }
+        )
 
     for rejection in rejections:
         typer.echo(extraction_mod.render_rejection(rejection), err=True)
     typer.echo(
         json.dumps(
             {
-                "ok": not rejections,
-                "positioning": str(path),
+                "ok": not (rejections or errors),
+                "positioning": str(path.resolve()),
                 "axes": axes,
                 "recorded": recorded,
                 "rejected": [dataclasses.asdict(r) for r in rejections],
+                "errors": errors,
                 "not_addressed": sum(r["not_addressed"] for r in recorded),
             },
             indent=2,
         )
     )
-    raise typer.Exit(code=1 if rejections else 0)
+    raise typer.Exit(code=1 if rejections or errors else 0)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -2537,9 +2537,12 @@ def _apply_verdict(
     """Write the human's verdict onto **every** member of the batch (spec §8).
 
     Unsampled members included: the verdict is a finding about the population
-    the sample was drawn from. Only the drawn papers get a check log entry —
-    they are the only ones a human actually looked at, and logging a check that
-    did not happen would forge the evidence trail.
+    the sample was drawn from. The drawn papers additionally get
+    ``in-sample: true`` and a check-log entry — they are the only ones a human
+    actually looked at, and claiming a check that did not happen, in either
+    place, would forge the evidence trail. The two frontmatter keys are written
+    through separate calls precisely so they cannot drift into meaning one
+    thing (spec §5).
 
     A failure on one member is reported and the sweep continues; aborting would
     leave the batch half-marked with no report of which half.
@@ -2561,6 +2564,7 @@ def _apply_verdict(
             artifact_mod.set_batch_check(target, verdict, date=date)
             updated.append(key)
             if key in drawn_cells:
+                artifact_mod.set_in_sample(target, in_sample=True, date=date)
                 log_entries.append(
                     str(
                         artifact_mod.append_check_log(
@@ -2621,7 +2625,16 @@ def extract_sample(
     no cell. A process that produced one confidently-wrong cell in a sample of
     three probably produced more in the other thirty-seven, so the finding is
     about the batch; silently repairing the caught cell would convert that
-    signal into a tidy-looking local fix (spec §8).
+    signal into a tidy-looking local fix (spec §8). The drawn papers also get
+    ``in-sample: true``, which means *a human checked these cells* — which is
+    why the draw itself writes nothing: an unanswered draw has established
+    nothing about any paper.
+
+    The verdict call re-draws over the batch it is given, so **give it the same
+    batch and the same ``--size``**. Both are deterministic, so identical
+    arguments mark exactly the papers the draw reported; a different membership
+    set or ``--size`` is a different batch, and marks a different set of papers
+    as checked.
 
     Never writes ``status.understanding``. Extraction certifies located cells
     checked by sample, which is a weaker claim than verified comprehension.

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -32,6 +32,7 @@ from defendable_science.dataset import retrieval as retrieval_mod
 from defendable_science.defend import record as record_mod
 from defendable_science.digest import artifact as artifact_mod
 from defendable_science.digest import extraction as extraction_mod
+from defendable_science.digest import sampling as sampling_mod
 from defendable_science.exploration import backlog as backlog_mod
 from defendable_science.literature import acquire as acquire_mod
 from defendable_science.literature import graph as graph_mod
@@ -2441,6 +2442,276 @@ def extract_record(
         )
     )
     raise typer.Exit(code=1 if rejections or errors or triage_not_updated else 0)
+
+
+#: The verdicts a human may record on a sampled check. Deliberately not
+#: ``pending``: that is the state an extraction *starts* in, and letting this
+#: command write it would give the batch a way to quietly un-fail itself.
+_SAMPLE_VERDICTS = ("verified", "failed")
+
+
+def _extraction_batch(layout: Layout) -> tuple[list[str], list[dict[str, str]]]:
+    """Collect every digest artifact that records an extraction (ruling AL).
+
+    A digest with no ``status.extraction`` block was never extracted — a
+    depth-mode reading record is the common case — so it is not part of an
+    extraction batch and gets no verdict. An artifact that cannot be *read* is
+    reported instead of skipped: excluding it silently would let a corrupt file
+    shrink the population the sample is drawn from.
+
+    :param layout: The resolved layout, which owns the digests directory.
+    :returns: The batch's citekeys, and one error entry per unreadable artifact.
+    """
+    members: list[str] = []
+    errors: list[dict[str, str]] = []
+    for path in sorted(layout.digests_dir.glob("*.md")):
+        try:
+            if artifact_mod.has_extraction(path):
+                members.append(path.stem)
+        except (extraction_mod.ExtractionError, OSError) as exc:
+            typer.echo(f"digest extract sample failed for {path.stem}: {exc}", err=True)
+            errors.append(
+                {"citekey": path.stem, "artifact": str(path), "reason": str(exc)}
+            )
+    return members, errors
+
+
+def _note_error(
+    errors: list[dict[str, str]], citekey: str, artifact: Path, reason: str
+) -> None:
+    """Append an error entry unless this exact fact is already reported.
+
+    A missing artifact fails both the cell read and the verdict write with the
+    same message; reporting it twice would suggest two problems.
+    """
+    entry = {"citekey": citekey, "artifact": str(artifact), "reason": reason}
+    if entry not in errors:
+        typer.echo(f"digest extract sample failed for {citekey}: {reason}", err=True)
+        errors.append(entry)
+
+
+def _read_sampled_cells(
+    layout: Layout, sample: list[str], errors: list[dict[str, str]]
+) -> tuple[dict[str, list[extraction_mod.Cell]], list[dict[str, Any]]]:
+    """Read each drawn paper's cells — what the human is asked to check.
+
+    The report carries the axis, the value and the locator for every cell,
+    because the question the human answers is *does the source at that locator
+    actually say this?* (spec §8). A paper whose cells cannot be read is an
+    error, never an empty cell list: "nothing to check here" is the one answer
+    an unreadable artifact must not produce.
+
+    :param layout: The resolved layout, which owns the artifact paths.
+    :param sample: The drawn citekeys.
+    :param errors: The run's error list, appended to in place.
+    :returns: The cells per drawn paper, and the report's ``sampled`` entries.
+    """
+    drawn_cells: dict[str, list[extraction_mod.Cell]] = {}
+    sampled: list[dict[str, Any]] = []
+    for key in sample:
+        target = layout.digest(key)
+        try:
+            drawn_cells[key] = artifact_mod.read_cells(target)
+        except (extraction_mod.ExtractionError, OSError) as exc:
+            _note_error(errors, key, target, str(exc))
+            continue
+        sampled.append(
+            {
+                "citekey": key,
+                "artifact": str(target),
+                "cells": [dataclasses.asdict(c) for c in drawn_cells[key]],
+            }
+        )
+    return drawn_cells, sampled
+
+
+def _apply_verdict(
+    layout: Layout,
+    members: list[str],
+    *,
+    verdict: str,
+    drawn_cells: dict[str, list[extraction_mod.Cell]],
+    log_root: Path,
+    errors: list[dict[str, str]],
+) -> tuple[list[str], list[str]]:
+    """Write the human's verdict onto **every** member of the batch (spec §8).
+
+    Unsampled members included: the verdict is a finding about the population
+    the sample was drawn from. Only the drawn papers get a check log entry —
+    they are the only ones a human actually looked at, and logging a check that
+    did not happen would forge the evidence trail.
+
+    A failure on one member is reported and the sweep continues; aborting would
+    leave the batch half-marked with no report of which half.
+
+    :param layout: The resolved layout.
+    :param members: Every citekey in the batch.
+    :param verdict: The verdict to write.
+    :param drawn_cells: The cells read for each sampled paper.
+    :param log_root: The accountability-log directory.
+    :param errors: The run's error list, appended to in place.
+    :returns: The citekeys updated, and the log entries written.
+    """
+    date = date_cls.today().isoformat()
+    updated: list[str] = []
+    log_entries: list[str] = []
+    for key in members:
+        target = layout.digest(key)
+        try:
+            artifact_mod.set_batch_check(target, verdict, date=date)
+            updated.append(key)
+            if key in drawn_cells:
+                log_entries.append(
+                    str(
+                        artifact_mod.append_check_log(
+                            target,
+                            key,
+                            drawn_cells[key],
+                            verdict=verdict,
+                            batch=members,
+                            log_dir=log_root,
+                            date=date,
+                        )
+                    )
+                )
+        except (extraction_mod.ExtractionError, OSError) as exc:
+            _note_error(errors, key, target, str(exc))
+    return updated, log_entries
+
+
+@extract.command(name="sample")
+def extract_sample(
+    citekey: Annotated[
+        list[str] | None,
+        typer.Option("--citekey", help="A batch member; repeatable."),
+    ] = None,
+    all_papers: Annotated[
+        bool,
+        typer.Option("--all", help="Every digest carrying a status.extraction block."),
+    ] = False,
+    size: Annotated[
+        int | None,
+        typer.Option("--size", help="How many papers to draw; max(3, 10%) by default."),
+    ] = None,
+    verdict: Annotated[
+        str | None,
+        typer.Option(
+            "--verdict",
+            help="Record the human's verdict on the batch: verified | failed.",
+        ),
+    ] = None,
+    log_dir: Annotated[
+        str | None,
+        typer.Option(
+            "--log-dir", help="Accountability log; from the layout if omitted."
+        ),
+    ] = None,
+) -> None:
+    """Draw the batch's deterministic sample, and record the human's verdict.
+
+    Two invocations, on purpose. The first draws — the same papers for the same
+    batch, in this process and every future one, so nobody can re-roll until an
+    easy sample comes up (spec §3.5) — and reports each drawn paper's cells with
+    their locators, which is exactly what the human is asked to check them
+    against. Nothing is written. The second passes ``--verdict`` over the same
+    batch and records the answer. The questioning itself is the skill's job: a
+    CLI prompt would put the agent between the human and the sources.
+
+    A ``failed`` verdict lands on **every** member, sampled or not, and touches
+    no cell. A process that produced one confidently-wrong cell in a sample of
+    three probably produced more in the other thirty-seven, so the finding is
+    about the batch; silently repairing the caught cell would convert that
+    signal into a tidy-looking local fix (spec §8).
+
+    Never writes ``status.understanding``. Extraction certifies located cells
+    checked by sample, which is a weaker claim than verified comprehension.
+
+    :param citekey: A batch member, repeatable. Mutually exclusive with
+        ``--all``, and exactly one of the two is required.
+    :param all_papers: Take the batch to be every digest artifact carrying a
+        ``status.extraction`` block.
+    :param size: How many papers to draw; ``max(3, 10%)`` of the batch by
+        default — a convention, not a statistical guarantee (spec §14).
+    :param verdict: ``verified`` or ``failed``; omitted, the command only draws.
+    :param log_dir: Directory for the accountability log; the layout's
+        ``defend-log`` when omitted — anchored to the layout, never the cwd, so
+        the run's evidence lands where a reviewer looks for it.
+    :raises typer.Exit: Code 0 when the sample was drawn (and, with
+        ``--verdict``, recorded on every member); code 1 when the batch is
+        empty or any member could not be read or updated; code 2 on a usage
+        error.
+    """
+    if bool(citekey) == all_papers:
+        raise typer.BadParameter(
+            "give exactly one of --citekey (repeatable) or --all: the batch is "
+            "what the sample is drawn from and what a verdict applies to, so it "
+            "cannot be guessed"
+        )
+    if verdict is not None and verdict not in _SAMPLE_VERDICTS:
+        raise typer.BadParameter(
+            f"--verdict must be one of {list(_SAMPLE_VERDICTS)}, got {verdict!r}"
+        )
+    if size is not None and size < 1:
+        raise typer.BadParameter("--size must be at least 1")
+
+    _config, layout = _layout_or_exit()
+    if all_papers:
+        members, errors = _extraction_batch(layout)
+    else:
+        members, errors = sorted(set(citekey or [])), []
+    log_root = (
+        Path(log_dir)
+        if log_dir is not None
+        else layout.research_root / artifact_mod.DEFAULT_LOG_DIR.name
+    )
+
+    sample: list[str] = []
+    if members:
+        sample = sampling_mod.select_sample(
+            members,
+            size if size is not None else sampling_mod.default_size(len(members)),
+        )
+    else:
+        # Not a passed sample of size zero: no paper was checked, and saying so
+        # is the whole point of the command.
+        typer.echo(
+            f"digest extract sample failed: no extracted papers under "
+            f"{layout.digests_dir} — nothing was sampled and nothing was "
+            "checked; run `digest extract record` first",
+            err=True,
+        )
+    drawn_cells, sampled = _read_sampled_cells(layout, sample, errors)
+
+    updated: list[str] = []
+    log_entries: list[str] = []
+    if verdict is not None:
+        updated, log_entries = _apply_verdict(
+            layout,
+            members,
+            verdict=verdict,
+            drawn_cells=drawn_cells,
+            log_root=log_root,
+            errors=errors,
+        )
+
+    ok = bool(members) and not errors
+    typer.echo(
+        json.dumps(
+            {
+                "ok": ok,
+                "batch": members,
+                "size": len(sample),
+                "sample": sample,
+                "verdict": verdict,
+                "sampled": sampled,
+                "updated": updated,
+                "log_entries": log_entries,
+                "errors": errors,
+            },
+            indent=2,
+        )
+    )
+    raise typer.Exit(code=0 if ok else 1)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/defendable-science/defendable_science/core/frontmatter.py
+++ b/defendable-science/defendable_science/core/frontmatter.py
@@ -1,0 +1,96 @@
+"""Host-preserving YAML-frontmatter editing for markdown artifacts.
+
+An artifact's frontmatter is a human's file: it carries comments, key order and
+whitespace that the person who wrote it chose. These helpers set one key under
+the ``status:`` block and leave every other byte alone — the same posture
+:mod:`defendable_science.core.mdtable` takes toward the table inside a document.
+
+Promoted here (unchanged) from ``defend/record.py`` when ``digest`` extraction
+needed the same editing without importing another front-end's private helpers,
+exactly as ``core/fixity.py``, ``core/mirror.py``, ``core/download.py`` and
+``core/mdtable.py`` were promoted before it.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+class FrontmatterError(ValueError):
+    """Raised when a document's YAML frontmatter is missing or malformed."""
+
+
+def split_frontmatter(text: str) -> tuple[list[str], list[str]]:
+    """Split a markdown doc into (frontmatter lines, body lines).
+
+    :param text: The document's markdown content.
+    :returns: The frontmatter lines (without the ``---`` fences) and the body
+        lines.
+    :raises FrontmatterError: If there is no terminated ``---`` frontmatter
+        block.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise FrontmatterError("artifact has no YAML frontmatter")
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return lines[1:i], lines[i + 1 :]
+    raise FrontmatterError("artifact has an unterminated frontmatter block")
+
+
+def rebuild(fm_lines: list[str], body_lines: list[str]) -> str:
+    """Reassemble a document from frontmatter and body lines.
+
+    :param fm_lines: The frontmatter lines, without their ``---`` fences.
+    :param body_lines: The body lines.
+    :returns: The reassembled document, newline-terminated.
+    """
+    parts = ["---", *fm_lines, "---", *body_lines]
+    return "\n".join(parts) + "\n"
+
+
+def set_field(fm_lines: list[str], key: str, value: str) -> list[str]:
+    """Set ``status.<key>`` to `value`, preserving any trailing comment.
+
+    Replaces the existing line if present; otherwise inserts it directly under
+    the ``status:`` block. Indentation is taken from the block's children.
+
+    :param fm_lines: The frontmatter lines (mutated copy returned).
+    :param key: The child key under ``status:`` (e.g. ``understanding``).
+    :param value: The rendered YAML value.
+    :returns: The updated frontmatter lines.
+    :raises FrontmatterError: If there is no ``status:`` block.
+    """
+    lines = list(fm_lines)
+    status_idx = next(
+        (i for i, ln in enumerate(lines) if re.match(r"^status:\s*$", ln)), None
+    )
+    if status_idx is None:
+        raise FrontmatterError("artifact frontmatter has no 'status:' block")
+
+    child_indent = "  "
+    for ln in lines[status_idx + 1 :]:
+        if ln.strip() and (stripped_indent := len(ln) - len(ln.lstrip())) > 0:
+            child_indent = " " * stripped_indent
+            break
+
+    key_pat = re.compile(rf"^{re.escape(child_indent)}{re.escape(key)}:\s*(.*)$")
+    for i in range(status_idx + 1, len(lines)):
+        line = lines[i]
+        # Stop at a dedent back to top level (end of the status block).
+        if line.strip() and not line.startswith(child_indent):
+            break
+        match = key_pat.match(line)
+        if match:
+            # A YAML comment needs whitespace before '#' (or the value is entirely
+            # a comment); a '#' *inside* a value is not a comment delimiter.
+            raw_value = match.group(1)
+            comment = ""
+            cmatch = re.search(r"\s#(.*)$", f" {raw_value}")
+            if cmatch:
+                comment = f"  # {cmatch.group(1).strip()}"
+            lines[i] = f"{child_indent}{key}: {value}{comment}"
+            return lines
+
+    lines.insert(status_idx + 1, f"{child_indent}{key}: {value}")
+    return lines

--- a/defendable-science/defendable_science/core/frontmatter.py
+++ b/defendable-science/defendable_science/core/frontmatter.py
@@ -106,7 +106,7 @@ def set_field(fm_lines: list[str], key: str, value: str) -> list[str]:
     inline (``key: {…}``) or as an indented **block mapping** underneath, which
     is how a human following a documented example writes it. Replacing only the
     ``key:`` line of a block mapping would orphan its children and leave the
-    frontmatter unparseable, so the whole value goes. Otherwise the key is
+    frontmatter unparsable, so the whole value goes. Otherwise the key is
     inserted directly under the ``status:`` block. Indentation is taken from
     the block's children.
 

--- a/defendable-science/defendable_science/core/frontmatter.py
+++ b/defendable-science/defendable_science/core/frontmatter.py
@@ -73,6 +73,14 @@ def _block_value_extent(lines: list[str], start: int, child_indent: str) -> int:
     whatever more-indented lines follow it. Blank lines inside the block are
     consumed; blank lines *after* it are not, so a reader's spacing survives.
 
+    A **comment-only** line is not a dedent, whatever column it sits at: YAML
+    allows a comment anywhere, and aligning a note flush-left or with the
+    parent key is ordinary. Treating one as the end of the block would stop the
+    scan short and let :func:`set_field` replace only part of the value —
+    orphaning the rest, which is the corruption this function exists to
+    prevent. Skipping it instead carries the scan on and puts the comment
+    inside the span, where `set_field`'s refusal sees it.
+
     :param lines: The frontmatter lines.
     :param start: Index of the ``key:`` line.
     :param child_indent: The indentation of ``status:``'s own children.
@@ -82,7 +90,8 @@ def _block_value_extent(lines: list[str], start: int, child_indent: str) -> int:
     i = start + 1
     while i < len(lines):
         line = lines[i]
-        if line.strip():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
             if len(line) - len(line.lstrip()) <= len(child_indent):
                 break
             end = i + 1
@@ -106,10 +115,12 @@ def set_field(fm_lines: list[str], key: str, value: str) -> list[str]:
     :param value: The rendered YAML value.
     :returns: The updated frontmatter lines.
     :raises FrontmatterError: If there is no ``status:`` block, or if the block
-        mapping being replaced carries a comment. A comment on a value this
-        call is about to overwrite cannot be round-tripped, and destroying a
-        human's annotation silently is the failure `patch_triage` refuses for
-        the same reason.
+        mapping being replaced carries a line that reads as a comment. A
+        comment on a value this call is about to overwrite cannot be
+        round-tripped, and destroying a human's annotation silently is the
+        failure `patch_triage` refuses for the same reason. The test is
+        textual, so a nested scalar containing ``" #"`` is refused too — the
+        safe direction, and the message says which line and what to do.
     """
     lines = list(fm_lines)
     status_idx = next(
@@ -127,8 +138,16 @@ def set_field(fm_lines: list[str], key: str, value: str) -> list[str]:
     key_pat = re.compile(rf"^{re.escape(child_indent)}{re.escape(key)}:\s*(.*)$")
     for i in range(status_idx + 1, len(lines)):
         line = lines[i]
-        # Stop at a dedent back to top level (end of the status block).
-        if line.strip() and not line.startswith(child_indent):
+        stripped = line.strip()
+        # Stop at a dedent back to top level (end of the status block) — but a
+        # comment-only line is not a dedent at any column. Ending the search on
+        # one would miss a key that follows it and insert a second copy, and a
+        # duplicate key silently shadows the value just written.
+        if (
+            stripped
+            and not stripped.startswith("#")
+            and not line.startswith(child_indent)
+        ):
             break
         match = key_pat.match(line)
         if match:
@@ -137,10 +156,12 @@ def set_field(fm_lines: list[str], key: str, value: str) -> list[str]:
             annotated = [ln for ln in lines[i + 1 : end] if _split_comment(ln)[1]]
             if annotated:
                 raise FrontmatterError(
-                    f"'status.{key}' is a block mapping carrying a comment "
-                    f"({annotated[0].strip()!r}), and this write replaces the "
-                    "whole value — move the note onto the "
-                    f"'{key}:' line or remove it, then re-run"
+                    f"'status.{key}' is a block mapping and this write replaces "
+                    f"the whole value, but the line {annotated[0].strip()!r} "
+                    "reads as carrying a comment, which cannot be carried over. "
+                    f"Move the note onto the '{key}:' line or delete it; if that "
+                    "'#' is part of a value rather than a comment, quote the "
+                    "value. Then re-run"
                 )
             lines[i:end] = [f"{child_indent}{key}: {value}{comment}"]
             return lines

--- a/defendable-science/defendable_science/core/frontmatter.py
+++ b/defendable-science/defendable_science/core/frontmatter.py
@@ -49,17 +49,67 @@ def rebuild(fm_lines: list[str], body_lines: list[str]) -> str:
     return "\n".join(parts) + "\n"
 
 
+def _split_comment(raw_value: str) -> tuple[str, str]:
+    """Split a YAML value's text from its trailing comment.
+
+    A YAML comment needs whitespace before ``#`` (or the value is entirely a
+    comment); a ``#`` *inside* a value is not a comment delimiter.
+
+    :param raw_value: Everything after ``key:`` on the line.
+    :returns: The value text (stripped), and the rendered trailing comment
+        (``""`` when there is none).
+    """
+    padded = f" {raw_value}"
+    cmatch = re.search(r"\s#(.*)$", padded)
+    if cmatch is None:
+        return raw_value.strip(), ""
+    return padded[: cmatch.start()].strip(), f"  # {cmatch.group(1).strip()}"
+
+
+def _block_value_extent(lines: list[str], start: int, child_indent: str) -> int:
+    """Return the index one past the block mapping nested under ``lines[start]``.
+
+    ``lines[start]`` is a ``key:`` line whose value is empty, so the value is
+    whatever more-indented lines follow it. Blank lines inside the block are
+    consumed; blank lines *after* it are not, so a reader's spacing survives.
+
+    :param lines: The frontmatter lines.
+    :param start: Index of the ``key:`` line.
+    :param child_indent: The indentation of ``status:``'s own children.
+    :returns: The exclusive end index of the key's value.
+    """
+    end = start + 1
+    i = start + 1
+    while i < len(lines):
+        line = lines[i]
+        if line.strip():
+            if len(line) - len(line.lstrip()) <= len(child_indent):
+                break
+            end = i + 1
+        i += 1
+    return end
+
+
 def set_field(fm_lines: list[str], key: str, value: str) -> list[str]:
     """Set ``status.<key>`` to `value`, preserving any trailing comment.
 
-    Replaces the existing line if present; otherwise inserts it directly under
-    the ``status:`` block. Indentation is taken from the block's children.
+    Replaces the existing value if the key is present — whether it was written
+    inline (``key: {…}``) or as an indented **block mapping** underneath, which
+    is how a human following a documented example writes it. Replacing only the
+    ``key:`` line of a block mapping would orphan its children and leave the
+    frontmatter unparseable, so the whole value goes. Otherwise the key is
+    inserted directly under the ``status:`` block. Indentation is taken from
+    the block's children.
 
     :param fm_lines: The frontmatter lines (mutated copy returned).
     :param key: The child key under ``status:`` (e.g. ``understanding``).
     :param value: The rendered YAML value.
     :returns: The updated frontmatter lines.
-    :raises FrontmatterError: If there is no ``status:`` block.
+    :raises FrontmatterError: If there is no ``status:`` block, or if the block
+        mapping being replaced carries a comment. A comment on a value this
+        call is about to overwrite cannot be round-tripped, and destroying a
+        human's annotation silently is the failure `patch_triage` refuses for
+        the same reason.
     """
     lines = list(fm_lines)
     status_idx = next(
@@ -82,14 +132,17 @@ def set_field(fm_lines: list[str], key: str, value: str) -> list[str]:
             break
         match = key_pat.match(line)
         if match:
-            # A YAML comment needs whitespace before '#' (or the value is entirely
-            # a comment); a '#' *inside* a value is not a comment delimiter.
-            raw_value = match.group(1)
-            comment = ""
-            cmatch = re.search(r"\s#(.*)$", f" {raw_value}")
-            if cmatch:
-                comment = f"  # {cmatch.group(1).strip()}"
-            lines[i] = f"{child_indent}{key}: {value}{comment}"
+            value_text, comment = _split_comment(match.group(1))
+            end = i + 1 if value_text else _block_value_extent(lines, i, child_indent)
+            annotated = [ln for ln in lines[i + 1 : end] if _split_comment(ln)[1]]
+            if annotated:
+                raise FrontmatterError(
+                    f"'status.{key}' is a block mapping carrying a comment "
+                    f"({annotated[0].strip()!r}), and this write replaces the "
+                    "whole value — move the note onto the "
+                    f"'{key}:' line or remove it, then re-run"
+                )
+            lines[i:end] = [f"{child_indent}{key}: {value}{comment}"]
             return lines
 
     lines.insert(status_idx + 1, f"{child_indent}{key}: {value}")

--- a/defendable-science/defendable_science/core/mdtable.py
+++ b/defendable-science/defendable_science/core/mdtable.py
@@ -17,6 +17,46 @@ Row = dict[str, str]
 #: A markdown heading of any level, with its title text.
 _HEADING = re.compile(r"^#{1,6}\s+(?P<title>.+?)\s*$")
 
+#: A CommonMark fenced-code-block marker: up to three spaces of indent, then at
+#: least three backticks or tildes, then the info string.
+_FENCE = re.compile(r"^ {0,3}(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
+
+
+def _fenced(lines: list[str]) -> list[bool]:
+    """Return, per line, whether it belongs to a fenced code block.
+
+    A document that *illustrates* a table inside a code fence is entirely
+    ordinary, and without this the illustration is indistinguishable from the
+    real table — :func:`parse_document` would select it and :func:`splice`
+    would then overwrite the author's example (the #94 failure class through a
+    different door). The fence markers themselves count as inside, so nothing
+    in the block is ever read as content.
+
+    Closing follows CommonMark: the same character as the opening fence, at
+    least as long, and no info string. An unclosed fence runs to the end.
+
+    :param lines: The document's lines.
+    :returns: One flag per line, ``True`` when the line is fenced.
+    """
+    mask = [False] * len(lines)
+    marker: str | None = None
+    for i, line in enumerate(lines):
+        match = _FENCE.match(line.rstrip("\n"))
+        if marker is None:
+            if match is not None:
+                marker = match.group("fence")
+                mask[i] = True
+            continue
+        mask[i] = True
+        if (
+            match is not None
+            and match.group("fence")[0] == marker[0]
+            and len(match.group("fence")) >= len(marker)
+            and not match.group("info").strip()
+        ):
+            marker = None
+    return mask
+
 
 class TableError(ValueError):
     """Raised when a document's table is malformed (a ragged data row)."""
@@ -116,7 +156,9 @@ def _collect_rows(
     return rows, end
 
 
-def _section_bounds(lines: list[str], title: str) -> tuple[int, int] | None:
+def _section_bounds(
+    lines: list[str], title: str, fenced: list[bool]
+) -> tuple[int, int] | None:
     """Return ``(start, end)`` line indices for the section under `title`.
 
     The section runs from the line after its heading to the line before the
@@ -124,11 +166,16 @@ def _section_bounds(lines: list[str], title: str) -> tuple[int, int] | None:
 
     :param lines: The document's lines.
     :param title: The heading text to find, compared case-insensitively.
+    :param fenced: Per-line fence flags from :func:`_fenced`; a ``#``-prefixed
+        line inside a code block is a comment or a shell prompt, not a heading,
+        and must neither open nor close a section.
     :returns: The bounds, or ``None`` when no such heading exists.
     """
     want = title.strip().casefold()
     start: int | None = None
     for i, line in enumerate(lines):
+        if fenced[i]:
+            continue
         match = _HEADING.match(line)
         if match is None:
             continue
@@ -159,9 +206,10 @@ def parse_document(
     :raises TableError: If a data row is ragged (see :func:`_collect_rows`).
     """
     lines = text.splitlines(keepends=True)
+    fenced = _fenced(lines)
     window = (0, len(lines))
     if under_heading is not None:
-        bounds = _section_bounds(lines, under_heading)
+        bounds = _section_bounds(lines, under_heading, fenced)
         if bounds is None:
             return Document(preamble=text)
         window = bounds
@@ -171,7 +219,9 @@ def parse_document(
     saw_table_shape = False
     for offset, line in enumerate(lines[window[0] : window[1]]):
         i = window[0] + offset
-        if "|" not in line:
+        if fenced[i] or "|" not in line:
+            # Fenced content is an illustration, not the document's table; it
+            # breaks a pending candidate exactly as prose does.
             candidate = None  # prose breaks a pending header candidate
             pending = 0
             continue

--- a/defendable-science/defendable_science/core/mdtable.py
+++ b/defendable-science/defendable_science/core/mdtable.py
@@ -208,6 +208,71 @@ def _section_bounds(
     return start, end
 
 
+def _scan_window(
+    lines: list[str],
+    fenced: list[bool],
+    window: tuple[int, int],
+    row_label: str,
+    *,
+    first_only: bool,
+) -> tuple[Document | None, list[int], bool]:
+    """Locate the separator-confirmed tables in `window`.
+
+    :param lines: The document's lines.
+    :param fenced: Per-line fence flags from :func:`_fenced`.
+    :param window: The half-open line range to search.
+    :param row_label: What to call a row in a ragged-row error message.
+    :param first_only: Stop at the first table found. What an unwindowed caller
+        wants, and not merely an optimisation: scanning on would raise on a
+        ragged row in some *later*, unrelated table the caller never asked
+        about.
+    :returns: The first table (or ``None``), the line index of every confirmed
+        header, and whether table-like rows were seen without a separator.
+    :raises TableError: If a data row of a scanned table is ragged.
+    """
+    candidate: list[str] | None = None
+    candidate_at = 0
+    pending = 0  # consecutive unconfirmed pipe rows (a table shape sans separator)
+    saw_table_shape = False
+    found: Document | None = None
+    header_lines: list[int] = []
+    i = window[0]
+    while i < window[1]:
+        if fenced[i] or "|" not in lines[i]:
+            # Fenced content is an illustration, not the document's table; it
+            # breaks a pending candidate exactly as prose does.
+            candidate = None  # prose breaks a pending header candidate
+            pending = 0
+            i += 1
+            continue
+        cells = split_cells(lines[i])
+        if not is_separator(cells):
+            candidate, candidate_at = cells, i  # a header only if a separator follows
+            pending += 1
+            if pending >= 2:  # header + row(s) shape with no separator between
+                saw_table_shape = True
+            i += 1
+            continue
+        if candidate is None:
+            i += 1
+            continue
+        rows, end = _collect_rows(lines, candidate, i + 1, window[1], row_label)
+        header_lines.append(candidate_at)
+        if found is None:
+            found = Document(
+                preamble="".join(lines[:candidate_at]),
+                header=candidate,
+                rows=rows,
+                postamble="".join(lines[end:]),
+            )
+            if first_only:
+                break
+        candidate = None
+        pending = 0
+        i = end  # the rows belong to that table, not to the next candidate
+    return found, header_lines, saw_table_shape
+
+
 def parse_document(
     text: str, *, under_heading: str | None = None, row_label: str = "table"
 ) -> Document:
@@ -225,9 +290,10 @@ def parse_document(
     :param row_label: What to call a row in a ragged-row error message.
     :returns: The located document; ``header`` is ``None`` when the window holds
         no table, in which case `preamble` is the whole of `text`.
-    :raises TableError: If a data row is ragged (see :func:`_collect_rows`), or
-        if `under_heading` matches more than one heading
-        (`AmbiguousSectionError`, see :func:`_section_bounds`).
+    :raises TableError: If a data row is ragged (see :func:`_collect_rows`); or,
+        for a call that named a section, if `under_heading` matches more than
+        one heading or that section holds more than one table
+        (`AmbiguousSectionError`).
     """
     lines = text.splitlines(keepends=True)
     fenced = _fenced(lines)
@@ -237,34 +303,28 @@ def parse_document(
         if bounds is None:
             return Document(preamble=text)
         window = bounds
-    candidate: list[str] | None = None
-    candidate_at = 0
-    pending = 0  # consecutive unconfirmed pipe rows (a table shape sans separator)
-    saw_table_shape = False
-    for offset, line in enumerate(lines[window[0] : window[1]]):
-        i = window[0] + offset
-        if fenced[i] or "|" not in line:
-            # Fenced content is an illustration, not the document's table; it
-            # breaks a pending candidate exactly as prose does.
-            candidate = None  # prose breaks a pending header candidate
-            pending = 0
-            continue
-        cells = split_cells(line)
-        if is_separator(cells):
-            if candidate is None:
-                continue
-            rows, end = _collect_rows(lines, candidate, i + 1, window[1], row_label)
-            return Document(
-                preamble="".join(lines[:candidate_at]),
-                header=candidate,
-                rows=rows,
-                postamble="".join(lines[end:]),
-            )
-        candidate, candidate_at = cells, i  # a header only if a separator follows
-        pending += 1
-        if pending >= 2:  # header + row(s) shape with no separator between
-            saw_table_shape = True
-    return Document(preamble=text, saw_table_shape=saw_table_shape)
+    # An unwindowed call legitimately meets many tables — a backlog's prose
+    # routinely holds more than one — so the first confirmed table is the
+    # answer, as it has always been. Only a caller that named a section is
+    # saying "I mean one specific table", and only there can a second one be
+    # ambiguous.
+    found, header_lines, saw_table_shape = _scan_window(
+        lines, fenced, window, row_label, first_only=under_heading is None
+    )
+    if found is None:
+        return Document(preamble=text, saw_table_shape=saw_table_shape)
+    if len(header_lines) > 1:
+        # The caller named a section because it means one specific table, and
+        # `splice` would write into whichever this returned. A legend above the
+        # matrix is ordinary authoring, and silently overwriting it while
+        # leaving the matrix untouched is the worst outcome available.
+        raise AmbiguousSectionError(
+            f"the {under_heading!r} section holds {len(header_lines)} tables "
+            f"(headers at lines {[n + 1 for n in header_lines]}) — which one is "
+            "meant cannot be guessed; keep one table in the section, or move "
+            "the others under a heading of their own"
+        )
+    return found
 
 
 def render_table(header: list[str], rows: list[Row]) -> str:

--- a/defendable-science/defendable_science/core/mdtable.py
+++ b/defendable-science/defendable_science/core/mdtable.py
@@ -62,6 +62,16 @@ class TableError(ValueError):
     """Raised when a document's table is malformed (a ragged data row)."""
 
 
+class AmbiguousSectionError(TableError):
+    """Raised when `under_heading` matches more than one heading.
+
+    A distinct type, not a distinct message, so a caller can offer the remedy
+    that fits — "merge the duplicate sections" is nothing like "give every row
+    one cell per header column". Subclasses `TableError` so every existing
+    ``except TableError`` keeps catching it.
+    """
+
+
 def escape_cell(cell: str) -> str:
     """Escape a cell for a markdown table (newlines and pipes)."""
     return cell.replace("\\", "\\\\").replace("|", r"\|").replace("\n", " ")
@@ -170,20 +180,32 @@ def _section_bounds(
         line inside a code block is a comment or a shell prompt, not a heading,
         and must neither open nor close a section.
     :returns: The bounds, or ``None`` when no such heading exists.
+    :raises AmbiguousSectionError: If more than one heading carries `title`.
+        Which of them is *the* section is unknowable, and taking the first
+        would let a caller write its table into a section it never meant —
+        silently, since the document parses perfectly well either way.
     """
     want = title.strip().casefold()
-    start: int | None = None
+    headings: list[tuple[int, str]] = []
     for i, line in enumerate(lines):
         if fenced[i]:
             continue
         match = _HEADING.match(line)
-        if match is None:
-            continue
-        if start is not None:
-            return start, i
-        if match.group("title").strip().casefold() == want:
-            start = i + 1
-    return None if start is None else (start, len(lines))
+        if match is not None:
+            headings.append((i, match.group("title").strip().casefold()))
+    matches = [i for i, heading in enumerate(headings) if heading[1] == want]
+    if len(matches) > 1:
+        raise AmbiguousSectionError(
+            f"{title!r} names {len(matches)} headings in this document (lines "
+            f"{[headings[i][0] + 1 for i in matches]}) — which section is "
+            "meant cannot be guessed; merge them, or rename all but one"
+        )
+    if not matches:
+        return None
+    at = matches[0]
+    start = headings[at][0] + 1
+    end = headings[at + 1][0] if at + 1 < len(headings) else len(lines)
+    return start, end
 
 
 def parse_document(
@@ -203,7 +225,9 @@ def parse_document(
     :param row_label: What to call a row in a ragged-row error message.
     :returns: The located document; ``header`` is ``None`` when the window holds
         no table, in which case `preamble` is the whole of `text`.
-    :raises TableError: If a data row is ragged (see :func:`_collect_rows`).
+    :raises TableError: If a data row is ragged (see :func:`_collect_rows`), or
+        if `under_heading` matches more than one heading
+        (`AmbiguousSectionError`, see :func:`_section_bounds`).
     """
     lines = text.splitlines(keepends=True)
     fenced = _fenced(lines)

--- a/defendable-science/defendable_science/core/mdtable.py
+++ b/defendable-science/defendable_science/core/mdtable.py
@@ -1,0 +1,223 @@
+"""Host-preserving markdown-table I/O (GFM), shared across front-ends.
+
+A table lives inside a document a human wrote. This module reads the table
+without losing the prose around it and writes it back without touching
+anything it did not author — the property issues #94 and #95 were filed for
+when an earlier writer discarded the host document and hardcoded a column
+schema. Columns are read from the file's own header, never assumed.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+Row = dict[str, str]
+
+#: A markdown heading of any level, with its title text.
+_HEADING = re.compile(r"^#{1,6}\s+(?P<title>.+?)\s*$")
+
+
+class TableError(ValueError):
+    """Raised when a document's table is malformed (a ragged data row)."""
+
+
+def escape_cell(cell: str) -> str:
+    """Escape a cell for a markdown table (newlines and pipes)."""
+    return cell.replace("\\", "\\\\").replace("|", r"\|").replace("\n", " ")
+
+
+def split_cells(line: str) -> list[str]:
+    """Split one markdown table row into unescaped cell values."""
+    line = line.strip()
+    if line.startswith("|"):
+        line = line[1:]
+    if line.endswith("|"):
+        line = line[:-1]
+    cells: list[str] = []
+    buf: list[str] = []
+    i = 0
+    while i < len(line):
+        char = line[i]
+        if char == "\\" and i + 1 < len(line):
+            buf.append(line[i + 1])
+            i += 2
+            continue
+        if char == "|":
+            cells.append("".join(buf).strip())
+            buf = []
+            i += 1
+            continue
+        buf.append(char)
+        i += 1
+    cells.append("".join(buf).strip())
+    return cells
+
+
+def is_separator(cells: list[str]) -> bool:
+    """Return whether a parsed row is a ``|---|---|`` separator."""
+    return bool(cells) and all(set(c) <= {"-", ":"} and c for c in cells)
+
+
+@dataclass
+class Document:
+    """A host markdown document with its table located in place.
+
+    :param preamble: Text before the table's header line, verbatim; the whole
+        document when it holds no table.
+    :param header: The column order read from the file, or ``None`` if the
+        document holds no table.
+    :param rows: The data rows, keyed by the file's own header.
+    :param postamble: Text after the table's last data row, verbatim.
+    :param saw_table_shape: Whether table-like rows were seen but never anchored
+        by a GFM separator (a malformed table, not an empty document).
+    """
+
+    preamble: str = ""
+    header: list[str] | None = None
+    rows: list[Row] = field(default_factory=list)
+    postamble: str = ""
+    saw_table_shape: bool = False
+
+
+def _collect_rows(
+    lines: list[str], header: list[str], start: int, end_limit: int, row_label: str
+) -> tuple[list[Row], int]:
+    """Parse the contiguous data rows at `start`, with the index just past them.
+
+    The table ends at the first line that is not a non-separator pipe row, so
+    whatever follows is host prose to be preserved rather than table content.
+
+    :param lines: The document's lines (newlines kept).
+    :param header: The confirmed header, whose width every row must match.
+    :param start: Index of the first line after the GFM separator.
+    :param end_limit: Index one past the last line the table may occupy.
+    :param row_label: What to call a row in an error message (the caller's
+        domain noun, so the diagnostic names the artifact the human edited).
+    :returns: The parsed rows and the index of the first post-table line.
+    :raises TableError: If a data row's cell count does not match `header` (a
+        ragged row would otherwise silently pad/drop required columns).
+    """
+    rows: list[Row] = []
+    end = start
+    while end < end_limit:
+        if "|" not in lines[end]:
+            break
+        cells = split_cells(lines[end])
+        if is_separator(cells):
+            break
+        if len(cells) != len(header):
+            raise TableError(
+                f"ragged {row_label} row: {len(cells)} cells, header has "
+                f"{len(header)} ({cells!r})"
+            )
+        rows.append({header[i]: cells[i] for i in range(len(header))})
+        end += 1
+    return rows, end
+
+
+def _section_bounds(lines: list[str], title: str) -> tuple[int, int] | None:
+    """Return ``(start, end)`` line indices for the section under `title`.
+
+    The section runs from the line after its heading to the line before the
+    next heading of any level, or to the end of the document.
+
+    :param lines: The document's lines.
+    :param title: The heading text to find, compared case-insensitively.
+    :returns: The bounds, or ``None`` when no such heading exists.
+    """
+    want = title.strip().casefold()
+    start: int | None = None
+    for i, line in enumerate(lines):
+        match = _HEADING.match(line)
+        if match is None:
+            continue
+        if start is not None:
+            return start, i
+        if match.group("title").strip().casefold() == want:
+            start = i + 1
+    return None if start is None else (start, len(lines))
+
+
+def parse_document(
+    text: str, *, under_heading: str | None = None, row_label: str = "table"
+) -> Document:
+    """Locate the markdown table in `text`, keeping the prose around it.
+
+    The header is the pipe line confirmed by a following GFM ``|---|`` separator;
+    that anchor is what distinguishes a real table from stray prose pipes.
+    `preamble` and `postamble` are always measured against the whole document,
+    so :func:`splice` round-trips even when the search is narrowed to a section.
+
+    :param text: The host markdown document.
+    :param under_heading: When given, only consider a table inside the section
+        under that heading. A document may hold several tables, and the caller
+        usually means one of them specifically.
+    :param row_label: What to call a row in a ragged-row error message.
+    :returns: The located document; ``header`` is ``None`` when the window holds
+        no table, in which case `preamble` is the whole of `text`.
+    :raises TableError: If a data row is ragged (see :func:`_collect_rows`).
+    """
+    lines = text.splitlines(keepends=True)
+    window = (0, len(lines))
+    if under_heading is not None:
+        bounds = _section_bounds(lines, under_heading)
+        if bounds is None:
+            return Document(preamble=text)
+        window = bounds
+    candidate: list[str] | None = None
+    candidate_at = 0
+    pending = 0  # consecutive unconfirmed pipe rows (a table shape sans separator)
+    saw_table_shape = False
+    for offset, line in enumerate(lines[window[0] : window[1]]):
+        i = window[0] + offset
+        if "|" not in line:
+            candidate = None  # prose breaks a pending header candidate
+            pending = 0
+            continue
+        cells = split_cells(line)
+        if is_separator(cells):
+            if candidate is None:
+                continue
+            rows, end = _collect_rows(lines, candidate, i + 1, window[1], row_label)
+            return Document(
+                preamble="".join(lines[:candidate_at]),
+                header=candidate,
+                rows=rows,
+                postamble="".join(lines[end:]),
+            )
+        candidate, candidate_at = cells, i  # a header only if a separator follows
+        pending += 1
+        if pending >= 2:  # header + row(s) shape with no separator between
+            saw_table_shape = True
+    return Document(preamble=text, saw_table_shape=saw_table_shape)
+
+
+def render_table(header: list[str], rows: list[Row]) -> str:
+    """Render `rows` as a GFM table in `header`'s column order."""
+    lines = [
+        "| " + " | ".join(header) + " |",
+        "|" + "|".join("---" for _ in header) + "|",
+    ]
+    lines.extend(
+        "| " + " | ".join(escape_cell(row.get(c, "")) for c in header) + " |"
+        for row in rows
+    )
+    return "\n".join(lines) + "\n"
+
+
+def splice(preamble: str, postamble: str, header: list[str], rows: list[Row]) -> str:
+    """Re-emit a host document with its table region replaced.
+
+    Everything the table does not own — the heading and the prose before and
+    after it — is written back verbatim, so ``load → mutate → save`` is lossless.
+
+    :param preamble: Host text before the table.
+    :param postamble: Host text after the table.
+    :param header: The column order to render.
+    :param rows: The rows to render.
+    :returns: The whole document, table spliced in.
+    """
+    if preamble and not preamble.endswith("\n"):
+        preamble += "\n"  # a table cannot start mid-line
+    return preamble + render_table(header, rows) + postamble

--- a/defendable-science/defendable_science/core/mdtable.py
+++ b/defendable-science/defendable_science/core/mdtable.py
@@ -130,6 +130,31 @@ class Document:
     saw_table_shape: bool = False
 
 
+def _row_span(lines: list[str], start: int, end_limit: int) -> int:
+    """Return the index just past the contiguous data rows at `start`.
+
+    Where a table ends, without deciding whether its rows are well-formed —
+    :func:`_collect_rows` is written in terms of this so the two can never
+    disagree about a table's extent. The scan needs the extent alone, so that
+    it can step over one table's rows while merely *counting* the tables in a
+    window, and leave every ragged-row verdict to the one table the caller
+    ends up with.
+
+    :param lines: The document's lines.
+    :param start: Index of the first line after the GFM separator.
+    :param end_limit: Index one past the last line the table may occupy.
+    :returns: The index of the first post-table line.
+    """
+    end = start
+    while (
+        end < end_limit
+        and "|" in lines[end]
+        and not is_separator(split_cells(lines[end]))
+    ):
+        end += 1
+    return end
+
+
 def _collect_rows(
     lines: list[str], header: list[str], start: int, end_limit: int, row_label: str
 ) -> tuple[list[Row], int]:
@@ -148,21 +173,16 @@ def _collect_rows(
     :raises TableError: If a data row's cell count does not match `header` (a
         ragged row would otherwise silently pad/drop required columns).
     """
+    end = _row_span(lines, start, end_limit)
     rows: list[Row] = []
-    end = start
-    while end < end_limit:
-        if "|" not in lines[end]:
-            break
-        cells = split_cells(lines[end])
-        if is_separator(cells):
-            break
+    for line in lines[start:end]:
+        cells = split_cells(line)
         if len(cells) != len(header):
             raise TableError(
                 f"ragged {row_label} row: {len(cells)} cells, header has "
                 f"{len(header)} ({cells!r})"
             )
         rows.append({header[i]: cells[i] for i in range(len(header))})
-        end += 1
     return rows, end
 
 
@@ -208,34 +228,46 @@ def _section_bounds(
     return start, end
 
 
+@dataclass
+class _Located:
+    """One separator-confirmed table's position, before its rows are read.
+
+    :param header: The confirmed header's cells.
+    :param header_at: The header line's index.
+    :param rows_at: The first data row's index (just past the separator).
+    """
+
+    header: list[str]
+    header_at: int
+    rows_at: int
+
+
 def _scan_window(
-    lines: list[str],
-    fenced: list[bool],
-    window: tuple[int, int],
-    row_label: str,
-    *,
-    first_only: bool,
-) -> tuple[Document | None, list[int], bool]:
-    """Locate the separator-confirmed tables in `window`.
+    lines: list[str], fenced: list[bool], window: tuple[int, int], *, first_only: bool
+) -> tuple[list[_Located], bool]:
+    """Locate the separator-confirmed tables in `window`, reading no rows.
+
+    Deliberately does **not** parse rows: a window holding two tables is
+    ambiguous, and the caller must be able to say so before any of them is
+    validated. Collecting as it went would let a ragged row in a scratch table
+    the caller never asked about raise first and displace the ambiguity
+    refusal, sending the author to count cells in the wrong table.
 
     :param lines: The document's lines.
     :param fenced: Per-line fence flags from :func:`_fenced`.
     :param window: The half-open line range to search.
-    :param row_label: What to call a row in a ragged-row error message.
-    :param first_only: Stop at the first table found. What an unwindowed caller
-        wants, and not merely an optimisation: scanning on would raise on a
-        ragged row in some *later*, unrelated table the caller never asked
-        about.
-    :returns: The first table (or ``None``), the line index of every confirmed
-        header, and whether table-like rows were seen without a separator.
-    :raises TableError: If a data row of a scanned table is ragged.
+    :param first_only: Stop at the first table. What an unwindowed caller
+        wants: it takes the first table and never refuses, so a second one
+        tells it nothing. It is also what keeps the ambiguity refusal scoped to
+        windowed calls — an unwindowed scan can never report more than one.
+    :returns: The tables found, in document order, and whether table-like rows
+        were seen but never anchored by a separator.
     """
     candidate: list[str] | None = None
     candidate_at = 0
     pending = 0  # consecutive unconfirmed pipe rows (a table shape sans separator)
     saw_table_shape = False
-    found: Document | None = None
-    header_lines: list[int] = []
+    located: list[_Located] = []
     i = window[0]
     while i < window[1]:
         if fenced[i] or "|" not in lines[i]:
@@ -256,21 +288,14 @@ def _scan_window(
         if candidate is None:
             i += 1
             continue
-        rows, end = _collect_rows(lines, candidate, i + 1, window[1], row_label)
-        header_lines.append(candidate_at)
-        if found is None:
-            found = Document(
-                preamble="".join(lines[:candidate_at]),
-                header=candidate,
-                rows=rows,
-                postamble="".join(lines[end:]),
-            )
-            if first_only:
-                break
+        located.append(_Located(candidate, candidate_at, i + 1))
+        if first_only:
+            break
         candidate = None
         pending = 0
-        i = end  # the rows belong to that table, not to the next candidate
-    return found, header_lines, saw_table_shape
+        # The rows belong to that table, not to the next candidate header.
+        i = _row_span(lines, i + 1, window[1])
+    return located, saw_table_shape
 
 
 def parse_document(
@@ -308,23 +333,32 @@ def parse_document(
     # answer, as it has always been. Only a caller that named a section is
     # saying "I mean one specific table", and only there can a second one be
     # ambiguous.
-    found, header_lines, saw_table_shape = _scan_window(
-        lines, fenced, window, row_label, first_only=under_heading is None
+    located, saw_table_shape = _scan_window(
+        lines, fenced, window, first_only=under_heading is None
     )
-    if found is None:
+    if not located:
         return Document(preamble=text, saw_table_shape=saw_table_shape)
-    if len(header_lines) > 1:
+    if len(located) > 1:
         # The caller named a section because it means one specific table, and
         # `splice` would write into whichever this returned. A legend above the
         # matrix is ordinary authoring, and silently overwriting it while
         # leaving the matrix untouched is the worst outcome available.
         raise AmbiguousSectionError(
-            f"the {under_heading!r} section holds {len(header_lines)} tables "
-            f"(headers at lines {[n + 1 for n in header_lines]}) — which one is "
+            f"the {under_heading!r} section holds {len(located)} tables (headers "
+            f"at lines {[t.header_at + 1 for t in located]}) — which one is "
             "meant cannot be guessed; keep one table in the section, or move "
             "the others under a heading of their own"
         )
-    return found
+    # Only now, and only for the one table the caller gets: a ragged-row
+    # verdict must be about the table they asked for.
+    table = located[0]
+    rows, end = _collect_rows(lines, table.header, table.rows_at, window[1], row_label)
+    return Document(
+        preamble="".join(lines[: table.header_at]),
+        header=table.header,
+        rows=rows,
+        postamble="".join(lines[end:]),
+    )
 
 
 def render_table(header: list[str], rows: list[Row]) -> str:

--- a/defendable-science/defendable_science/defend/record.py
+++ b/defendable-science/defendable_science/defend/record.py
@@ -15,11 +15,17 @@ ADR-0033 (evidentiary points, shared with the ``digest`` skill).
 from __future__ import annotations
 
 import json
-import re
 from dataclasses import asdict, dataclass, field
 from datetime import date as date_cls
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from defendable_science.core.frontmatter import (
+    FrontmatterError,
+    rebuild,
+    set_field,
+    split_frontmatter,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -109,73 +115,11 @@ def _unresolved_gaps(points: list[PointRecord]) -> list[str]:
 
 
 # --- frontmatter patching ---------------------------------------------------
-
-
-def _split_frontmatter(text: str) -> tuple[list[str], list[str]]:
-    """Split a markdown doc into (frontmatter lines, body lines).
-
-    :raises RecordError: If there is no terminated ``---`` frontmatter block.
-    """
-    lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
-        raise RecordError("artifact has no YAML frontmatter")
-    for i in range(1, len(lines)):
-        if lines[i].strip() == "---":
-            return lines[1:i], lines[i + 1 :]
-    raise RecordError("artifact has an unterminated frontmatter block")
-
-
-def _rebuild(fm_lines: list[str], body_lines: list[str]) -> str:
-    """Reassemble a document from frontmatter and body lines."""
-    parts = ["---", *fm_lines, "---", *body_lines]
-    return "\n".join(parts) + "\n"
-
-
-def _set_field(fm_lines: list[str], key: str, value: str) -> list[str]:
-    """Set ``status.<key>`` to `value`, preserving any trailing comment.
-
-    Replaces the existing line if present; otherwise inserts it directly under
-    the ``status:`` block. Indentation is taken from the block's children.
-
-    :param fm_lines: The frontmatter lines (mutated copy returned).
-    :param key: The child key under ``status:`` (e.g. ``understanding``).
-    :param value: The rendered YAML value.
-    :returns: The updated frontmatter lines.
-    :raises RecordError: If there is no ``status:`` block.
-    """
-    lines = list(fm_lines)
-    status_idx = next(
-        (i for i, ln in enumerate(lines) if re.match(r"^status:\s*$", ln)), None
-    )
-    if status_idx is None:
-        raise RecordError("artifact frontmatter has no 'status:' block")
-
-    child_indent = "  "
-    for ln in lines[status_idx + 1 :]:
-        if ln.strip() and (stripped_indent := len(ln) - len(ln.lstrip())) > 0:
-            child_indent = " " * stripped_indent
-            break
-
-    key_pat = re.compile(rf"^{re.escape(child_indent)}{re.escape(key)}:\s*(.*)$")
-    for i in range(status_idx + 1, len(lines)):
-        line = lines[i]
-        # Stop at a dedent back to top level (end of the status block).
-        if line.strip() and not line.startswith(child_indent):
-            break
-        match = key_pat.match(line)
-        if match:
-            # A YAML comment needs whitespace before '#' (or the value is entirely
-            # a comment); a '#' *inside* a value is not a comment delimiter.
-            raw_value = match.group(1)
-            comment = ""
-            cmatch = re.search(r"\s#(.*)$", f" {raw_value}")
-            if cmatch:
-                comment = f"  # {cmatch.group(1).strip()}"
-            lines[i] = f"{child_indent}{key}: {value}{comment}"
-            return lines
-
-    lines.insert(status_idx + 1, f"{child_indent}{key}: {value}")
-    return lines
+#
+# The line-level helpers live in ``core.frontmatter`` — ``digest`` extraction
+# needs the same editing for ``status.extraction`` and must not reach into this
+# module's privates. Their `FrontmatterError` is re-raised as `RecordError`
+# here so this front-end's public contract (and its messages) are unchanged.
 
 
 def patch_understanding(
@@ -196,10 +140,13 @@ def patch_understanding(
     if status not in ("ok", "gaps"):
         raise RecordError(f"status must be 'ok' or 'gaps', got {status!r}")
     understanding = json.dumps({"status": status, "unresolved": gaps})
-    fm_lines, body_lines = _split_frontmatter(text)
-    fm_lines = _set_field(fm_lines, "understanding", understanding)
-    fm_lines = _set_field(fm_lines, "last-updated", last_updated)
-    return _rebuild(fm_lines, body_lines)
+    try:
+        fm_lines, body_lines = split_frontmatter(text)
+        fm_lines = set_field(fm_lines, "understanding", understanding)
+        fm_lines = set_field(fm_lines, "last-updated", last_updated)
+    except FrontmatterError as exc:
+        raise RecordError(str(exc)) from exc
+    return rebuild(fm_lines, body_lines)
 
 
 # --- the accountability log -------------------------------------------------
@@ -345,14 +292,35 @@ def record(
     )
 
 
-def _append_log(log_dir: Path, entry: LogEntry) -> Path:
-    """Write a per-examination log file (unique name), returning its path."""
+def append_log_entry(log_dir: Path, date: str, stem: str, body: str) -> Path:
+    """Write a uniquely-named log file under `log_dir`, returning its path.
+
+    One writer owns the accountability-log directory so its naming stays
+    consistent across the examination kinds that write into it — ``defend``'s
+    per-point record and ``digest`` extraction's per-paper cells both land
+    here, and the log is only independently reviewable if it is one trail.
+
+    Never overwrites: a second entry for the same artifact on the same day gets
+    a ``-2`` suffix, because the log is append-only evidence.
+
+    :param log_dir: The accountability-log directory (created if absent).
+    :param date: ISO date, used as the filename prefix.
+    :param stem: The artifact stem, used as the filename body.
+    :param body: The rendered YAML to write.
+    :returns: The path written.
+    """
     log_dir.mkdir(parents=True, exist_ok=True)
-    stem = Path(entry.artifact).stem
-    target = log_dir / f"{entry.date}-{stem}.yml"
+    target = log_dir / f"{date}-{stem}.yml"
     n = 2
     while target.exists():
-        target = log_dir / f"{entry.date}-{stem}-{n}.yml"
+        target = log_dir / f"{date}-{stem}-{n}.yml"
         n += 1
-    target.write_text(_log_yaml(entry), encoding="utf-8")
+    target.write_text(body, encoding="utf-8")
     return target
+
+
+def _append_log(log_dir: Path, entry: LogEntry) -> Path:
+    """Write a per-examination log file (unique name), returning its path."""
+    return append_log_entry(
+        log_dir, entry.date, Path(entry.artifact).stem, _log_yaml(entry)
+    )

--- a/defendable-science/defendable_science/digest/__init__.py
+++ b/defendable-science/defendable_science/digest/__init__.py
@@ -1,0 +1,1 @@
+"""Reading an external paper: depth-first comprehension, and breadth extraction."""

--- a/defendable-science/defendable_science/digest/artifact.py
+++ b/defendable-science/defendable_science/digest/artifact.py
@@ -80,9 +80,13 @@ class ExtractionStatus:
     """The ``status.extraction`` block written into a paper's artifact.
 
     :param cells: How many cells were recorded for this paper.
-    :param locators: Whether every value-bearing cell carries a locator.
-        Only ever ``ok``: :func:`write_extraction` refuses to write anything
-        else rather than record a claim it cannot make (spec §3.3).
+    :param locators: Whether every value-bearing cell carries a **non-empty**
+        locator. Only ever ``ok``: :func:`write_extraction` refuses to write a
+        cell without one, so there is no other value it could hold. It is not
+        a claim about locator *shape* — that check belongs to
+        :func:`~.extraction.validate`, which the ``digest extract record``
+        command fuses to this writer (spec §3.3), so a cell recorded through
+        any public surface has been shape-checked too.
     :param in_sample: Whether **this** paper was drawn into the checked sample.
     :param batch_check: The verdict on the *batch* this paper was extracted in
         — one of `BATCH_CHECK_VERDICTS`. Separate from `in_sample` because they
@@ -303,6 +307,26 @@ def _extraction_mapping(fm_lines: list[str], path: Path) -> dict[str, Any]:
     return block
 
 
+def _dump_block(block: dict[str, Any], path: Path) -> str:
+    """Re-render a parsed ``status.extraction`` mapping as one YAML flow line.
+
+    The mapping came back from the YAML parser, so it can hold a type JSON
+    cannot render — an unquoted ISO date decodes to `datetime.date`, and
+    ``json.dumps`` raises `TypeError` on it. Left unguarded that is a raw
+    traceback out of a file a human edits, so it is reported as what it is.
+
+    :raises ExtractionError: If the block holds a value JSON cannot render.
+    """
+    try:
+        return json.dumps(block)
+    except TypeError as exc:
+        raise ExtractionError(
+            f"{path}: 'status.extraction' holds a value that cannot be "
+            f"rewritten ({exc}); this block is written by `digest extract "
+            "record` — remove the hand-added key, or quote its value"
+        ) from exc
+
+
 def _check_verdict(verdict: str) -> None:
     """Refuse a verdict outside `BATCH_CHECK_VERDICTS`."""
     if verdict not in BATCH_CHECK_VERDICTS:
@@ -454,7 +478,7 @@ def set_batch_check(
         fm_lines, body = split_frontmatter(path.read_text(encoding="utf-8"))
         block = _extraction_mapping(fm_lines, path)
         block["batch-check"] = verdict
-        fm_lines = set_field(fm_lines, EXTRACTION_KEY, json.dumps(block))
+        fm_lines = set_field(fm_lines, EXTRACTION_KEY, _dump_block(block, path))
         if date is not None:
             fm_lines = set_field(fm_lines, "last-updated", date)
     except FrontmatterError as exc:

--- a/defendable-science/defendable_science/digest/artifact.py
+++ b/defendable-science/defendable_science/digest/artifact.py
@@ -494,6 +494,34 @@ def write_extraction(
     )
 
 
+def _set_extraction_key(
+    artifact: str | Path, key: str, value: Any, date: str | None
+) -> None:
+    """Set one key of an already-extracted artifact's ``status.extraction``.
+
+    Exactly one key per call, and ``last-updated`` when a date is given:
+    `set_batch_check` and `set_in_sample` answer different questions (spec §5)
+    and must stay separately callable, so nothing can set them together by
+    accident. The body — and so every cell — is rebuilt verbatim.
+
+    :raises ExtractionError: If the artifact is missing or malformed, or carries
+        no ``status.extraction`` block.
+    """
+    path = Path(artifact)
+    if not path.is_file():
+        raise ExtractionError(f"{path}: digest artifact not found")
+    try:
+        fm_lines, body = split_frontmatter(path.read_text(encoding="utf-8"))
+        block = _extraction_mapping(fm_lines, path)
+        block[key] = value
+        fm_lines = set_field(fm_lines, EXTRACTION_KEY, _dump_block(block, path))
+        if date is not None:
+            fm_lines = set_field(fm_lines, "last-updated", date)
+    except FrontmatterError as exc:
+        raise ExtractionError(f"{path}: {exc}") from exc
+    path.write_text(rebuild(fm_lines, body), encoding="utf-8")
+
+
 def set_batch_check(
     artifact: str | Path, verdict: str, *, date: str | None = None
 ) -> None:
@@ -511,19 +539,32 @@ def set_batch_check(
         or malformed, or it carries no ``status.extraction`` block.
     """
     _check_verdict(verdict)
-    path = Path(artifact)
-    if not path.is_file():
-        raise ExtractionError(f"{path}: digest artifact not found")
-    try:
-        fm_lines, body = split_frontmatter(path.read_text(encoding="utf-8"))
-        block = _extraction_mapping(fm_lines, path)
-        block["batch-check"] = verdict
-        fm_lines = set_field(fm_lines, EXTRACTION_KEY, _dump_block(block, path))
-        if date is not None:
-            fm_lines = set_field(fm_lines, "last-updated", date)
-    except FrontmatterError as exc:
-        raise ExtractionError(f"{path}: {exc}") from exc
-    path.write_text(rebuild(fm_lines, body), encoding="utf-8")
+    _set_extraction_key(artifact, "batch-check", verdict, date)
+
+
+def set_in_sample(
+    artifact: str | Path, *, in_sample: bool, date: str | None = None
+) -> None:
+    """Record that a human checked **this** paper's cells against its sources.
+
+    ``in-sample: true`` means *a human looked at these cells and the places they
+    cite*, not *this paper was nominated* — a draw that is never followed by a
+    verdict has established nothing, so only ``digest extract sample
+    --verdict`` sets it. Writing it at draw time would let an unanswered
+    invocation leave behind an artifact claiming it had been checked.
+
+    Separate from `set_batch_check` because the two keys answer different
+    questions (spec §5): an unsampled paper in a failed batch reads
+    ``in-sample: false``, ``batch-check: failed``.
+
+    :param artifact: The per-paper digest artifact.
+    :param in_sample: Whether this paper's cells were checked by a human.
+    :param date: ISO date for ``status.last-updated``; left alone if omitted.
+    :raises ExtractionError: If the artifact is missing or malformed, or carries
+        no ``status.extraction`` block — a paper that was never extracted cannot
+        have been sampled.
+    """
+    _set_extraction_key(artifact, "in-sample", in_sample, date)
 
 
 def append_check_log(

--- a/defendable-science/defendable_science/digest/artifact.py
+++ b/defendable-science/defendable_science/digest/artifact.py
@@ -89,7 +89,11 @@ class ExtractionStatus:
         :func:`~.extraction.validate`, which the ``digest extract record``
         command fuses to this writer (spec §3.3), so a cell recorded through
         any public surface has been shape-checked too.
-    :param in_sample: Whether **this** paper was drawn into the checked sample.
+    :param in_sample: Whether a human checked **this** paper's cells against its
+        sources. Not "was nominated for checking": a draw that is never followed
+        by a verdict has established nothing, so only ``digest extract sample
+        --verdict`` ever sets it true (see :func:`set_in_sample`). Written
+        ``False`` at record time, when no sample has been drawn yet.
     :param batch_check: The verdict on the *batch* this paper was extracted in
         — one of `BATCH_CHECK_VERDICTS`. Separate from `in_sample` because they
         answer different questions: a single field would have to read ``failed``
@@ -457,7 +461,10 @@ def write_extraction(
     :param artifact: The per-paper digest artifact to write.
     :param cells: This paper's validated cells; must be non-empty and all about
         the same paper.
-    :param in_sample: Whether this paper was drawn into the checked sample.
+    :param in_sample: Whether a human has checked this paper's cells against its
+        sources — ``False`` from ``digest extract record``, which runs before
+        any sample is drawn. Re-extracting a paper resets it, so the flag can
+        never outlive the cells it certified.
     :param batch_check: The batch's verdict, from `BATCH_CHECK_VERDICTS`.
     :param log_dir: The accountability-log directory (`DEFAULT_LOG_DIR`).
     :param date: ISO date, for ``status.last-updated`` and the log entry.

--- a/defendable-science/defendable_science/digest/artifact.py
+++ b/defendable-science/defendable_science/digest/artifact.py
@@ -1,9 +1,10 @@
 """Extraction mode's writer — the per-paper artifact and the shared log.
 
-Extraction and depth reading share one file per paper,
-``docs/research/literature/digests/<citekey>.md``, because they are two claims
-of different strength about the same paper and both belong in its reading
-record (spec §5). They do **not** share a frontmatter key:
+Extraction and depth reading share one file per paper (for illustration, the
+default layout's ``docs/research/literature/digests/<citekey>.md``; the real
+path comes from :meth:`Layout.digest`), because they are two claims of
+different strength about the same paper and both belong in its reading record
+(spec §5). They do **not** share a frontmatter key:
 
 * depth mode writes ``status.understanding`` — *this reader understands it*;
 * extraction writes ``status.extraction`` — *these cells were extracted, each

--- a/defendable-science/defendable_science/digest/artifact.py
+++ b/defendable-science/defendable_science/digest/artifact.py
@@ -286,6 +286,25 @@ def _cell_from_item(item: Any, citekey: str, path: Path) -> Cell:
 # --- the frontmatter block ------------------------------------------------------
 
 
+def _status_extraction(fm_lines: list[str], path: Path) -> dict[str, Any] | None:
+    """Return the artifact's ``status.extraction`` mapping, or ``None``.
+
+    ``None`` means *this paper was never extracted* — a fact. Frontmatter that
+    will not parse is a different thing entirely and raises, because an
+    unreadable artifact reported as an unextracted one is exactly the silent
+    substitution the failure-honesty rule forbids.
+
+    :raises ExtractionError: If the frontmatter will not parse.
+    """
+    try:
+        data = yaml.safe_load("\n".join(fm_lines))
+    except yaml.YAMLError as exc:
+        raise ExtractionError(f"{path}: frontmatter is not valid YAML: {exc}") from exc
+    status = data.get("status") if isinstance(data, dict) else None
+    block = status.get(EXTRACTION_KEY) if isinstance(status, dict) else None
+    return block if isinstance(block, dict) else None
+
+
 def _extraction_mapping(fm_lines: list[str], path: Path) -> dict[str, Any]:
     """Return the artifact's existing ``status.extraction`` mapping.
 
@@ -294,19 +313,38 @@ def _extraction_mapping(fm_lines: list[str], path: Path) -> dict[str, Any]:
         want of a PDF gets no block at all (spec §6.4), and inventing one here
         would manufacture a record of an extraction that did not happen.
     """
-    try:
-        data = yaml.safe_load("\n".join(fm_lines))
-    except yaml.YAMLError as exc:
-        raise ExtractionError(f"{path}: frontmatter is not valid YAML: {exc}") from exc
-    status = data.get("status") if isinstance(data, dict) else None
-    block = status.get(EXTRACTION_KEY) if isinstance(status, dict) else None
-    if not isinstance(block, dict):
+    block = _status_extraction(fm_lines, path)
+    if block is None:
         raise ExtractionError(
             f"{path}: no 'status.{EXTRACTION_KEY}' block — this paper has not "
             "been extracted, so there is no extraction to record a verdict "
             "against"
         )
     return block
+
+
+def has_extraction(artifact: str | Path) -> bool:
+    """Whether `artifact` carries a ``status.extraction`` block.
+
+    The membership test for an extraction batch: a digest with no such block was
+    never extracted (it may be a depth-mode reading record, which owns
+    ``status.understanding`` instead), so it is not a paper this batch's sampled
+    check has anything to say about.
+
+    :param artifact: The per-paper digest artifact.
+    :returns: ``True`` if the artifact records an extraction.
+    :raises ExtractionError: If the artifact is missing, or its frontmatter is
+        absent or unparsable — a file that cannot be read is not evidence that
+        the paper was never extracted, and must not be quietly excluded.
+    """
+    path = Path(artifact)
+    if not path.is_file():
+        raise ExtractionError(f"{path}: digest artifact not found")
+    try:
+        fm_lines, _body = split_frontmatter(path.read_text(encoding="utf-8"))
+    except FrontmatterError as exc:
+        raise ExtractionError(f"{path}: {exc}") from exc
+    return _status_extraction(fm_lines, path) is not None
 
 
 def _dump_block(block: dict[str, Any], path: Path) -> str:
@@ -486,3 +524,51 @@ def set_batch_check(
     except FrontmatterError as exc:
         raise ExtractionError(f"{path}: {exc}") from exc
     path.write_text(rebuild(fm_lines, body), encoding="utf-8")
+
+
+def append_check_log(
+    artifact: str | Path,
+    citekey: str,
+    cells: list[Cell],
+    *,
+    verdict: str,
+    batch: Iterable[str],
+    log_dir: str | Path,
+    date: str,
+) -> Path:
+    """Record one sampled paper's check in the shared accountability log.
+
+    The same trail :func:`write_extraction` and ``defend record`` write to
+    (spec §8), so the evidence is independently reviewable later without
+    re-running the session. Every cell the human was shown goes in, alongside
+    the batch it was drawn from — the verdict is a statement about that
+    population, and an entry that named only the paper would read as one about
+    the paper.
+
+    :param artifact: The sampled paper's digest artifact.
+    :param citekey: The paper the cells belong to.
+    :param cells: The cells the human checked.
+    :param verdict: The batch verdict recorded, from `BATCH_CHECK_VERDICTS`.
+    :param batch: Every citekey in the batch, sampled or not.
+    :param log_dir: The accountability-log directory.
+    :param date: ISO date for the entry and its filename.
+    :returns: The log entry written.
+    :raises ExtractionError: If `verdict` is not a known verdict.
+    """
+    _check_verdict(verdict)
+    path = Path(artifact)
+    entry = {
+        "date": date,
+        "artifact": str(path),
+        "kind": "extraction-check",
+        "citekey": citekey,
+        "verdict": verdict,
+        "batch": sorted(batch),
+        "cells": [_cell_mapping(c) for c in cells],
+    }
+    return append_log_entry(
+        Path(log_dir),
+        date,
+        citekey,
+        yaml.safe_dump([entry], sort_keys=False, allow_unicode=True),
+    )

--- a/defendable-science/defendable_science/digest/artifact.py
+++ b/defendable-science/defendable_science/digest/artifact.py
@@ -1,0 +1,462 @@
+"""Extraction mode's writer — the per-paper artifact and the shared log.
+
+Extraction and depth reading share one file per paper,
+``docs/research/literature/digests/<citekey>.md``, because they are two claims
+of different strength about the same paper and both belong in its reading
+record (spec §5). They do **not** share a frontmatter key:
+
+* depth mode writes ``status.understanding`` — *this reader understands it*;
+* extraction writes ``status.extraction`` — *these cells were extracted, each
+  carrying a locator, and a sample of the batch was checked by a human*.
+
+``progress status literature`` reports any digest carrying an ``understanding``
+block as "digested & understood" (``skills/progress/SKILL.md:140-143``), so a
+shared key would count a paper that was never read as read. Nothing in this
+module writes ``understanding``, and that is a guarantee, not an accident.
+
+The cells themselves are the durable record; ``positioning.md``'s matrix row is
+a projection rendered from them (spec §5), so they are persisted as structured
+YAML in a delimited block rather than as prose.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from defendable_science.core.frontmatter import (
+    FrontmatterError,
+    rebuild,
+    set_field,
+    split_frontmatter,
+)
+from defendable_science.defend.record import DEFAULT_LOG_DIR as DEFAULT_LOG_DIR
+from defendable_science.defend.record import append_log_entry
+from defendable_science.digest.extraction import (
+    NOT_ADDRESSED,
+    Cell,
+    ExtractionError,
+    cell_from_mapping,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+#: The admissible verdicts on a batch's sampled check (spec §5). ``pending``
+#: until a human has checked; ``failed`` applies to **every** artifact in the
+#: run, sampled or not, because a failed sample is evidence about the
+#: population (spec §8).
+BATCH_CHECK_VERDICTS = ("pending", "verified", "failed")
+
+#: The frontmatter key extraction owns. Deliberately not ``understanding``.
+EXTRACTION_KEY = "extraction"
+
+#: Delimiters for the generated cells block. HTML comments so they survive
+#: markdown rendering invisibly, and so the writer can replace exactly its own
+#: span without touching a word of anything a human added to the artifact.
+CELLS_BEGIN = "<!-- defendable-science: extracted cells (generated) -->"
+CELLS_END = "<!-- defendable-science: end extracted cells -->"
+
+#: The seed for a paper that has only ever been extracted: a ``status:`` block
+#: and nothing else. No ``understanding`` key, not even a pending one — an
+#: absent key says "not read", which is the truth, while
+#: ``understanding: {status: pending}`` would announce an intention this run
+#: has not formed.
+_SEED = "---\nstatus:\n---\n"
+
+_CELLS_HEADING = "## Extracted cells"
+_CELLS_CAVEAT = (
+    "*Extraction mode: cells with locators, checked by sample. Not verified "
+    "comprehension — see `status.extraction`, not `status.understanding`.*"
+)
+
+
+@dataclass
+class ExtractionStatus:
+    """The ``status.extraction`` block written into a paper's artifact.
+
+    :param cells: How many cells were recorded for this paper.
+    :param locators: Whether every value-bearing cell carries a locator.
+        Only ever ``ok``: :func:`write_extraction` refuses to write anything
+        else rather than record a claim it cannot make (spec §3.3).
+    :param in_sample: Whether **this** paper was drawn into the checked sample.
+    :param batch_check: The verdict on the *batch* this paper was extracted in
+        — one of `BATCH_CHECK_VERDICTS`. Separate from `in_sample` because they
+        answer different questions: a single field would have to read ``failed``
+        for a paper that was never checked, which parses as a finding about that
+        paper (spec §5).
+    """
+
+    cells: int
+    locators: str
+    in_sample: bool
+    batch_check: str
+
+    def as_mapping(self) -> dict[str, Any]:
+        """Return the block as its YAML mapping, with the on-disk key names.
+
+        :returns: The mapping written under ``status.extraction``.
+        """
+        return {
+            "cells": self.cells,
+            "locators": self.locators,
+            "in-sample": self.in_sample,
+            "batch-check": self.batch_check,
+        }
+
+
+# --- rendering ----------------------------------------------------------------
+
+
+def _cell_mapping(cell: Cell) -> dict[str, Any]:
+    """Render one cell as the mapping persisted in the artifact and the log.
+
+    A `NOT_ADDRESSED` cell's locator is recorded as ``scope-evidence``, not as
+    ``locator``: it names where the paper declares the scope that excludes the
+    axis, which is evidence *for* the absence rather than the source of a
+    value, and calling it a locator would let a later reader treat an absence
+    as a cited claim.
+    """
+    item: dict[str, Any] = {"axis": cell.axis, "value": cell.value}
+    if cell.value == NOT_ADDRESSED:
+        item["justification"] = cell.justification
+        if cell.locator is not None:
+            item["scope-evidence"] = cell.locator
+    else:
+        item["locator"] = cell.locator
+    return item
+
+
+def _render_block(citekey: str, cells: list[Cell]) -> list[str]:
+    """Render the delimited cells block as body lines."""
+    payload = yaml.safe_dump(
+        {"citekey": citekey, "cells": [_cell_mapping(c) for c in cells]},
+        sort_keys=False,
+        allow_unicode=True,
+    )
+    return [
+        CELLS_BEGIN,
+        "",
+        _CELLS_HEADING,
+        "",
+        _CELLS_CAVEAT,
+        "",
+        "```yaml",
+        *payload.splitlines(),
+        "```",
+        "",
+        CELLS_END,
+    ]
+
+
+# --- locating and splicing the block ------------------------------------------
+
+
+def _locate_block(body: list[str], path: Path) -> tuple[int, int] | None:
+    """Return the block's (begin, end) line indices, or ``None`` if absent.
+
+    :raises ExtractionError: If the markers are present but not a single
+        well-ordered pair — guessing which span to overwrite risks destroying
+        content this module did not author.
+    """
+    begins = [i for i, ln in enumerate(body) if ln.strip() == CELLS_BEGIN]
+    ends = [i for i, ln in enumerate(body) if ln.strip() == CELLS_END]
+    if not begins and not ends:
+        return None
+    if len(begins) == 1 and len(ends) == 1 and begins[0] < ends[0]:
+        return begins[0], ends[0]
+    raise ExtractionError(
+        f"{path}: the extracted-cells markers are malformed — expected exactly "
+        f"one {CELLS_BEGIN!r} followed by one {CELLS_END!r}, found "
+        f"{len(begins)} and {len(ends)}; repair or delete the block by hand, "
+        "then re-run"
+    )
+
+
+def _splice_block(body: list[str], block: list[str], path: Path) -> list[str]:
+    """Replace the cells block in `body`, or append it if there is none.
+
+    Replacement, never a second block: re-extracting a paper restates its cells
+    rather than leaving two answers in the file for a reader to choose between.
+    """
+    span = _locate_block(body, path)
+    if span is not None:
+        begin, end = span
+        return [*body[:begin], *block, *body[end + 1 :]]
+    trimmed = list(body)
+    while trimmed and not trimmed[-1].strip():
+        trimmed.pop()
+    return [*trimmed, "", *block]
+
+
+# --- reading back --------------------------------------------------------------
+
+
+def _fenced_payload(inner: list[str], path: Path) -> str:
+    """Return the YAML text inside the block's fenced code span."""
+    try:
+        start = inner.index("```yaml")
+        stop = inner.index("```", start + 1)
+    except ValueError as exc:
+        raise ExtractionError(
+            f"{path}: the extracted-cells block has no ```yaml fence — it was "
+            "hand-edited or truncated; re-run extraction for this paper"
+        ) from exc
+    return "\n".join(inner[start + 1 : stop])
+
+
+def _load_payload(payload: str, path: Path) -> tuple[str, list[Any]]:
+    """Decode the block's YAML into (citekey, raw cell items)."""
+    try:
+        data = yaml.safe_load(payload)
+    except yaml.YAMLError as exc:
+        raise ExtractionError(
+            f"{path}: the extracted-cells block is not valid YAML: {exc}"
+        ) from exc
+    citekey = data.get("citekey") if isinstance(data, dict) else None
+    items = data.get("cells") if isinstance(data, dict) else None
+    if not isinstance(citekey, str) or not isinstance(items, list):
+        raise ExtractionError(
+            f"{path}: the extracted-cells block is malformed — expected a "
+            "mapping with a 'citekey' string and a 'cells' list"
+        )
+    return citekey, items
+
+
+def read_cells(artifact: str | Path) -> list[Cell]:
+    """Read a paper's recorded cells back out of its artifact.
+
+    The inverse of :func:`write_extraction`'s body write, and the source the
+    ``positioning.md`` matrix is rendered from — the row is a projection of
+    these, never authored independently (spec §5).
+
+    Fails loudly rather than returning an empty list: a paper with no block has
+    not been extracted, and reporting that as "extracted, zero cells" would be
+    a finding about the paper rather than about the file.
+
+    :param artifact: The per-paper digest artifact.
+    :returns: The recorded cells, in the order they were written.
+    :raises ExtractionError: If the artifact is missing, has no frontmatter, or
+        its cells block is absent or malformed.
+    """
+    path = Path(artifact)
+    if not path.is_file():
+        raise ExtractionError(f"{path}: digest artifact not found")
+    try:
+        _, body = split_frontmatter(path.read_text(encoding="utf-8"))
+    except FrontmatterError as exc:
+        raise ExtractionError(f"{path}: {exc}") from exc
+    span = _locate_block(body, path)
+    if span is None:
+        raise ExtractionError(
+            f"{path}: no extracted-cells block — this paper has not been "
+            "extracted; run `digest extract record` for it"
+        )
+    begin, end = span
+    citekey, items = _load_payload(_fenced_payload(body[begin + 1 : end], path), path)
+    return [_cell_from_item(item, citekey, path) for item in items]
+
+
+def _cell_from_item(item: Any, citekey: str, path: Path) -> Cell:
+    """Rebuild one `Cell` from its persisted mapping."""
+    if not isinstance(item, dict):
+        raise ExtractionError(
+            f"{path}: the extracted-cells block holds a non-mapping entry "
+            f"({item!r}); each cell must be a mapping of field to value"
+        )
+    fields = dict(item)
+    if "scope-evidence" in fields:
+        fields["locator"] = fields.pop("scope-evidence")
+    try:
+        return cell_from_mapping({"citekey": citekey, **fields})
+    except ExtractionError as exc:
+        raise ExtractionError(f"{path}: {exc}") from exc
+
+
+# --- the frontmatter block ------------------------------------------------------
+
+
+def _extraction_mapping(fm_lines: list[str], path: Path) -> dict[str, Any]:
+    """Return the artifact's existing ``status.extraction`` mapping.
+
+    :raises ExtractionError: If the frontmatter will not parse, or carries no
+        ``status.extraction`` mapping. Never creates one: a paper skipped for
+        want of a PDF gets no block at all (spec §6.4), and inventing one here
+        would manufacture a record of an extraction that did not happen.
+    """
+    try:
+        data = yaml.safe_load("\n".join(fm_lines))
+    except yaml.YAMLError as exc:
+        raise ExtractionError(f"{path}: frontmatter is not valid YAML: {exc}") from exc
+    status = data.get("status") if isinstance(data, dict) else None
+    block = status.get(EXTRACTION_KEY) if isinstance(status, dict) else None
+    if not isinstance(block, dict):
+        raise ExtractionError(
+            f"{path}: no 'status.{EXTRACTION_KEY}' block — this paper has not "
+            "been extracted, so there is no extraction to record a verdict "
+            "against"
+        )
+    return block
+
+
+def _check_verdict(verdict: str) -> None:
+    """Refuse a verdict outside `BATCH_CHECK_VERDICTS`."""
+    if verdict not in BATCH_CHECK_VERDICTS:
+        raise ExtractionError(
+            f"batch-check must be one of {list(BATCH_CHECK_VERDICTS)}, got "
+            f"{verdict!r} — an unrecognised verdict written into the artifact "
+            "would be read by nothing and trusted by everything"
+        )
+
+
+# --- the writer -----------------------------------------------------------------
+
+
+def _one_citekey(cells: list[Cell]) -> str:
+    """Return the single citekey `cells` are about.
+
+    :raises ExtractionError: If there are no cells, or they are about more than
+        one paper — the artifact is per-paper, so writing a mixed batch into it
+        would file one paper's evidence under another's name.
+    """
+    citekeys = sorted({c.citekey for c in cells})
+    if len(citekeys) != 1:
+        raise ExtractionError(
+            "write_extraction takes one paper's cells; got "
+            f"{citekeys or 'none'} — a paper with nothing extracted gets no "
+            "status.extraction block at all (spec §6.4)"
+        )
+    return citekeys[0]
+
+
+def _refuse_unvalidated(cells: Iterable[Cell]) -> None:
+    """Refuse cells that :func:`~.extraction.validate` would have rejected.
+
+    Validation and writing are one action (spec §3.3), so reaching the writer
+    with an unlocated cell means validation was bypassed. Writing it anyway
+    would put ``locators: ok`` in the frontmatter over a cell with no locator —
+    a false claim in the exact field a reader checks.
+    """
+    for cell in cells:
+        if cell.value == NOT_ADDRESSED:
+            if not (cell.justification or "").strip():
+                raise ExtractionError(
+                    f"{cell.citekey} / axis {cell.axis!r} is {NOT_ADDRESSED!r} "
+                    "with no justification; refusing to record it — validate "
+                    "the cells with `digest extract record`"
+                )
+        elif not (cell.locator or "").strip():
+            raise ExtractionError(
+                f"{cell.citekey} / axis {cell.axis!r} has no locator; refusing "
+                "to record it — validate the cells with `digest extract record`"
+            )
+
+
+def _log_body(artifact: Path, citekey: str, cells: list[Cell], date: str) -> str:
+    """Render the accountability-log entry for one paper's extraction.
+
+    Every cell goes in, `NOT_ADDRESSED` ones with their justifications: the
+    count of absences is the anti-gaming signal (spec §6.5), and it is only
+    auditable later if the absences are in the trail alongside the values.
+    """
+    entry = {
+        "date": date,
+        "artifact": str(artifact),
+        "kind": "extraction",
+        "citekey": citekey,
+        "cells": [_cell_mapping(c) for c in cells],
+        "not-addressed": sum(1 for c in cells if c.value == NOT_ADDRESSED),
+    }
+    return yaml.safe_dump([entry], sort_keys=False, allow_unicode=True)
+
+
+def write_extraction(
+    artifact: str | Path,
+    cells: list[Cell],
+    *,
+    in_sample: bool,
+    batch_check: str,
+    log_dir: str | Path,
+    date: str,
+) -> Path:
+    """Record one paper's extracted cells, and append the accountability log.
+
+    Creates the artifact from a minimal seed if it does not exist; otherwise
+    edits in place, replacing the cells block and the ``status.extraction``
+    line and leaving every other byte — prose, comments, and any
+    ``status.understanding`` depth mode wrote — exactly as it was.
+
+    :param artifact: The per-paper digest artifact to write.
+    :param cells: This paper's validated cells; must be non-empty and all about
+        the same paper.
+    :param in_sample: Whether this paper was drawn into the checked sample.
+    :param batch_check: The batch's verdict, from `BATCH_CHECK_VERDICTS`.
+    :param log_dir: The accountability-log directory (`DEFAULT_LOG_DIR`).
+    :param date: ISO date, for ``status.last-updated`` and the log entry.
+    :returns: The accountability-log entry written — the one path the caller
+        does not already hold.
+    :raises ExtractionError: If the cells are empty, span more than one paper,
+        or would not survive validation; if `batch_check` is not a known
+        verdict; or if the existing artifact's frontmatter is malformed.
+    """
+    path = Path(artifact)
+    citekey = _one_citekey(cells)
+    _refuse_unvalidated(cells)
+    _check_verdict(batch_check)
+
+    text = path.read_text(encoding="utf-8") if path.is_file() else _SEED
+    try:
+        fm_lines, body = split_frontmatter(text)
+        status = ExtractionStatus(
+            cells=len(cells),
+            locators="ok",
+            in_sample=in_sample,
+            batch_check=batch_check,
+        )
+        fm_lines = set_field(fm_lines, EXTRACTION_KEY, json.dumps(status.as_mapping()))
+        fm_lines = set_field(fm_lines, "last-updated", date)
+    except FrontmatterError as exc:
+        raise ExtractionError(f"{path}: {exc}") from exc
+
+    body = _splice_block(body, _render_block(citekey, cells), path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(rebuild(fm_lines, body), encoding="utf-8")
+    return append_log_entry(
+        Path(log_dir), date, path.stem, _log_body(path, citekey, cells, date)
+    )
+
+
+def set_batch_check(
+    artifact: str | Path, verdict: str, *, date: str | None = None
+) -> None:
+    """Set ``status.extraction.batch-check`` on an already-extracted artifact.
+
+    Touches that one key (and ``last-updated``, when a date is given). The
+    cells are left byte-identical on purpose: a failed sample is evidence about
+    the *batch*, and quietly repairing the caught cell would convert a signal
+    about the population into a tidy-looking local fix (spec §8).
+
+    :param artifact: The per-paper digest artifact.
+    :param verdict: One of `BATCH_CHECK_VERDICTS`.
+    :param date: ISO date for ``status.last-updated``; left alone if omitted.
+    :raises ExtractionError: If the verdict is unknown, the artifact is missing
+        or malformed, or it carries no ``status.extraction`` block.
+    """
+    _check_verdict(verdict)
+    path = Path(artifact)
+    if not path.is_file():
+        raise ExtractionError(f"{path}: digest artifact not found")
+    try:
+        fm_lines, body = split_frontmatter(path.read_text(encoding="utf-8"))
+        block = _extraction_mapping(fm_lines, path)
+        block["batch-check"] = verdict
+        fm_lines = set_field(fm_lines, EXTRACTION_KEY, json.dumps(block))
+        if date is not None:
+            fm_lines = set_field(fm_lines, "last-updated", date)
+    except FrontmatterError as exc:
+        raise ExtractionError(f"{path}: {exc}") from exc
+    path.write_text(rebuild(fm_lines, body), encoding="utf-8")

--- a/defendable-science/defendable_science/digest/artifact.py
+++ b/defendable-science/defendable_science/digest/artifact.py
@@ -2,7 +2,8 @@
 
 Extraction and depth reading share one file per paper (for illustration, the
 default layout's ``docs/research/literature/digests/<citekey>.md``; the real
-path comes from :meth:`Layout.digest`), because they are two claims of
+path comes from :meth:`defendable_science.scaffold.layout.Layout.digest`),
+because they are two claims of
 different strength about the same paper and both belong in its reading record
 (spec §5). They do **not** share a frontmatter key:
 

--- a/defendable-science/defendable_science/digest/extraction.py
+++ b/defendable-science/defendable_science/digest/extraction.py
@@ -43,35 +43,52 @@ def axes_from_positioning(path: str | Path) -> list[str]:
     The axes are the matrix header minus its first column, which labels the
     row rather than naming an attribute.
 
+    Every refusal below names the offending file and says what to do about it:
+    this function's whole job is to stop a survey that would otherwise produce
+    confidently-shaped, meaningless cells, so a diagnosis without a remedy
+    would only move the dead end one step later.
+
     :param path: The positioning document.
     :returns: The axes, in the matrix's own column order.
     :raises ExtractionError: If the file is missing; if it has no
         ``Concept matrix`` section, or that section has no table, or its table
-        is ragged; if the header carries unreplaced template placeholders or an
-        unnamed column; if there are no axes beyond the row label; or if two
-        axes share a name.
+        is missing its GFM separator, or is ragged; if the header carries
+        unreplaced template placeholders or an unnamed column; if there are no
+        axes beyond the row label; or if two axes share a name.
     """
     target = Path(path)
     if not target.is_file():
         raise ExtractionError(f"{target}: positioning document not found")
     text = target.read_text(encoding="utf-8")
     try:
-        doc = parse_document(text, under_heading=CONCEPT_MATRIX_HEADING)
+        doc = parse_document(
+            text, under_heading=CONCEPT_MATRIX_HEADING, row_label="concept-matrix"
+        )
     except TableError as exc:
-        raise ExtractionError(f"{target}: {exc}") from exc
+        raise ExtractionError(
+            f"{target}: {exc} — give every row one cell per header column"
+        ) from exc
     if doc.header is None:
         if _MATRIX_HEADING_LINE.search(text) is None:
             raise ExtractionError(
-                f"{target}: no '{CONCEPT_MATRIX_HEADING}' section — run "
-                "`literature position --level paper` first"
+                f"{target}: no '{CONCEPT_MATRIX_HEADING}' section — ask the "
+                "`literature` skill for `position --level paper` to write one"
+            )
+        if doc.saw_table_shape:
+            raise ExtractionError(
+                f"{target}: the '{CONCEPT_MATRIX_HEADING}' table is missing its "
+                "`|---|---|` separator line under the header row — add it so the "
+                "matrix parses as a table"
             )
         raise ExtractionError(
-            f"{target}: the '{CONCEPT_MATRIX_HEADING}' section holds no table"
+            f"{target}: the '{CONCEPT_MATRIX_HEADING}' section holds no table — add "
+            "the matrix, one column per attribute your delta turns on"
         )
     axes = [c.strip() for c in doc.header[1:]]
     if not axes:
         raise ExtractionError(
-            f"{target}: the concept matrix has no comparison axes, only a row label"
+            f"{target}: the concept matrix has no comparison axes, only a row "
+            "label — add one column per attribute your delta turns on"
         )
     placeholders = [a for a in axes if PLACEHOLDER_RE.match(a)]
     if placeholders:
@@ -80,11 +97,17 @@ def axes_from_positioning(path: str | Path) -> list[str]:
             f"placeholders {placeholders} — replace them with the attributes "
             "your delta turns on before extracting against them"
         )
-    if any(not a for a in axes):
+    unnamed = [i for i, a in enumerate(axes, start=2) if not a]
+    if unnamed:
         raise ExtractionError(
-            f"{target}: the concept matrix has an unnamed column — every axis "
-            "needs a name a reader can answer against"
+            f"{target}: the concept matrix has unnamed columns at position(s) "
+            f"{unnamed} (1-based, counting the row label) — name each one after "
+            "the attribute it compares, or delete it"
         )
-    if len(set(axes)) != len(axes):
-        raise ExtractionError(f"{target}: duplicate axis names in {axes}")
+    duplicates = sorted({a for a in axes if axes.count(a) > 1})
+    if duplicates:
+        raise ExtractionError(
+            f"{target}: duplicate axis names {duplicates} in the concept matrix "
+            "— rename them so each axis is distinct, or drop the repeat"
+        )
     return axes

--- a/defendable-science/defendable_science/digest/extraction.py
+++ b/defendable-science/defendable_science/digest/extraction.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from defendable_science.core.mdtable import TableError, parse_document
+from defendable_science.core.mdtable import Row, TableError, parse_document
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -43,11 +43,37 @@ class ExtractionError(ValueError):
     """Raised when extraction cannot proceed and must not guess."""
 
 
-def axes_from_positioning(path: str | Path) -> list[str]:
-    """Read the comparison axes from a positioning document's concept matrix.
+@dataclass(frozen=True)
+class Matrix:
+    """A positioning document's concept-matrix table, located in its host.
 
-    The axes are the matrix header minus its first column, which labels the
-    row rather than naming an attribute.
+    Carries enough to write the table back without touching a byte the table
+    does not own, so the merge in :mod:`defendable_science.digest.render` reads
+    and validates the matrix exactly once.
+
+    :param header: The file's own column order — the row label, then the axes.
+        Never ``None``: every "there is no table" case is a refusal.
+    :param rows: The matrix's data rows, keyed by `header`.
+    :param axes: The comparison axes, i.e. `header` minus its first column,
+        stripped and checked.
+    :param preamble: Host text before the table, verbatim.
+    :param postamble: Host text after the table, verbatim.
+    """
+
+    header: list[str]
+    rows: list[Row]
+    axes: list[str]
+    preamble: str
+    postamble: str
+
+    @property
+    def label_column(self) -> str:
+        """The first column, which labels the row rather than naming an axis."""
+        return self.header[0]
+
+
+def read_matrix(path: str | Path) -> Matrix:
+    """Read and validate a positioning document's concept matrix.
 
     Every refusal below names the offending file and says what to do about it:
     this function's whole job is to stop a survey that would otherwise produce
@@ -55,7 +81,7 @@ def axes_from_positioning(path: str | Path) -> list[str]:
     would only move the dead end one step later.
 
     :param path: The positioning document.
-    :returns: The axes, in the matrix's own column order.
+    :returns: The located matrix, its axes in the matrix's own column order.
     :raises ExtractionError: If the file is missing; if it has no
         ``Concept matrix`` section, or that section has no table, or its table
         is missing its GFM separator, or is ragged; if the header carries
@@ -116,7 +142,28 @@ def axes_from_positioning(path: str | Path) -> list[str]:
             f"{target}: duplicate axis names {duplicates} in the concept matrix "
             "— rename them so each axis is distinct, or drop the repeat"
         )
-    return axes
+    return Matrix(
+        header=doc.header,
+        rows=doc.rows,
+        axes=axes,
+        preamble=doc.preamble,
+        postamble=doc.postamble,
+    )
+
+
+def axes_from_positioning(path: str | Path) -> list[str]:
+    """Read the comparison axes from a positioning document's concept matrix.
+
+    The axes are the matrix header minus its first column, which labels the row
+    rather than naming an attribute. Thin over :func:`read_matrix`, which is
+    what the writer and the renderer use: the axes are the only part of the
+    matrix the *question set* (spec §6.1) is about.
+
+    :param path: The positioning document.
+    :returns: The axes, in the matrix's own column order.
+    :raises ExtractionError: As :func:`read_matrix`.
+    """
+    return read_matrix(path).axes
 
 
 # --- cells --------------------------------------------------------------------

--- a/defendable-science/defendable_science/digest/extraction.py
+++ b/defendable-science/defendable_science/digest/extraction.py
@@ -147,9 +147,10 @@ def _checked_axes(header: list[str], target: Path) -> list[str]:
     :returns: The axes, stripped, in column order.
     :raises ExtractionError: If there are no axes beyond the row label, if the
         header carries unreplaced template placeholders or an unnamed column,
-        or if two axes share a name.
+        or if two **columns** share a name.
     """
-    axes = [c.strip() for c in header[1:]]
+    columns = [c.strip() for c in header]
+    axes = columns[1:]
     if not axes:
         raise ExtractionError(
             f"{target}: the concept matrix has no comparison axes, only a row "
@@ -169,11 +170,18 @@ def _checked_axes(header: list[str], target: Path) -> list[str]:
             f"{unnamed} (1-based, counting the row label) — name each one after "
             "the attribute it compares, or delete it"
         )
-    duplicates = sorted({a for a in axes if axes.count(a) > 1})
+    # The **whole** header, row label included. A row is parsed into a mapping
+    # keyed by the header, so a repeated name collapses two cells into one:
+    # `| Method | Method |` loses the citekey the first column carried, and
+    # re-emitting writes the survivor into both columns. Checking only the axes
+    # would let that through, and it destroys authored content silently.
+    duplicates = sorted({c for c in columns if columns.count(c) > 1})
     if duplicates:
         raise ExtractionError(
-            f"{target}: duplicate axis names {duplicates} in the concept matrix "
-            "— rename them so each axis is distinct, or drop the repeat"
+            f"{target}: duplicate column names {duplicates} in the concept "
+            "matrix — two columns of one name collapse into a single cell, "
+            "losing what the other one held; rename them so each column is "
+            "distinct, or drop the repeat"
         )
     return axes
 

--- a/defendable-science/defendable_science/digest/extraction.py
+++ b/defendable-science/defendable_science/digest/extraction.py
@@ -275,9 +275,14 @@ def cell_from_mapping(item: Mapping[str, Any]) -> Cell:
 
 # --- locators -----------------------------------------------------------------
 
-#: Locator forms accepted out of the box. Extended or replaced via
+#: Locator forms accepted out of the box. **Extended, never replaced**, via
 #: ``literature.extraction.locator_patterns`` — a set built around §/Eq./Thm.
-#: encodes one citation culture, and this plugin forbids domain assumptions.
+#: encodes one citation culture, and this plugin forbids domain assumptions, so
+#: a survey of trials or case law adds the forms it locates claims by. Configured
+#: patterns are appended to these (:func:`compile_locator_patterns`); there is
+#: deliberately no way to drop a default. Widening the accepted set only ever
+#: costs a shape that would otherwise have been rejected — never a false
+#: negative on a locator the author meant.
 #:
 #: A configured pattern must not rely on its own group numbering: the set is
 #: concatenated into one alternation, so a numbered backreference like
@@ -305,7 +310,8 @@ def compile_locator_patterns(extra: list[str] | None = None) -> list[re.Pattern[
     comma-separated list, so ``"§3, Eq. (4)"`` is accepted while
     ``"somewhere in §3"`` is not — a partial match would defeat the check.
 
-    :param extra: Additional raw patterns from configuration.
+    :param extra: Additional raw patterns from configuration, **appended** to
+        `DEFAULT_LOCATOR_PATTERNS` rather than replacing them.
     :returns: One compiled pattern matching any comma-joined combination.
     :raises ExtractionError: If a configured pattern is not valid regex, or if
         the configured set cannot be combined (e.g. two patterns reusing one

--- a/defendable-science/defendable_science/digest/extraction.py
+++ b/defendable-science/defendable_science/digest/extraction.py
@@ -11,9 +11,15 @@ Design: ``docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md``.
 from __future__ import annotations
 
 import re
+from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from defendable_science.core.mdtable import TableError, parse_document
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 #: The heading whose table holds the comparison axes.
 CONCEPT_MATRIX_HEADING = "Concept matrix"
@@ -111,3 +117,243 @@ def axes_from_positioning(path: str | Path) -> list[str]:
             "— rename them so each axis is distinct, or drop the repeat"
         )
     return axes
+
+
+# --- cells --------------------------------------------------------------------
+
+#: The distinguished value for an axis the paper does not address. A cell may
+#: not simply be omitted (rule 2 below), so the dodge lands here, where it is
+#: counted and visible rather than invisible in a short row.
+NOT_ADDRESSED = "not-addressed"
+
+
+@dataclass(frozen=True)
+class Cell:
+    """One paper's recorded value on one comparison axis.
+
+    :param citekey: The paper this cell is about.
+    :param axis: The concept-matrix axis it fills, verbatim from the header.
+    :param value: The extracted value, or `NOT_ADDRESSED`.
+    :param locator: Where in the paper the value comes from — required unless
+        `value` is `NOT_ADDRESSED`.
+    :param justification: Why the axis is out of the paper's scope — required
+        when `value` is `NOT_ADDRESSED`.
+    """
+
+    citekey: str
+    axis: str
+    value: str
+    locator: str | None = None
+    justification: str | None = None
+
+
+#: Each `Cell` field's admissible decoded-JSON types, with the phrasing used to
+#: report a mismatch (mirrors ``defend.record._POINT_FIELD_TYPES``).
+_CELL_FIELD_TYPES: dict[str, tuple[tuple[type, ...], str]] = {
+    "citekey": ((str,), "a string"),
+    "axis": ((str,), "a string"),
+    "value": ((str,), "a string"),
+    "locator": ((str, type(None)), "a string or null"),
+    "justification": ((str, type(None)), "a string or null"),
+}
+
+
+def cell_from_mapping(item: Mapping[str, Any]) -> Cell:
+    """Build a `Cell` from a decoded JSON object, enforcing field types.
+
+    An unknown key is refused rather than dropped: silently ignoring a
+    misspelled ``locater`` would turn a typo into a cell with no locator at
+    all, which rule 1 would then blame on the wrong thing.
+
+    :param item: One decoded JSON object, keyed by `Cell` field name.
+    :returns: The validated cell.
+    :raises ExtractionError: If a key is unknown, a field's value has the wrong
+        type, or a required field is missing.
+    """
+    unknown = sorted(set(item) - set(_CELL_FIELD_TYPES))
+    if unknown:
+        raise ExtractionError(
+            f"cell has unknown field(s) {unknown}; expected any of "
+            f"{sorted(_CELL_FIELD_TYPES)}"
+        )
+    for name, (admissible, expected) in _CELL_FIELD_TYPES.items():
+        if name in item and not isinstance(item[name], admissible):
+            raise ExtractionError(
+                f"cell field {name!r} must be {expected}, "
+                f"got {type(item[name]).__name__}"
+            )
+    try:
+        return Cell(**item)
+    except TypeError as exc:
+        raise ExtractionError(f"cell is malformed: {exc}") from exc
+
+
+# --- locators -----------------------------------------------------------------
+
+#: Locator forms accepted out of the box. Extended or replaced via
+#: ``literature.extraction.locator_patterns`` — a set built around §/Eq./Thm.
+#: encodes one citation culture, and this plugin forbids domain assumptions.
+DEFAULT_LOCATOR_PATTERNS: tuple[str, ...] = (
+    r"§\s*\d+(\.\d+)*",
+    r"(Section|Sec\.)\s*\d+(\.\d+)*",
+    # The en dash is the typographic page-range separator and is what a reader
+    # copying a page range out of a PDF will paste, so both dashes are accepted.
+    r"(pp?\.|pages?)\s*\d+(\s*[-–]\s*\d+)?",  # noqa: RUF001
+    r"(Eq\.|Equation)\s*\(?\d+\)?",
+    r"(Table|Tbl\.)\s*\d+",
+    r"(Fig\.|Figure)\s*\d+",
+    r"(Alg\.|Algorithm)\s*\d+",
+    r"(Thm\.|Theorem|Lemma|Cor\.|Corollary|Def\.|Definition|Prop\.|Proposition)\s*\d+",
+)
+
+
+def compile_locator_patterns(extra: list[str] | None = None) -> list[re.Pattern[str]]:
+    """Compile the locator pattern set into anchored, comma-joinable matchers.
+
+    Each pattern is anchored whole-string and permitted to repeat in a
+    comma-separated list, so ``"§3, Eq. (4)"`` is accepted while
+    ``"somewhere in §3"`` is not — a partial match would defeat the check.
+
+    :param extra: Additional raw patterns from configuration.
+    :returns: One compiled pattern matching any comma-joined combination.
+    :raises ExtractionError: If a configured pattern is not valid regex.
+    """
+    for pattern in extra or []:
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            raise ExtractionError(
+                f"invalid locator pattern {pattern!r} in config: {exc}"
+            ) from exc
+    raw = [*DEFAULT_LOCATOR_PATTERNS, *(extra or [])]
+    one = "|".join(f"(?:{p})" for p in raw)
+    joined = rf"\A\s*(?:{one})(?:\s*,\s*(?:{one}))*\s*\Z"
+    return [re.compile(joined, re.IGNORECASE)]
+
+
+def is_valid_locator(locator: str, patterns: list[re.Pattern[str]]) -> bool:
+    """Return whether `locator` is well-formed against the pattern set.
+
+    Proves the locator's *shape*, never its correctness — a cell may cite §3
+    when the claim is in §5, and what catches that is ``defend --target
+    cited-work`` later, which is why the locator is mandatory at all.
+
+    :param locator: The recorded locator.
+    :param patterns: Compiled patterns from :func:`compile_locator_patterns`.
+    :returns: Whether it matches.
+    """
+    return any(p.match(locator) is not None for p in patterns)
+
+
+# --- validation (spec §7.2) ----------------------------------------------------
+
+
+@dataclass
+class Rejection:
+    """One reason a paper's extraction was refused.
+
+    :param citekey: The paper the refusal is about.
+    :param axis: The offending axis, or ``None`` for a whole-paper problem.
+    :param reason: What is wrong, naming the cell — a bare count would send the
+        reader hunting (spec §7.4).
+    """
+
+    citekey: str
+    axis: str | None
+    reason: str
+
+
+def _cell_problem(
+    cell: Cell, axes: list[str], patterns: list[re.Pattern[str]]
+) -> str | None:
+    """Return why `cell` is inadmissible, or ``None`` if it is fine (rules 1, 3)."""
+    if cell.axis not in axes:
+        return (
+            f"axis {cell.axis!r} is not a matrix axis — the concept matrix has "
+            f"{axes}; fix the axis name or add the column to the matrix"
+        )
+    if cell.value == NOT_ADDRESSED:
+        if not (cell.justification or "").strip():
+            return (
+                f"axis {cell.axis!r} is {NOT_ADDRESSED!r} with no justification — "
+                "say what in the paper puts this axis out of its scope"
+            )
+        return None
+    if cell.locator is None:
+        return (
+            f"axis {cell.axis!r} has no locator — cite where in the paper the "
+            f"value comes from, or record it as {NOT_ADDRESSED!r} with a "
+            "justification"
+        )
+    if not is_valid_locator(cell.locator, patterns):
+        return (
+            f"axis {cell.axis!r}: locator {cell.locator!r} matches no known form "
+            "— use e.g. '§3', 'p. 7', 'Eq. (4)', 'Thm. 2', or a comma-joined "
+            "combination, or extend `literature.extraction.locator_patterns`"
+        )
+    return None
+
+
+def _paper_rejections(
+    citekey: str, cells: list[Cell], axes: list[str], patterns: list[re.Pattern[str]]
+) -> list[Rejection]:
+    """Return every rejection for one paper's cells (spec §7.2 rules 1-3)."""
+    rejections = [
+        Rejection(citekey, cell.axis, problem)
+        for cell in cells
+        if (problem := _cell_problem(cell, axes, patterns)) is not None
+    ]
+    counts = Counter(cell.axis for cell in cells)
+    rejections += [
+        Rejection(
+            citekey,
+            axis,
+            f"axis {axis!r} is recorded {n} times — an axis may not be filled "
+            "twice for one paper; keep exactly one cell per axis",
+        )
+        for axis, n in counts.items()
+        if n > 1
+    ]
+    # Rule 2, the load-bearing one: without it an agent that finds an axis hard
+    # omits the cell, and a short row looks exactly like a clean row.
+    rejections += [
+        Rejection(
+            citekey,
+            axis,
+            f"axis {axis!r} is missing — every matrix axis must be accounted "
+            f"for; record a value with a locator, or {NOT_ADDRESSED!r} with a "
+            "justification",
+        )
+        for axis in axes
+        if axis not in counts
+    ]
+    return rejections
+
+
+def validate(
+    cells: list[Cell], axes: list[str], patterns: list[re.Pattern[str]]
+) -> tuple[dict[str, list[Cell]], list[Rejection]]:
+    """Partition cells into acceptable papers and rejections (spec §7.2).
+
+    Rejection is **per paper, whole**: a paper with any bad cell contributes no
+    accepted cells at all, so no partial row is ever written, while the rest of
+    the batch continues — one bad entry must not abort a 40-paper sweep, and
+    nothing may half-land (rule 4, the ``fetch_all`` posture).
+
+    :param cells: Every extracted cell, for any number of papers.
+    :param axes: The concept matrix's axes, from :func:`axes_from_positioning`.
+    :param patterns: Compiled patterns from :func:`compile_locator_patterns`.
+    :returns: The accepted cells grouped by citekey, and every rejection.
+    """
+    by_citekey: dict[str, list[Cell]] = {}
+    for cell in cells:
+        by_citekey.setdefault(cell.citekey, []).append(cell)
+    accepted: dict[str, list[Cell]] = {}
+    rejections: list[Rejection] = []
+    for citekey, paper_cells in by_citekey.items():
+        problems = _paper_rejections(citekey, paper_cells, axes, patterns)
+        if problems:
+            rejections += problems
+        else:
+            accepted[citekey] = paper_cells
+    return accepted, rejections

--- a/defendable-science/defendable_science/digest/extraction.py
+++ b/defendable-science/defendable_science/digest/extraction.py
@@ -285,6 +285,23 @@ class Rejection:
     reason: str
 
 
+def render_rejection(rejection: Rejection) -> str:
+    """Render one rejection as a single human-readable line (spec §7.4).
+
+    Composed in one place so every front-end reports a refusal identically:
+    "3 cells rejected" sends the reader hunting, and a caller improvising its
+    own format makes the log and the terminal disagree about the same event.
+
+    `Rejection.axis` is not re-emitted — every reason already names the axis it
+    is about, and prefixing it again would read as two different axes. The
+    field stays the machine-readable one, for JSON output.
+
+    :param rejection: The refusal to render.
+    :returns: ``<citekey> / <reason>``.
+    """
+    return f"{rejection.citekey} / {rejection.reason}"
+
+
 def _cell_problem(
     cell: Cell, axes: list[str], patterns: list[re.Pattern[str]]
 ) -> str | None:

--- a/defendable-science/defendable_science/digest/extraction.py
+++ b/defendable-science/defendable_science/digest/extraction.py
@@ -1,0 +1,90 @@
+"""Extraction mode's pure library — axes, cells, locators, validation.
+
+No I/O beyond reading the positioning document: everything here is a function
+of its inputs, so the rules can be tested exhaustively without touching a
+registry, a PDF, or an artifact. The writer that fuses validation to recording
+lives in :mod:`defendable_science.digest.artifact`; nothing here writes.
+
+Design: ``docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from defendable_science.core.mdtable import TableError, parse_document
+
+#: The heading whose table holds the comparison axes.
+CONCEPT_MATRIX_HEADING = "Concept matrix"
+
+#: The matrix's self-reference row — the author's own delta, never a paper.
+SELF_ROW = "**This paper**"
+
+#: An unreplaced template placeholder, e.g. ``<attr 1>`` or ``<prior work>``.
+PLACEHOLDER_RE = re.compile(r"^<[^>]*>$")
+
+#: The concept-matrix heading as a line, matched the way the parser matches it:
+#: any level, case-insensitively (see ``core.mdtable._section_bounds``). Used
+#: only to tell "no such section" apart from "section, but no table".
+_MATRIX_HEADING_LINE = re.compile(
+    rf"^#{{1,6}}\s+{re.escape(CONCEPT_MATRIX_HEADING)}\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+class ExtractionError(ValueError):
+    """Raised when extraction cannot proceed and must not guess."""
+
+
+def axes_from_positioning(path: str | Path) -> list[str]:
+    """Read the comparison axes from a positioning document's concept matrix.
+
+    The axes are the matrix header minus its first column, which labels the
+    row rather than naming an attribute.
+
+    :param path: The positioning document.
+    :returns: The axes, in the matrix's own column order.
+    :raises ExtractionError: If the file is missing; if it has no
+        ``Concept matrix`` section, or that section has no table, or its table
+        is ragged; if the header carries unreplaced template placeholders or an
+        unnamed column; if there are no axes beyond the row label; or if two
+        axes share a name.
+    """
+    target = Path(path)
+    if not target.is_file():
+        raise ExtractionError(f"{target}: positioning document not found")
+    text = target.read_text(encoding="utf-8")
+    try:
+        doc = parse_document(text, under_heading=CONCEPT_MATRIX_HEADING)
+    except TableError as exc:
+        raise ExtractionError(f"{target}: {exc}") from exc
+    if doc.header is None:
+        if _MATRIX_HEADING_LINE.search(text) is None:
+            raise ExtractionError(
+                f"{target}: no '{CONCEPT_MATRIX_HEADING}' section — run "
+                "`literature position --level paper` first"
+            )
+        raise ExtractionError(
+            f"{target}: the '{CONCEPT_MATRIX_HEADING}' section holds no table"
+        )
+    axes = [c.strip() for c in doc.header[1:]]
+    if not axes:
+        raise ExtractionError(
+            f"{target}: the concept matrix has no comparison axes, only a row label"
+        )
+    placeholders = [a for a in axes if PLACEHOLDER_RE.match(a)]
+    if placeholders:
+        raise ExtractionError(
+            f"{target}: the concept matrix still carries template "
+            f"placeholders {placeholders} — replace them with the attributes "
+            "your delta turns on before extracting against them"
+        )
+    if any(not a for a in axes):
+        raise ExtractionError(
+            f"{target}: the concept matrix has an unnamed column — every axis "
+            "needs a name a reader can answer against"
+        )
+    if len(set(axes)) != len(axes):
+        raise ExtractionError(f"{target}: duplicate axis names in {axes}")
+    return axes

--- a/defendable-science/defendable_science/digest/extraction.py
+++ b/defendable-science/defendable_science/digest/extraction.py
@@ -16,7 +16,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from defendable_science.core.mdtable import Row, TableError, parse_document
+from defendable_science.core.mdtable import (
+    AmbiguousSectionError,
+    Row,
+    TableError,
+    parse_document,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -83,10 +88,11 @@ def read_matrix(path: str | Path) -> Matrix:
     :param path: The positioning document.
     :returns: The located matrix, its axes in the matrix's own column order.
     :raises ExtractionError: If the file is missing; if it has no
-        ``Concept matrix`` section, or that section has no table, or its table
-        is missing its GFM separator, or is ragged; if the header carries
-        unreplaced template placeholders or an unnamed column; if there are no
-        axes beyond the row label; or if two axes share a name.
+        ``Concept matrix`` section, or **more than one**, or that section has
+        no table, or its table is missing its GFM separator, or is ragged; if
+        the header carries unreplaced template placeholders or an unnamed
+        column; if there are no axes beyond the row label; or if two axes share
+        a name.
     """
     target = Path(path)
     if not target.is_file():
@@ -96,6 +102,11 @@ def read_matrix(path: str | Path) -> Matrix:
         doc = parse_document(
             text, under_heading=CONCEPT_MATRIX_HEADING, row_label="concept-matrix"
         )
+    except AmbiguousSectionError as exc:
+        # Its own message already carries the remedy, and it is not the ragged
+        # row's — appending that one would send the author counting cells in a
+        # table that is perfectly well-formed.
+        raise ExtractionError(f"{target}: {exc}") from exc
     except TableError as exc:
         raise ExtractionError(
             f"{target}: {exc} — give every row one cell per header column"
@@ -116,7 +127,29 @@ def read_matrix(path: str | Path) -> Matrix:
             f"{target}: the '{CONCEPT_MATRIX_HEADING}' section holds no table — add "
             "the matrix, one column per attribute your delta turns on"
         )
-    axes = [c.strip() for c in doc.header[1:]]
+    return Matrix(
+        header=doc.header,
+        rows=doc.rows,
+        axes=_checked_axes(doc.header, target),
+        preamble=doc.preamble,
+        postamble=doc.postamble,
+    )
+
+
+def _checked_axes(header: list[str], target: Path) -> list[str]:
+    """Return the matrix's axes — `header` minus its row label — or refuse.
+
+    Split from :func:`read_matrix` only to keep each function's branching
+    readable; every refusal here is one of that function's documented ones.
+
+    :param header: The matrix's own column order.
+    :param target: The positioning document, named in every message.
+    :returns: The axes, stripped, in column order.
+    :raises ExtractionError: If there are no axes beyond the row label, if the
+        header carries unreplaced template placeholders or an unnamed column,
+        or if two axes share a name.
+    """
+    axes = [c.strip() for c in header[1:]]
     if not axes:
         raise ExtractionError(
             f"{target}: the concept matrix has no comparison axes, only a row "
@@ -142,13 +175,7 @@ def read_matrix(path: str | Path) -> Matrix:
             f"{target}: duplicate axis names {duplicates} in the concept matrix "
             "— rename them so each axis is distinct, or drop the repeat"
         )
-    return Matrix(
-        header=doc.header,
-        rows=doc.rows,
-        axes=axes,
-        preamble=doc.preamble,
-        postamble=doc.postamble,
-    )
+    return axes
 
 
 def axes_from_positioning(path: str | Path) -> list[str]:

--- a/defendable-science/defendable_science/digest/extraction.py
+++ b/defendable-science/defendable_science/digest/extraction.py
@@ -425,6 +425,23 @@ def _paper_rejections(
     citekey: str, cells: list[Cell], axes: list[str], patterns: list[re.Pattern[str]]
 ) -> list[Rejection]:
     """Return every rejection for one paper's cells (spec §7.2 rules 1-3)."""
+    if citekey.strip() == SELF_ROW:
+        # `render` refuses this row too, but only at the far end and for the
+        # *whole* merge: a recorded `**This paper**` artifact would then block
+        # every other paper's cells from landing, with a message about the
+        # author's own delta rather than about the artifact that poisoned the
+        # batch. Caught here it is one rejected paper, like any other, and the
+        # rest of the batch records. Returned alone — the missing-axis and
+        # locator reasons below would only bury the one that matters.
+        return [
+            Rejection(
+                citekey,
+                None,
+                f"citekey {SELF_ROW} is the matrix's self-reference row — the "
+                "author's own delta, not an extracted paper; record it by hand "
+                "in the positioning document and drop these cells",
+            )
+        ]
     rejections = [
         Rejection(citekey, cell.axis, problem)
         for cell in cells
@@ -466,6 +483,9 @@ def validate(
     accepted cells at all, so no partial row is ever written, while the rest of
     the batch continues — one bad entry must not abort a 40-paper sweep, and
     nothing may half-land (rule 4, the ``fetch_all`` posture).
+
+    A paper whose citekey is `SELF_ROW` is rejected whole for that reason
+    alone: it is the author's own delta, not an extracted paper.
 
     :param cells: Every extracted cell, for any number of papers.
     :param axes: The concept matrix's axes, from :func:`axes_from_positioning`.

--- a/defendable-science/defendable_science/digest/extraction.py
+++ b/defendable-science/defendable_science/digest/extraction.py
@@ -135,7 +135,10 @@ class Cell:
     :param axis: The concept-matrix axis it fills, verbatim from the header.
     :param value: The extracted value, or `NOT_ADDRESSED`.
     :param locator: Where in the paper the value comes from — required unless
-        `value` is `NOT_ADDRESSED`.
+        `value` is `NOT_ADDRESSED`. A `NOT_ADDRESSED` cell *may* still carry
+        one, naming where the paper declares the scope that excludes this axis:
+        that is evidence **for** the absence, not a pointer at where a claim
+        is not, so it is recorded as scope evidence rather than a value source.
     :param justification: Why the axis is out of the paper's scope — required
         when `value` is `NOT_ADDRESSED`.
     """
@@ -193,6 +196,12 @@ def cell_from_mapping(item: Mapping[str, Any]) -> Cell:
 #: Locator forms accepted out of the box. Extended or replaced via
 #: ``literature.extraction.locator_patterns`` — a set built around §/Eq./Thm.
 #: encodes one citation culture, and this plugin forbids domain assumptions.
+#:
+#: A configured pattern must not rely on its own group numbering: the set is
+#: concatenated into one alternation, so a numbered backreference like
+#: ``(a)\1`` compiles fine alone and then silently renumbers against a
+#: different group. No validation can catch that (a name collision, by
+#: contrast, is caught below) — prefer non-capturing ``(?:…)`` groups.
 DEFAULT_LOCATOR_PATTERNS: tuple[str, ...] = (
     r"§\s*\d+(\.\d+)*",
     r"(Section|Sec\.)\s*\d+(\.\d+)*",
@@ -216,19 +225,32 @@ def compile_locator_patterns(extra: list[str] | None = None) -> list[re.Pattern[
 
     :param extra: Additional raw patterns from configuration.
     :returns: One compiled pattern matching any comma-joined combination.
-    :raises ExtractionError: If a configured pattern is not valid regex.
+    :raises ExtractionError: If a configured pattern is not valid regex, or if
+        the configured set cannot be combined (e.g. two patterns reusing one
+        group name).
     """
-    for pattern in extra or []:
+    configured = extra or []
+    for pattern in configured:
         try:
             re.compile(pattern)
         except re.error as exc:
             raise ExtractionError(
                 f"invalid locator pattern {pattern!r} in config: {exc}"
             ) from exc
-    raw = [*DEFAULT_LOCATOR_PATTERNS, *(extra or [])]
+    raw = [*DEFAULT_LOCATOR_PATTERNS, *configured]
     one = "|".join(f"(?:{p})" for p in raw)
     joined = rf"\A\s*(?:{one})(?:\s*,\s*(?:{one}))*\s*\Z"
-    return [re.compile(joined, re.IGNORECASE)]
+    try:
+        return [re.compile(joined, re.IGNORECASE)]
+    except re.error as exc:
+        # Patterns that each compile alone can still clash once combined — two
+        # reusing a group name is the common case. Reporting the raw failure
+        # would quote an offset into a joined pattern the user never wrote.
+        raise ExtractionError(
+            f"locator patterns {configured} cannot be combined into one "
+            f"matcher: {exc.msg} — make each pattern self-contained, using "
+            "non-capturing `(?:…)` groups rather than named or numbered ones"
+        ) from exc
 
 
 def is_valid_locator(locator: str, patterns: list[re.Pattern[str]]) -> bool:

--- a/defendable-science/defendable_science/digest/render.py
+++ b/defendable-science/defendable_science/digest/render.py
@@ -1,0 +1,134 @@
+"""Extraction mode's matrix merge — extracted cells into ``positioning.md``.
+
+A **merge, not a rewrite** (spec §9). The document this writes into is one the
+author hand-wrote: taxonomy prose, a PRISMA log, the per-branch delta, section
+comments. Everything the concept-matrix table does not own is written back
+verbatim by :func:`~defendable_science.core.mdtable.splice`, and the table
+itself is only ever inserted into or updated.
+
+Three properties are load-bearing, and each is a test in
+``tests/test_digest_render.py``:
+
+* **Render never deletes a row.** A paper leaving the survey is removed by
+  hand. Automatic deletion is the one operation here with no safe failure mode
+  — a bug that drops rows loses the author's work silently, and
+  defendable-science#94 is a live reminder of how that goes.
+* **``**This paper**`` is never touched.** It is the author's own delta, not a
+  paper anything extracted; a caller that asks to write it is refused rather
+  than obeyed or silently skipped.
+* **An ambiguous matrix is refused, not guessed at.** Two rows carrying one
+  citekey give no answer to *which row is the row*, and picking one would
+  overwrite a line the author wrote deliberately.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from defendable_science.core.mdtable import Row, splice
+from defendable_science.digest.extraction import (
+    NOT_ADDRESSED,
+    SELF_ROW,
+    ExtractionError,
+    Matrix,
+    read_matrix,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: How `NOT_ADDRESSED` appears in the matrix. Deliberately not an empty cell:
+#: an empty cell reads as *not yet extracted*, and "the paper does not address
+#: this axis" is a different — and evidenced — claim (spec §6.5). Italicised so
+#: it is visibly a marker rather than a value a paper reported.
+MATRIX_NOT_ADDRESSED = "*not addressed*"
+
+
+def _row_index(rows: list[Row], label: str, citekey: str) -> int | None:
+    """Return the index of `citekey`'s row, or ``None`` if it has none.
+
+    :raises ExtractionError: If more than one row carries the label. Which of
+        them is *the* row is unknowable, and updating either would overwrite a
+        line a human wrote on purpose.
+    """
+    hits = [i for i, row in enumerate(rows) if row.get(label, "").strip() == citekey]
+    if len(hits) > 1:
+        raise ExtractionError(
+            f"{citekey!r} appears in {len(hits)} rows of the concept matrix — "
+            "which row is the paper's row cannot be guessed; merge or delete "
+            "the duplicates by hand, then re-run"
+        )
+    return hits[0] if hits else None
+
+
+def _insertion_point(rows: list[Row], label: str) -> int:
+    """Return where a new row goes: last, but above the author's own delta.
+
+    `SELF_ROW` is the matrix's punchline — the delta every other row is there
+    to contrast with — so new prior work is inserted above it rather than
+    pushing it into the middle of the table.
+    """
+    if rows and rows[-1].get(label, "").strip() == SELF_ROW:
+        return len(rows) - 1
+    return len(rows)
+
+
+def _checked_values(values: dict[str, str], matrix: Matrix, citekey: str) -> Row:
+    """Return `values` as matrix cells, refusing an axis the matrix lacks.
+
+    :raises ExtractionError: If a key is not one of the matrix's axes. Writing
+        it would need a column the author never made, and dropping it would
+        lose a recorded cell without saying so.
+    """
+    unknown = sorted(set(values) - set(matrix.axes))
+    if unknown:
+        raise ExtractionError(
+            f"{citekey}: {unknown} is not a matrix axis — the concept matrix "
+            f"has {matrix.axes}; fix the axis name, or add the column to the "
+            "matrix and re-extract against it"
+        )
+    return {
+        axis: MATRIX_NOT_ADDRESSED if value == NOT_ADDRESSED else value
+        for axis, value in values.items()
+    }
+
+
+def render_matrix(positioning: Path, rows: dict[str, dict[str, str]]) -> str:
+    """Merge extracted cells into the concept matrix, returning the document.
+
+    Pure: it reads `positioning` and returns the text that should replace it,
+    writing nothing. Every refusal therefore leaves the file byte-identical,
+    which is the property the caller depends on.
+
+    A row already in the file and absent from `rows` survives untouched, as
+    does any column the author added beyond the axes. A citekey with no row
+    gets one, filled for the axes given and left empty for the rest — empty
+    because the author has something to fill in there, which is true.
+
+    :param positioning: The positioning document holding the concept matrix.
+    :param rows: The cells to merge: citekey → axis → value. A value equal to
+        `NOT_ADDRESSED` renders as `MATRIX_NOT_ADDRESSED`.
+    :returns: The whole document with its matrix merged.
+    :raises ExtractionError: If the matrix cannot be read or is not ready to be
+        rendered into (see :func:`~.extraction.read_matrix`); if `rows` names
+        `SELF_ROW`, which is the author's own delta; if it names an axis the
+        matrix does not have; or if a citekey labels more than one row.
+    """
+    matrix = read_matrix(positioning)
+    if SELF_ROW in rows:
+        raise ExtractionError(
+            f"{positioning}: refusing to write the {SELF_ROW} row — it is the "
+            "author's own delta, not an extracted paper; record it by hand"
+        )
+    merged: list[Row] = [dict(row) for row in matrix.rows]
+    label = matrix.label_column
+    for citekey in sorted(rows):
+        values = _checked_values(rows[citekey], matrix, citekey)
+        index = _row_index(merged, label, citekey)
+        if index is None:
+            fresh: Row = dict.fromkeys(matrix.header, "")
+            fresh[label] = citekey
+            merged.insert(_insertion_point(merged, label), {**fresh, **values})
+        else:
+            merged[index].update(values)
+    return splice(matrix.preamble, matrix.postamble, matrix.header, merged)

--- a/defendable-science/defendable_science/digest/sampling.py
+++ b/defendable-science/defendable_science/digest/sampling.py
@@ -1,0 +1,90 @@
+"""Which papers the human checks — deterministically (spec §8, §3.5).
+
+Extraction's honesty claim rests on one thing: a human verified a sample of the
+extracted cells against the actual sources. That check is only worth anything if
+the sample cannot be steered, so selection is **seeded from the batch itself**:
+the same set of citekeys always draws the same papers, in this process and in
+every future one. A freshly-random draw per run would let anyone re-roll until
+an easy sample came up, and the run would look identical from the outside.
+
+The seed is a SHA-256 of the sorted citekeys, never Python's `hash()`:
+`hash()` on a `str` is salted per interpreter (``PYTHONHASHSEED``), so a
+`hash()`-seeded draw changes on every invocation while passing every
+same-process test. That failure mode is silent, which is precisely why it is
+ruled out here rather than left to review.
+
+Pure: no filesystem, no clock, no config. Membership of the batch is resolved by
+the caller (``digest extract sample``); this module only draws from it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from math import ceil
+
+from defendable_science.digest.extraction import ExtractionError
+
+#: Floor on the sample size. A convention, not a statistical guarantee — the
+#: spec says so plainly (§14), and `digest extract sample --size` exists so a
+#: real survey can calibrate it rather than inherit this guess.
+MIN_SAMPLE_SIZE = 3
+
+#: The batch fraction sampled above the floor: ``max(3, 10%)``.
+SAMPLE_DIVISOR = 10
+
+
+def default_size(n: int) -> int:
+    """Return the conventional sample size for a batch of `n` papers.
+
+    ``max(3, 10%)``, never more than the batch itself.
+
+    :param n: How many papers are in the batch.
+    :returns: The number of papers to draw.
+    """
+    return min(n, max(MIN_SAMPLE_SIZE, ceil(n / SAMPLE_DIVISOR)))
+
+
+def _seed(citekeys: list[str]) -> int:
+    """Derive the draw's seed from an already-sorted, de-duplicated batch.
+
+    :param citekeys: The batch, sorted and unique.
+    :returns: The seed for `random.Random`.
+    """
+    return int.from_bytes(
+        hashlib.sha256("\n".join(citekeys).encode("utf-8")).digest(), "big"
+    )
+
+
+def select_sample(citekeys: list[str], size: int) -> list[str]:
+    """Draw the batch's checked sample — the same papers, every time.
+
+    Duplicates are collapsed and the population is sorted before seeding, so the
+    draw depends on the *set* of papers and nothing else: not the order they
+    were listed in, not the process they were drawn in.
+
+    :param citekeys: The batch's citekeys, in any order.
+    :param size: How many to draw; clamped to the batch size, so a batch smaller
+        than the sample is checked whole.
+    :returns: The drawn citekeys, sorted for a stable report.
+    :raises ExtractionError: If the batch is empty, or `size` is below one —
+        either would report "sampled, nothing to check" for a run in which
+        nothing was checked, which is the one thing this command must never say.
+    """
+    population = sorted(set(citekeys))
+    if not population:
+        raise ExtractionError(
+            "an empty batch has no sample; there is nothing to check — name the "
+            "papers with --citekey, or extract some first"
+        )
+    if size < 1:
+        raise ExtractionError(
+            f"sample size must be at least 1, got {size} — a sample of none is "
+            "an unchecked batch, not a checked one"
+        )
+    # Deterministic by design: this PRNG is a reproducible selector, not a
+    # source of unpredictability.
+    drawn = random.Random(_seed(population)).sample(
+        population, min(size, len(population))
+    )
+    return sorted(drawn)

--- a/defendable-science/defendable_science/exploration/backlog.py
+++ b/defendable-science/defendable_science/exploration/backlog.py
@@ -63,14 +63,17 @@ _RANK_SOURCES = frozenset({"candidate", "parked"})
 #: Character cap on a minted row id (truncated on a word boundary).
 _ID_MAX = 40
 
-BacklogError = TableError
-"""Raised on an illegal transition, a missing row, or a guard violation.
 
-Aliases :class:`~defendable_science.core.mdtable.TableError` rather than
-subclassing it, so a ragged row raised while parsing the host table is still
-catchable as the single backlog error it was before the table core moved out
-of this module.
-"""
+class BacklogError(TableError):
+    """Raised on an illegal transition, a missing row, or a guard violation.
+
+    Subclasses :class:`~defendable_science.core.mdtable.TableError` so a ragged
+    row surfacing from the shared table parser is catchable as the one backlog
+    error (the parse boundaries below re-raise as this type). The direction
+    matters: a backlog failure is *a kind of* error a table front-end can raise,
+    whereas making ``TableError`` mean "any backlog condition" would have handed
+    the shared core a contract it cannot keep for its other consumers.
+    """
 
 
 def columns_for(level: Level) -> list[str]:
@@ -157,7 +160,10 @@ class Backlog:
             or a data row's cell count does not match the header (a ragged row
             would otherwise silently pad/drop required columns).
         """
-        doc = parse_document(text, row_label="backlog")
+        try:
+            doc = parse_document(text, row_label="backlog")
+        except TableError as exc:  # a table fault reaching a backlog caller
+            raise BacklogError(str(exc)) from exc
         if doc.header is None and doc.saw_table_shape:
             raise BacklogError(
                 "malformed backlog table: table-like rows with no GFM '|---|' "
@@ -487,12 +493,16 @@ def append_papers_registry(
     :param root: The paper's root path, relative to the repo.
     :param backend: The experiment-backend binding for the paper.
     :raises BacklogError: If `paper_id` is already registered, the registry table
-        lacks one of :data:`REGISTRY_COLUMNS`, or its rows are not anchored by a
-        GFM separator (writing into a malformed registry would corrupt it).
+        lacks one of :data:`REGISTRY_COLUMNS`, its rows are not anchored by a GFM
+        separator (writing into a malformed registry would corrupt it), or one of
+        its rows is ragged.
     """
     path = Path(papers_md)
     text = path.read_text(encoding="utf-8") if path.is_file() else ""
-    doc = parse_document(text, row_label="backlog")
+    try:
+        doc = parse_document(text, row_label="registry")
+    except TableError as exc:  # a table fault reaching a backlog caller
+        raise BacklogError(str(exc)) from exc
     if doc.header is None and doc.saw_table_shape:
         raise BacklogError(
             f"malformed registry table in {path}: table-like rows with no GFM "

--- a/defendable-science/defendable_science/exploration/backlog.py
+++ b/defendable-science/defendable_science/exploration/backlog.py
@@ -19,6 +19,16 @@ from datetime import date as date_cls
 from pathlib import Path
 from typing import Literal
 
+from defendable_science.core.mdtable import Document as Document
+from defendable_science.core.mdtable import Row as Row
+from defendable_science.core.mdtable import TableError
+from defendable_science.core.mdtable import escape_cell as escape_cell
+from defendable_science.core.mdtable import is_separator as is_separator
+from defendable_science.core.mdtable import parse_document as parse_document
+from defendable_science.core.mdtable import render_table as render_table
+from defendable_science.core.mdtable import splice as splice
+from defendable_science.core.mdtable import split_cells as split_cells
+
 Level = Literal["hypothesis", "paper"]
 
 HYPOTHESIS_COLUMNS = [
@@ -53,11 +63,14 @@ _RANK_SOURCES = frozenset({"candidate", "parked"})
 #: Character cap on a minted row id (truncated on a word boundary).
 _ID_MAX = 40
 
-Row = dict[str, str]
+BacklogError = TableError
+"""Raised on an illegal transition, a missing row, or a guard violation.
 
-
-class BacklogError(ValueError):
-    """Raised on an illegal transition, a missing row, or a guard violation."""
+Aliases :class:`~defendable_science.core.mdtable.TableError` rather than
+subclassing it, so a ragged row raised while parsing the host table is still
+catchable as the single backlog error it was before the table core moved out
+of this module.
+"""
 
 
 def columns_for(level: Level) -> list[str]:
@@ -84,168 +97,6 @@ def _slug(one_line: str, limit: int = _ID_MAX) -> str:
         return base
     head, sep, _ = base[: limit + 1].rpartition("-")
     return head if sep else base[:limit]
-
-
-# --- markdown table I/O -----------------------------------------------------
-
-
-def _escape(cell: str) -> str:
-    """Escape a cell for a markdown table (newlines and pipes)."""
-    return cell.replace("\\", "\\\\").replace("|", r"\|").replace("\n", " ")
-
-
-def _split_cells(line: str) -> list[str]:
-    """Split one markdown table row into unescaped cell values."""
-    line = line.strip()
-    if line.startswith("|"):
-        line = line[1:]
-    if line.endswith("|"):
-        line = line[:-1]
-    cells: list[str] = []
-    buf: list[str] = []
-    i = 0
-    while i < len(line):
-        char = line[i]
-        if char == "\\" and i + 1 < len(line):
-            buf.append(line[i + 1])
-            i += 2
-            continue
-        if char == "|":
-            cells.append("".join(buf).strip())
-            buf = []
-            i += 1
-            continue
-        buf.append(char)
-        i += 1
-    cells.append("".join(buf).strip())
-    return cells
-
-
-def _is_separator(cells: list[str]) -> bool:
-    """Return whether a parsed row is a ``|---|---|`` separator."""
-    return bool(cells) and all(set(c) <= {"-", ":"} and c for c in cells)
-
-
-@dataclass
-class _Document:
-    """A host markdown document with its table located in place.
-
-    :param preamble: Text before the table's header line, verbatim; the whole
-        document when it holds no table.
-    :param header: The column order read from the file, or ``None`` if the
-        document holds no table.
-    :param rows: The data rows, keyed by the file's own header.
-    :param postamble: Text after the table's last data row, verbatim.
-    :param saw_table_shape: Whether table-like rows were seen but never anchored
-        by a GFM separator (a malformed table, not an empty document).
-    """
-
-    preamble: str = ""
-    header: list[str] | None = None
-    rows: list[Row] = field(default_factory=list)
-    postamble: str = ""
-    saw_table_shape: bool = False
-
-
-def _collect_rows(
-    lines: list[str], header: list[str], start: int
-) -> tuple[list[Row], int]:
-    """Parse the contiguous data rows at `start`, with the index just past them.
-
-    The table ends at the first line that is not a non-separator pipe row, so
-    whatever follows is host prose to be preserved rather than table content.
-
-    :param lines: The document's lines (newlines kept).
-    :param header: The confirmed header, whose width every row must match.
-    :param start: Index of the first line after the GFM separator.
-    :returns: The parsed rows and the index of the first post-table line.
-    :raises BacklogError: If a data row's cell count does not match `header` (a
-        ragged row would otherwise silently pad/drop required columns).
-    """
-    rows: list[Row] = []
-    end = start
-    while end < len(lines):
-        if "|" not in lines[end]:
-            break
-        cells = _split_cells(lines[end])
-        if _is_separator(cells):
-            break
-        if len(cells) != len(header):
-            raise BacklogError(
-                f"ragged backlog row: {len(cells)} cells, header has "
-                f"{len(header)} ({cells!r})"
-            )
-        rows.append({header[i]: cells[i] for i in range(len(header))})
-        end += 1
-    return rows, end
-
-
-def _parse_document(text: str) -> _Document:
-    """Locate the markdown table in `text`, keeping the prose around it.
-
-    The header is the pipe line confirmed by a following GFM ``|---|`` separator;
-    that anchor is what distinguishes a real table from stray prose pipes.
-
-    :param text: The host markdown document.
-    :returns: The located document (``header is None`` if it holds no table).
-    :raises BacklogError: If a data row is ragged (see :func:`_collect_rows`).
-    """
-    lines = text.splitlines(keepends=True)
-    candidate: list[str] | None = None
-    candidate_at = 0
-    pending = 0  # consecutive unconfirmed pipe rows (a table shape sans separator)
-    saw_table_shape = False
-    for i, line in enumerate(lines):
-        if "|" not in line:
-            candidate = None  # prose breaks a pending header candidate
-            pending = 0
-            continue
-        cells = _split_cells(line)
-        if _is_separator(cells):
-            if candidate is None:
-                continue
-            rows, end = _collect_rows(lines, candidate, i + 1)
-            return _Document(
-                preamble="".join(lines[:candidate_at]),
-                header=candidate,
-                rows=rows,
-                postamble="".join(lines[end:]),
-            )
-        candidate, candidate_at = cells, i  # a header only if a separator follows
-        pending += 1
-        if pending >= 2:  # header + row(s) shape with no separator between
-            saw_table_shape = True
-    return _Document(preamble=text, saw_table_shape=saw_table_shape)
-
-
-def _render_table(header: list[str], rows: list[Row]) -> str:
-    """Render `rows` as a GFM table in `header`'s column order."""
-    lines = [
-        "| " + " | ".join(header) + " |",
-        "|" + "|".join("---" for _ in header) + "|",
-    ]
-    lines.extend(
-        "| " + " | ".join(_escape(row.get(c, "")) for c in header) + " |"
-        for row in rows
-    )
-    return "\n".join(lines) + "\n"
-
-
-def _splice(preamble: str, postamble: str, header: list[str], rows: list[Row]) -> str:
-    """Re-emit a host document with its table region replaced.
-
-    Everything the table does not own — the heading and the prose before and
-    after it — is written back verbatim, so ``load → mutate → save`` is lossless.
-
-    :param preamble: Host text before the table.
-    :param postamble: Host text after the table.
-    :param header: The column order to render.
-    :param rows: The rows to render.
-    :returns: The whole document, table spliced in.
-    """
-    if preamble and not preamble.endswith("\n"):
-        preamble += "\n"  # a table cannot start mid-line
-    return preamble + _render_table(header, rows) + postamble
 
 
 @dataclass
@@ -306,7 +157,7 @@ class Backlog:
             or a data row's cell count does not match the header (a ragged row
             would otherwise silently pad/drop required columns).
         """
-        doc = _parse_document(text)
+        doc = parse_document(text, row_label="backlog")
         if doc.header is None and doc.saw_table_shape:
             raise BacklogError(
                 "malformed backlog table: table-like rows with no GFM '|---|' "
@@ -334,7 +185,7 @@ class Backlog:
         The table is rendered in :attr:`columns` order; the heading and prose
         around it are written back verbatim.
         """
-        return _splice(self.preamble, self.postamble, self.columns, self.rows)
+        return splice(self.preamble, self.postamble, self.columns, self.rows)
 
     def save(self, path: str | Path) -> None:
         """Write the backlog — table and surrounding prose — to `path`."""
@@ -641,7 +492,7 @@ def append_papers_registry(
     """
     path = Path(papers_md)
     text = path.read_text(encoding="utf-8") if path.is_file() else ""
-    doc = _parse_document(text)
+    doc = parse_document(text, row_label="backlog")
     if doc.header is None and doc.saw_table_shape:
         raise BacklogError(
             f"malformed registry table in {path}: table-like rows with no GFM "
@@ -659,7 +510,7 @@ def append_papers_registry(
     doc.rows.append({"paper-id": paper_id, "root": root, "backend": backend})
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        _splice(doc.preamble, doc.postamble, header, doc.rows), encoding="utf-8"
+        splice(doc.preamble, doc.postamble, header, doc.rows), encoding="utf-8"
     )
 
 

--- a/defendable-science/defendable_science/literature/registry.py
+++ b/defendable-science/defendable_science/literature/registry.py
@@ -555,6 +555,24 @@ def _has_comments(text: str) -> bool:
     return any(line.lstrip().startswith("#") for line in text.splitlines())
 
 
+def _aliased_rows(raw: dict[Any, Any]) -> list[list[str]]:
+    """Return the groups of citekeys whose rows are the *same* Python object.
+
+    ``yaml.safe_load`` gives every alias of one anchor the same object, so
+    ``b2021: *shared`` is not a copy of ``a2020`` — it *is* ``a2020``. Identity
+    is the exact test for that and cannot false-positive: two rows written out
+    separately are distinct objects however identical they read.
+
+    :param raw: The top-level mapping, as :func:`triage_mapping` returned it.
+    :returns: One sorted citekey list per shared object, groups sorted; empty
+        when no two rows are the same object.
+    """
+    by_object: dict[int, list[str]] = {}
+    for key, row in raw.items():
+        by_object.setdefault(id(row), []).append(str(key))
+    return sorted(sorted(keys) for keys in by_object.values() if len(keys) > 1)
+
+
 def patch_triage(
     path: str | Path, citekey: str, updates: dict[str, str | int | bool | None]
 ) -> None:
@@ -575,17 +593,28 @@ def patch_triage(
     avoid. So the write is refused, naming the rows, and the human is told to
     edit by hand.
 
+    It covers, too, **two citekeys whose rows are one anchored mapping**
+    (``a2020: &shared`` / ``b2021: *shared``). ``yaml.safe_load`` hands both
+    names the same object, so setting a field on either sets it on both, and
+    ``safe_dump`` re-emits the alias — leaving a file that still looks
+    hand-authored while carrying, say, an extraction record for a paper nothing
+    ever extracted. Inventing an audit-trail entry is worse than losing one, so
+    this is refused as well, naming the rows that share an object.
+    :func:`_aliased_rows` tests object *identity*, which cannot false-positive:
+    two rows written out separately are distinct objects however alike they read.
+
     .. warning::
-       One class of loss is **not** guarded: ``yaml.safe_load`` resolves anchors
-       and aliases, so a sidecar using ``&anchor`` / ``*alias`` is written back
-       fully expanded. The data survives; the sharing does not. A file using
-       anchors should be hand-edited rather than patched.
+       One class of loss remains **unguarded** (defendable-science#143): an
+       anchored *scalar or nested value inside* a row (``rationale: *reason``)
+       is written back fully expanded. The data survives; the sharing does not.
+       A file using anchors that way should be hand-edited rather than patched.
 
     :param path: The sidecar path (created if absent).
     :param citekey: The row to patch (created if absent).
     :param updates: Scalar keys to set; a ``None`` value deletes the key.
     :raises RegistryError: If the file carries comments, holds a row that is not
-        a mapping, is unreadable, or any update value is not a scalar.
+        a mapping, holds two rows that are the same anchored mapping, is
+        unreadable, or any update value is not a scalar.
     """
     for key, value in updates.items():
         if value is not None and not isinstance(value, (str, int, bool)):
@@ -611,6 +640,15 @@ def patch_triage(
                 "'citekey: value' or a citekey with nothing under it yet. This "
                 "writer cannot rewrite the file without dropping them, so it is "
                 f"refusing — set {sorted(updates)} on {citekey!r} by hand"
+            )
+        shared = _aliased_rows(raw)
+        if shared:
+            raise RegistryError(
+                f"{target}: rows {shared} are the same mapping — citekeys joined "
+                "by a YAML anchor. Setting a field on any one of them would set "
+                "it on all of them, recording work that was never done on the "
+                "others. So it is refusing — give each row its own keys, or set "
+                f"{sorted(updates)} on {citekey!r} by hand"
             )
         data: dict[str, Any] = {str(key): row for key, row in raw.items()}
     else:

--- a/defendable-science/defendable_science/scaffold/layout.py
+++ b/defendable-science/defendable_science/scaffold/layout.py
@@ -113,6 +113,15 @@ class Layout:
         """The triage decision sidecar."""
         return self.literature_dir / "triage.yml"
 
+    @property
+    def digests_dir(self) -> Path:
+        """The directory holding one ``digest`` artifact per read paper."""
+        return self.literature_dir / "digests"
+
+    def digest(self, citekey: str) -> Path:
+        """Return the digest artifact of `citekey`."""
+        return self.digests_dir / f"{citekey}.md"
+
     # --- config ---
 
     @property
@@ -159,6 +168,10 @@ class Layout:
     def paper_docs_dir(self, paper_id: str) -> Path:
         """Return the staged-document directory of `paper_id`."""
         return self.paper_dir(paper_id) / "paper"
+
+    def positioning(self, paper_id: str) -> Path:
+        """Return the positioning document of `paper_id`."""
+        return self.paper_docs_dir(paper_id) / "positioning.md"
 
     def hypothesis_dir(self, paper_id: str, slug: str) -> Path:
         """Return one hypothesis folder of `paper_id`."""

--- a/defendable-science/tests/test_backlog.py
+++ b/defendable-science/tests/test_backlog.py
@@ -1253,3 +1253,50 @@ def test_registry_dumps_carries_a_heading_and_no_data_rows() -> None:
     assert "| paper-id | root | backend |" in text
     assert "|---" in text
     assert text.count("\n|") == 2  # header + separator only
+
+
+_REGISTRY_WITH_FENCED_EXAMPLE = """# Papers
+
+Register a paper by adding a row:
+
+```markdown
+| paper-id | root | backend |
+|---|---|---|
+| example | docs/research/example | bench |
+```
+
+| paper-id | root | backend |
+|---|---|---|
+| first | docs/research/first | bench |
+
+## Scope notes
+"""
+
+
+def test_registry_row_never_lands_in_a_fenced_example(tmp_path: Path) -> None:
+    """A how-to fence is documentation, not the registry (ruling AG)."""
+    papers = tmp_path / "papers.md"
+    papers.write_text(_REGISTRY_WITH_FENCED_EXAMPLE, encoding="utf-8")
+    b.append_papers_registry(papers, "second", "docs/research/second", "sim")
+    text = papers.read_text(encoding="utf-8")
+    fence = _REGISTRY_WITH_FENCED_EXAMPLE[
+        _REGISTRY_WITH_FENCED_EXAMPLE.index(
+            "```markdown"
+        ) : _REGISTRY_WITH_FENCED_EXAMPLE.index("\n\n| paper-id")
+    ]
+    assert fence in text  # byte-identical, example row and all
+    assert text == _REGISTRY_WITH_FENCED_EXAMPLE.replace(
+        "| first | docs/research/first | bench |\n",
+        "| first | docs/research/first | bench |\n| second | docs/research/second | sim |\n",
+    )
+
+
+def test_backlog_loads_past_a_fenced_example_table(tmp_path: Path) -> None:
+    """`Backlog.loads` reads the real table, not the one in the code fence."""
+    text = (
+        "# Backlog\n\nFormat:\n\n```\n| id | title |\n|---|---|\n| X1 | example |\n"
+        "```\n\n| id | status |\n|---|---|\n| h1 | parked |\n"
+    )
+    backlog = b.Backlog.loads(text, "hypothesis")
+    assert [row["id"] for row in backlog.rows] == ["h1"]
+    assert "| X1 | example |" in backlog.preamble

--- a/defendable-science/tests/test_backlog.py
+++ b/defendable-science/tests/test_backlog.py
@@ -275,7 +275,7 @@ def test_registry_root_fallback(tmp_path: Path) -> None:
 
 
 def test_split_cells_without_borders() -> None:
-    assert b._split_cells("a | b | c") == ["a", "b", "c"]
+    assert b.split_cells("a | b | c") == ["a", "b", "c"]
 
 
 def test_loads_ragged_row_raises() -> None:
@@ -558,7 +558,7 @@ def test_registry_row_lands_inside_the_table(tmp_path: Path) -> None:
     assert "| second | docs/research/second | sim |\n\n## Scope notes" in text
     assert text.endswith("- **first** — the anchor paper.\n")
     # Still one table: the parser sees both rows.
-    doc = b._parse_document(text)
+    doc = b.parse_document(text)
     assert [r["paper-id"] for r in doc.rows] == ["first", "second"]
 
 
@@ -571,7 +571,7 @@ def test_registry_extra_columns_are_filled_empty(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     b.append_papers_registry(papers, "second", "docs/research/second", "sim")
-    doc = b._parse_document(papers.read_text(encoding="utf-8"))
+    doc = b.parse_document(papers.read_text(encoding="utf-8"))
     assert doc.rows[1] == {
         "paper-id": "second",
         "root": "docs/research/second",
@@ -628,7 +628,7 @@ def test_scaffold_paper_row_is_inside_the_table(tmp_path: Path) -> None:
     research.mkdir(parents=True)
     (research / "papers.md").write_text(_REGISTRY_DOC, encoding="utf-8")
     b.scaffold_paper(research, "second", "a follow-up paper", backend="sim")
-    doc = b._parse_document((research / "papers.md").read_text(encoding="utf-8"))
+    doc = b.parse_document((research / "papers.md").read_text(encoding="utf-8"))
     assert [r["paper-id"] for r in doc.rows] == ["first", "second"]
     assert doc.rows[1]["root"] == "docs/research/second"
     assert doc.postamble.startswith("\n## Scope notes")
@@ -737,7 +737,7 @@ def test_promote_scaffold_paper_registers_and_reports(tmp_path: Path) -> None:
     }
     assert (root / "paper" / "pitch.md").is_file()
     assert (root / "backlog.md").is_file()
-    registry = b._parse_document((research / "papers.md").read_text(encoding="utf-8"))
+    registry = b.parse_document((research / "papers.md").read_text(encoding="utf-8"))
     assert registry.rows == [
         {
             "paper-id": "depth-collapse",

--- a/defendable-science/tests/test_backlog.py
+++ b/defendable-science/tests/test_backlog.py
@@ -603,6 +603,19 @@ def test_registry_malformed_table_raises(tmp_path: Path) -> None:
         b.append_papers_registry(papers, "p1", "docs/research/p1", "bench")
 
 
+def test_registry_ragged_row_raises_naming_the_registry(tmp_path: Path) -> None:
+    # A short registry row would silently pad required columns; the diagnostic
+    # must name the artifact the human edited, not the backlog.
+    papers = tmp_path / "papers.md"
+    papers.write_text(
+        "| paper-id | root | backend |\n|---|---|---|\n| first |\n", encoding="utf-8"
+    )
+    before = papers.read_text(encoding="utf-8")
+    with pytest.raises(b.BacklogError, match="ragged registry row"):
+        b.append_papers_registry(papers, "p1", "docs/research/p1", "bench")
+    assert papers.read_text(encoding="utf-8") == before
+
+
 def test_registry_absent_file_creates_three_column_table(tmp_path: Path) -> None:
     papers = tmp_path / "nested" / "papers.md"
     b.append_papers_registry(papers, "p1", "docs/research/p1", "bench")

--- a/defendable-science/tests/test_digest_artifact.py
+++ b/defendable-science/tests/test_digest_artifact.py
@@ -552,3 +552,143 @@ def test_set_batch_check_reports_an_artifact_without_frontmatter(
     target.write_text("# just prose\n", encoding="utf-8")
     with pytest.raises(ex.ExtractionError, match="no YAML frontmatter"):
         art.set_batch_check(target, "verified")
+
+
+# --- a hand-written block-style status.extraction (spec §5's own shape) --------
+
+#: Spec §5's example, literally: a human following the documented shape writes
+#: `extraction` as an indented block mapping, not as a flow mapping.
+SPEC_BLOCK_ARTIFACT = """---
+status:
+  understanding: {status: pending, unresolved: []}    # depth mode; untouched
+  extraction:
+    cells: 8
+    locators: ok
+    in-sample: false
+    batch-check: pending
+  last-updated: 2026-08-28
+---
+
+Prose.
+"""
+
+
+def test_writing_over_a_block_style_extraction_leaves_parseable_frontmatter(
+    tmp_path: Path,
+) -> None:
+    """The whole block mapping is the key's value, so the whole block goes.
+
+    Replacing only the `extraction:` line orphaned its children and produced a
+    frontmatter no parser would read — while reporting a completed write.
+    """
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(SPEC_BLOCK_ARTIFACT, encoding="utf-8")
+    _write(target, tmp_path / "log")
+
+    assert _status(target)["extraction"] == {
+        "cells": 2,
+        "locators": "ok",
+        "in-sample": False,
+        "batch-check": "pending",
+    }
+    assert _status(target)["understanding"] == {"status": "pending", "unresolved": []}
+    assert "Prose." in target.read_text(encoding="utf-8").splitlines()
+    assert art.read_cells(target) == _cells()
+
+
+def test_set_batch_check_over_a_block_style_extraction_keeps_its_other_keys(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(SPEC_BLOCK_ARTIFACT, encoding="utf-8")
+    art.set_batch_check(target, "failed")
+
+    assert _status(target)["extraction"] == {
+        "cells": 8,
+        "locators": "ok",
+        "in-sample": False,
+        "batch-check": "failed",
+    }
+    assert str(_status(target)["last-updated"]) == "2026-08-28"
+
+
+def test_a_block_style_value_does_not_swallow_the_keys_after_it(
+    tmp_path: Path,
+) -> None:
+    """Only the nested lines are the value; `last-updated` is a sibling."""
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(SPEC_BLOCK_ARTIFACT, encoding="utf-8")
+    _write(target, tmp_path / "log")
+
+    assert set(_status(target)) == {"understanding", "extraction", "last-updated"}
+
+
+def test_a_blank_line_inside_the_block_does_not_orphan_its_tail(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(
+        "---\nstatus:\n  extraction:\n    cells: 8\n\n    locators: ok\n"
+        "  last-updated: 2026-08-01\n---\n",
+        encoding="utf-8",
+    )
+    _write(target, tmp_path / "log")
+
+    assert _status(target)["extraction"]["cells"] == 2
+    assert set(_status(target)) == {"extraction", "last-updated"}
+
+
+def test_a_blank_line_after_the_block_survives(tmp_path: Path) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(
+        "---\nstatus:\n  extraction:\n    cells: 8\n\ntitle: x\n---\n",
+        encoding="utf-8",
+    )
+    _write(target, tmp_path / "log")
+
+    fm, _ = split_frontmatter(target.read_text(encoding="utf-8"))
+    assert "" in fm
+    assert "title: x" in fm
+
+
+def test_a_comment_inside_the_replaced_block_is_refused_not_destroyed(
+    tmp_path: Path,
+) -> None:
+    """`patch_triage`'s posture: refuse what cannot be round-tripped."""
+    target = tmp_path / f"{CITEKEY}.md"
+    original = (
+        "---\nstatus:\n  extraction:\n    cells: 8  # counted by hand\n"
+        "    batch-check: pending\n---\n"
+    )
+    target.write_text(original, encoding="utf-8")
+    with pytest.raises(ex.ExtractionError, match="carrying a comment"):
+        _write(target, tmp_path / "log")
+    assert target.read_text(encoding="utf-8") == original
+
+
+def test_a_comment_on_the_extraction_line_itself_is_preserved(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(
+        "---\nstatus:\n  extraction:  # hand-seeded\n    cells: 8\n---\n",
+        encoding="utf-8",
+    )
+    _write(target, tmp_path / "log")
+
+    fm, _ = split_frontmatter(target.read_text(encoding="utf-8"))
+    assert any(ln.endswith("# hand-seeded") for ln in fm)
+    assert _status(target)["extraction"]["cells"] == 2
+
+
+def test_set_batch_check_reports_a_block_value_json_cannot_rewrite(
+    tmp_path: Path,
+) -> None:
+    """An unquoted date under `extraction` decodes to `datetime.date`."""
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(
+        "---\nstatus:\n  extraction:\n    cells: 8\n    checked-on: 2026-08-28\n---\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ex.ExtractionError, match="cannot be rewritten"):
+        art.set_batch_check(target, "failed")

--- a/defendable-science/tests/test_digest_artifact.py
+++ b/defendable-science/tests/test_digest_artifact.py
@@ -842,3 +842,49 @@ def test_append_check_log_refuses_an_unknown_verdict(tmp_path: Path) -> None:
             log_dir=tmp_path / "log",
             date=DATE,
         )
+
+
+# --- set_in_sample: "a human checked these cells" ------------------------------
+
+
+def test_set_in_sample_touches_only_that_key(tmp_path: Path) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(DEPTH_ARTIFACT, encoding="utf-8")
+    _write(target, tmp_path / "log")
+    before = target.read_text(encoding="utf-8")
+
+    art.set_in_sample(target, in_sample=True)
+
+    after = target.read_text(encoding="utf-8")
+    assert _status(target)["extraction"] == {
+        "cells": 2,
+        "locators": "ok",
+        "in-sample": True,
+        # The verdict on the run is a separate question and must not move with it.
+        "batch-check": "pending",
+    }
+    assert UNDERSTANDING_LINE in after.splitlines()
+    assert _cells_span(after) == _cells_span(before)
+    assert _last_updated(target) == DATE
+
+
+def test_set_in_sample_can_stamp_the_check_date(tmp_path: Path) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    _write(target, tmp_path / "log")
+    art.set_in_sample(target, in_sample=True, date="2026-09-02")
+
+    assert _last_updated(target) == "2026-09-02"
+    assert _status(target)["extraction"]["in-sample"] is True
+
+
+def test_set_in_sample_refuses_a_missing_artifact(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="digest artifact not found"):
+        art.set_in_sample(tmp_path / "nope.md", in_sample=True)
+
+
+def test_set_in_sample_never_invents_an_extraction_block(tmp_path: Path) -> None:
+    """A paper that was never extracted cannot have been sampled."""
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text("---\nstatus:\n---\n", encoding="utf-8")
+    with pytest.raises(ex.ExtractionError, match="has not been extracted"):
+        art.set_in_sample(target, in_sample=True)

--- a/defendable-science/tests/test_digest_artifact.py
+++ b/defendable-science/tests/test_digest_artifact.py
@@ -784,3 +784,61 @@ def test_a_top_level_key_after_the_status_block_still_ends_the_search(
     fm, _ = split_frontmatter(target.read_text(encoding="utf-8"))
     assert "  extraction: not-a-status-child" in fm
     assert _status(target)["extraction"]["cells"] == 2
+
+
+# --- has_extraction: the batch-membership test (spec §8, ruling AL) ------------
+
+
+def test_has_extraction_is_true_for_an_extracted_artifact(tmp_path: Path) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    _write(target, tmp_path / "log")
+
+    assert art.has_extraction(target) is True
+
+
+def test_has_extraction_is_false_for_a_depth_only_digest(tmp_path: Path) -> None:
+    """A depth-mode reading record was never extracted, so it is not a member."""
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(
+        "---\nstatus:\n  understanding: {status: complete}\n---\n", encoding="utf-8"
+    )
+
+    assert art.has_extraction(target) is False
+
+
+def test_has_extraction_refuses_a_missing_artifact(tmp_path: Path) -> None:
+    """Absent is not 'never extracted' — the caller must hear about it."""
+    with pytest.raises(ex.ExtractionError, match="not found"):
+        art.has_extraction(tmp_path / "nowhere.md")
+
+
+def test_has_extraction_refuses_an_artifact_without_frontmatter(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text("just prose\n", encoding="utf-8")
+
+    with pytest.raises(ex.ExtractionError):
+        art.has_extraction(target)
+
+
+def test_has_extraction_refuses_unparseable_frontmatter(tmp_path: Path) -> None:
+    """Unreadable YAML is a failure, never a quiet 'not in the batch'."""
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text("---\nstatus: [unclosed\n---\n", encoding="utf-8")
+
+    with pytest.raises(ex.ExtractionError, match="not valid YAML"):
+        art.has_extraction(target)
+
+
+def test_append_check_log_refuses_an_unknown_verdict(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="batch-check must be one of"):
+        art.append_check_log(
+            tmp_path / f"{CITEKEY}.md",
+            CITEKEY,
+            _cells(),
+            verdict="probably fine",
+            batch=[CITEKEY],
+            log_dir=tmp_path / "log",
+            date=DATE,
+        )

--- a/defendable-science/tests/test_digest_artifact.py
+++ b/defendable-science/tests/test_digest_artifact.py
@@ -1,0 +1,554 @@
+"""Tests for extraction's artifact writer and the shared log appender."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+
+from defendable_science.core.frontmatter import split_frontmatter
+from defendable_science.digest import artifact as art
+from defendable_science.digest import extraction as ex
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+DATE = "2026-08-28"
+CITEKEY = "sill1997monotonic"
+
+#: A depth-mode artifact: an ``understanding`` block, a trailing comment, and
+#: prose. Every byte of it must survive an extraction write.
+DEPTH_ARTIFACT = """---
+title: Monotonic networks
+status:
+  understanding: {"status": "gaps", "unresolved": ["why convexity matters"]}  # defend
+  last-updated: 2026-08-01
+---
+
+# sill1997monotonic
+
+The author's own summary prose.
+"""
+
+UNDERSTANDING_LINE = (
+    '  understanding: {"status": "gaps", "unresolved": '
+    '["why convexity matters"]}  # defend'
+)
+
+
+def _cells(citekey: str = CITEKEY) -> list[ex.Cell]:
+    """Two cells: one value with a locator, one justified absence."""
+    return [
+        ex.Cell(citekey, "guarantee type", "architectural", locator="§2, Eq. (3)"),
+        ex.Cell(
+            citekey,
+            "scope",
+            ex.NOT_ADDRESSED,
+            justification="scoped to fully-monotone inputs in §1; never revisited",
+        ),
+    ]
+
+
+def _write(
+    path: Path,
+    log_dir: Path,
+    cells: list[ex.Cell] | None = None,
+    *,
+    in_sample: bool = False,
+    batch_check: str = "pending",
+) -> Path:
+    return art.write_extraction(
+        path,
+        _cells() if cells is None else cells,
+        in_sample=in_sample,
+        batch_check=batch_check,
+        log_dir=log_dir,
+        date=DATE,
+    )
+
+
+def _status(path: Path) -> dict[str, Any]:
+    fm, _ = split_frontmatter(path.read_text(encoding="utf-8"))
+    status = yaml.safe_load("\n".join(fm))["status"]
+    assert isinstance(status, dict)
+    return status
+
+
+def _last_updated(path: Path) -> str:
+    """``last-updated`` as written; YAML decodes an unquoted ISO date to a date."""
+    return str(_status(path)["last-updated"])
+
+
+# --- behaviour 1: a fresh artifact --------------------------------------------
+
+
+def test_a_fresh_artifact_is_seeded_with_the_extraction_block(tmp_path: Path) -> None:
+    target = tmp_path / "digests" / f"{CITEKEY}.md"
+    _write(target, tmp_path / "log")
+
+    assert _status(target)["extraction"] == {
+        "cells": 2,
+        "locators": "ok",
+        "in-sample": False,
+        "batch-check": "pending",
+    }
+    assert _last_updated(target) == DATE
+    assert art.read_cells(target) == _cells()
+
+
+def test_a_fresh_artifact_carries_the_cells_in_its_body(tmp_path: Path) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    _write(target, tmp_path / "log")
+    text = target.read_text(encoding="utf-8")
+    assert art.CELLS_BEGIN in text
+    assert art.CELLS_END in text
+    assert "guarantee type" in text
+
+
+# --- behaviour 2: an existing depth-mode artifact ------------------------------
+
+
+def test_an_existing_understanding_block_is_left_byte_identical(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(DEPTH_ARTIFACT, encoding="utf-8")
+    _write(target, tmp_path / "log")
+
+    lines = target.read_text(encoding="utf-8").splitlines()
+    assert UNDERSTANDING_LINE in lines
+    assert "title: Monotonic networks" in lines
+    assert "The author's own summary prose." in lines
+    assert _status(target)["extraction"]["cells"] == 2
+
+
+# --- behaviour 3: the guarantee-inflation guard (spec §3.2) --------------------
+
+
+def test_extraction_never_writes_an_understanding_key(tmp_path: Path) -> None:
+    """`progress` reads any `understanding` block as "digested & understood".
+
+    A paper with eight extracted cells that nobody read must not be counted as
+    read, so extraction's writer may not write that key at all — not even as
+    ``pending``. This test fails the moment the two writers are "simplified"
+    into one.
+    """
+    target = tmp_path / f"{CITEKEY}.md"
+    _write(target, tmp_path / "log")
+
+    fm, _ = split_frontmatter(target.read_text(encoding="utf-8"))
+    assert set(_status(target)) == {"extraction", "last-updated"}
+    assert not [ln for ln in fm if "understanding" in ln]
+
+
+def test_extraction_does_not_advance_a_pending_understanding_block(
+    tmp_path: Path,
+) -> None:
+    seeded = (
+        '---\nstatus:\n  understanding: {"status": "pending", "unresolved": []}\n---\n'
+    )
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(seeded, encoding="utf-8")
+    _write(target, tmp_path / "log")
+
+    assert _status(target)["understanding"] == {"status": "pending", "unresolved": []}
+
+
+# --- behaviour 4: in-sample and batch-check are separate keys (spec §5) --------
+
+
+def test_an_unsampled_paper_in_a_failed_batch_says_so_without_blaming_itself(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    _write(target, tmp_path / "log", in_sample=False, batch_check="failed")
+
+    block = _status(target)["extraction"]
+    assert block["in-sample"] is False
+    assert block["batch-check"] == "failed"
+
+
+def test_a_sampled_paper_in_a_verified_batch(tmp_path: Path) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    _write(target, tmp_path / "log", in_sample=True, batch_check="verified")
+
+    block = _status(target)["extraction"]
+    assert block["in-sample"] is True
+    assert block["batch-check"] == "verified"
+
+
+def test_an_unknown_batch_check_verdict_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="batch-check must be one of"):
+        _write(tmp_path / "a.md", tmp_path / "log", batch_check="probably fine")
+
+
+# --- behaviour 5: re-running replaces the cells --------------------------------
+
+
+def test_re_extracting_replaces_the_cells_rather_than_appending(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    _write(target, tmp_path / "log")
+    second = [ex.Cell(CITEKEY, "guarantee type", "learned", locator="§4")]
+    _write(target, tmp_path / "log", second)
+
+    text = target.read_text(encoding="utf-8")
+    assert text.count(art.CELLS_BEGIN) == 1
+    assert text.count(art.CELLS_END) == 1
+    assert art.read_cells(target) == second
+    assert _status(target)["extraction"]["cells"] == 1
+
+
+def test_re_extracting_preserves_prose_on_both_sides_of_the_block(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(DEPTH_ARTIFACT, encoding="utf-8")
+    _write(target, tmp_path / "log")
+    with target.open("a", encoding="utf-8") as fh:
+        fh.write("\nA note added afterwards.\n")
+    _write(target, tmp_path / "log")
+
+    lines = target.read_text(encoding="utf-8").splitlines()
+    assert "The author's own summary prose." in lines
+    assert "A note added afterwards." in lines
+
+
+# --- behaviour 6: the accountability log ---------------------------------------
+
+
+def test_the_log_entry_records_every_cell_including_the_absences(
+    tmp_path: Path,
+) -> None:
+    log_dir = tmp_path / "defend-log"
+    entry_path = _write(tmp_path / f"{CITEKEY}.md", log_dir)
+
+    assert entry_path == log_dir / f"{DATE}-{CITEKEY}.yml"
+    entry = yaml.safe_load(entry_path.read_text(encoding="utf-8"))[0]
+    assert entry["kind"] == "extraction"
+    assert entry["citekey"] == CITEKEY
+    assert entry["date"] == DATE
+    assert entry["not-addressed"] == 1
+    assert entry["cells"] == [
+        {
+            "axis": "guarantee type",
+            "value": "architectural",
+            "locator": "§2, Eq. (3)",
+        },
+        {
+            "axis": "scope",
+            "value": ex.NOT_ADDRESSED,
+            "justification": ("scoped to fully-monotone inputs in §1; never revisited"),
+        },
+    ]
+
+
+def test_a_second_extraction_the_same_day_never_overwrites_the_first(
+    tmp_path: Path,
+) -> None:
+    log_dir = tmp_path / "defend-log"
+    first = _write(tmp_path / f"{CITEKEY}.md", log_dir)
+    second = _write(
+        tmp_path / f"{CITEKEY}.md",
+        log_dir,
+        [ex.Cell(CITEKEY, "scope", "global", locator="§4")],
+    )
+
+    assert second == log_dir / f"{DATE}-{CITEKEY}-2.yml"
+    assert (
+        yaml.safe_load(first.read_text(encoding="utf-8"))[0]["cells"][0]["value"]
+        == "architectural"
+    )
+
+
+# --- behaviour 7: set_batch_check ----------------------------------------------
+
+
+def test_set_batch_check_touches_only_that_key(tmp_path: Path) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(DEPTH_ARTIFACT, encoding="utf-8")
+    _write(target, tmp_path / "log")
+    before = target.read_text(encoding="utf-8")
+
+    art.set_batch_check(target, "failed")
+
+    after = target.read_text(encoding="utf-8")
+    assert _status(target)["extraction"] == {
+        "cells": 2,
+        "locators": "ok",
+        "in-sample": False,
+        "batch-check": "failed",
+    }
+    assert UNDERSTANDING_LINE in after.splitlines()
+    assert _cells_span(after) == _cells_span(before)
+    assert _last_updated(target) == DATE
+
+
+def _cells_span(text: str) -> list[str]:
+    lines = text.splitlines()
+    return lines[lines.index(art.CELLS_BEGIN) : lines.index(art.CELLS_END) + 1]
+
+
+def test_set_batch_check_can_stamp_the_verdict_date(tmp_path: Path) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    _write(target, tmp_path / "log")
+    art.set_batch_check(target, "verified", date="2026-09-02")
+
+    assert _last_updated(target) == "2026-09-02"
+    assert _status(target)["extraction"]["batch-check"] == "verified"
+
+
+def test_set_batch_check_refuses_an_unknown_verdict(tmp_path: Path) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    _write(target, tmp_path / "log")
+    with pytest.raises(ex.ExtractionError, match="batch-check must be one of"):
+        art.set_batch_check(target, "looks-fine")
+    assert _status(target)["extraction"]["batch-check"] == "pending"
+
+
+def test_set_batch_check_refuses_a_missing_artifact(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="digest artifact not found"):
+        art.set_batch_check(tmp_path / "nope.md", "verified")
+
+
+def test_set_batch_check_never_invents_an_extraction_block(tmp_path: Path) -> None:
+    """A paper skipped for want of a PDF has no block, and must not gain one."""
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(DEPTH_ARTIFACT, encoding="utf-8")
+    with pytest.raises(ex.ExtractionError, match=r"no 'status\.extraction' block"):
+        art.set_batch_check(target, "failed")
+    assert target.read_text(encoding="utf-8") == DEPTH_ARTIFACT
+
+
+@pytest.mark.parametrize(
+    "frontmatter",
+    [
+        "status:\n  understanding: {}",  # a status block, but no extraction
+        "status: pending",  # status is a scalar, not a mapping
+        "just a bare string",  # frontmatter is not a mapping at all
+    ],
+)
+def test_set_batch_check_refuses_frontmatter_without_an_extraction_mapping(
+    tmp_path: Path, frontmatter: str
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(f"---\n{frontmatter}\n---\n", encoding="utf-8")
+    with pytest.raises(ex.ExtractionError, match=r"no 'status\.extraction' block"):
+        art.set_batch_check(target, "failed")
+
+
+def test_set_batch_check_reports_unparseable_frontmatter_as_such(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text("---\nstatus: [\n---\n", encoding="utf-8")
+    with pytest.raises(ex.ExtractionError, match="frontmatter is not valid YAML"):
+        art.set_batch_check(target, "failed")
+
+
+def test_set_batch_check_reports_a_missing_status_block(tmp_path: Path) -> None:
+    """`status.extraction` is read before the setter, so this is the read's word."""
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text("---\nnotstatus: 1\n---\n", encoding="utf-8")
+    with pytest.raises(ex.ExtractionError, match=r"no 'status\.extraction' block"):
+        art.set_batch_check(target, "failed")
+
+
+# --- the writer refuses what validation would have rejected (spec §3.3) --------
+
+
+def test_write_extraction_refuses_an_empty_cell_list(tmp_path: Path) -> None:
+    """A skipped paper gets no `status.extraction` block at all (spec §6.4)."""
+    with pytest.raises(ex.ExtractionError, match="takes one paper's cells"):
+        _write(tmp_path / "a.md", tmp_path / "log", [])
+    assert not (tmp_path / "a.md").exists()
+
+
+def test_write_extraction_refuses_cells_from_two_papers(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="takes one paper's cells"):
+        _write(tmp_path / "a.md", tmp_path / "log", [*_cells(), *_cells("other2020")])
+
+
+def test_write_extraction_refuses_a_value_cell_with_no_locator(
+    tmp_path: Path,
+) -> None:
+    cells = [ex.Cell(CITEKEY, "scope", "global", locator="   ")]
+    with pytest.raises(ex.ExtractionError, match="has no locator; refusing"):
+        _write(tmp_path / "a.md", tmp_path / "log", cells)
+
+
+def test_write_extraction_refuses_an_unjustified_absence(tmp_path: Path) -> None:
+    cells = [ex.Cell(CITEKEY, "scope", ex.NOT_ADDRESSED)]
+    with pytest.raises(ex.ExtractionError, match="with no justification"):
+        _write(tmp_path / "a.md", tmp_path / "log", cells)
+
+
+def test_write_extraction_reports_a_malformed_host_artifact(tmp_path: Path) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text("# no frontmatter here\n", encoding="utf-8")
+    with pytest.raises(ex.ExtractionError, match="no YAML frontmatter"):
+        _write(target, tmp_path / "log")
+
+
+def test_write_extraction_reports_a_frontmatter_without_a_status_block(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text("---\ntitle: x\n---\n", encoding="utf-8")
+    with pytest.raises(ex.ExtractionError, match="no 'status:' block"):
+        _write(target, tmp_path / "log")
+
+
+# --- a justified absence may cite the scope that excludes the axis -------------
+
+
+def test_an_absence_locator_is_recorded_as_scope_evidence_not_a_value_source(
+    tmp_path: Path,
+) -> None:
+    cells = [
+        ex.Cell(
+            CITEKEY,
+            "scope",
+            ex.NOT_ADDRESSED,
+            locator="§1",
+            justification="the paper scopes itself to fully-monotone inputs",
+        )
+    ]
+    target = tmp_path / f"{CITEKEY}.md"
+    _write(target, tmp_path / "log", cells)
+
+    text = target.read_text(encoding="utf-8")
+    assert "scope-evidence: §1" in text
+    assert "locator:" not in text
+    assert art.read_cells(target) == cells
+
+
+# --- read_cells ----------------------------------------------------------------
+
+
+def test_read_cells_refuses_a_missing_artifact(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="digest artifact not found"):
+        art.read_cells(tmp_path / "nope.md")
+
+
+def test_read_cells_refuses_an_artifact_without_frontmatter(tmp_path: Path) -> None:
+    target = tmp_path / "a.md"
+    target.write_text("# nothing\n", encoding="utf-8")
+    with pytest.raises(ex.ExtractionError, match="no YAML frontmatter"):
+        art.read_cells(target)
+
+
+def test_read_cells_refuses_an_unextracted_paper_rather_than_returning_none(
+    tmp_path: Path,
+) -> None:
+    """Empty would read as "extracted, zero cells" — a claim about the paper."""
+    target = tmp_path / "a.md"
+    target.write_text(DEPTH_ARTIFACT, encoding="utf-8")
+    with pytest.raises(ex.ExtractionError, match="no extracted-cells block"):
+        art.read_cells(target)
+
+
+def _artifact_with_body(tmp_path: Path, body: str) -> Path:
+    target = tmp_path / "a.md"
+    target.write_text(f"---\nstatus:\n---\n{body}", encoding="utf-8")
+    return target
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        f"{art.CELLS_END}\n",  # an end with no begin
+        f"{art.CELLS_BEGIN}\n",  # a begin with no end
+        f"{art.CELLS_BEGIN}\n{art.CELLS_BEGIN}\n{art.CELLS_END}\n",  # duplicated
+        f"{art.CELLS_END}\n{art.CELLS_BEGIN}\n",  # out of order
+    ],
+)
+def test_read_cells_refuses_malformed_markers(tmp_path: Path, body: str) -> None:
+    with pytest.raises(ex.ExtractionError, match="markers are malformed"):
+        art.read_cells(_artifact_with_body(tmp_path, body))
+
+
+def test_write_extraction_refuses_to_guess_which_span_to_replace(
+    tmp_path: Path,
+) -> None:
+    target = _artifact_with_body(tmp_path, f"{art.CELLS_BEGIN}\nstale\n")
+    before = target.read_text(encoding="utf-8")
+    with pytest.raises(ex.ExtractionError, match="markers are malformed"):
+        _write(target, tmp_path / "log")
+    assert target.read_text(encoding="utf-8") == before
+
+
+def test_read_cells_refuses_a_block_with_no_yaml_fence(tmp_path: Path) -> None:
+    body = f"{art.CELLS_BEGIN}\naxis: scope\n{art.CELLS_END}\n"
+    with pytest.raises(ex.ExtractionError, match="no ```yaml fence"):
+        art.read_cells(_artifact_with_body(tmp_path, body))
+
+
+def _fenced(payload: str) -> str:
+    return f"{art.CELLS_BEGIN}\n```yaml\n{payload}\n```\n{art.CELLS_END}\n"
+
+
+def test_read_cells_refuses_a_block_that_is_not_valid_yaml(tmp_path: Path) -> None:
+    target = _artifact_with_body(tmp_path, _fenced("citekey: ["))
+    with pytest.raises(ex.ExtractionError, match="not valid YAML"):
+        art.read_cells(target)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ["- a bare list", "citekey: k\ncells: not-a-list"],
+)
+def test_read_cells_refuses_a_block_of_the_wrong_shape(
+    tmp_path: Path, payload: str
+) -> None:
+    with pytest.raises(ex.ExtractionError, match="block is malformed"):
+        art.read_cells(_artifact_with_body(tmp_path, _fenced(payload)))
+
+
+def test_read_cells_refuses_a_non_mapping_cell_entry(tmp_path: Path) -> None:
+    payload = "citekey: k\ncells:\n- just a string"
+    with pytest.raises(ex.ExtractionError, match="non-mapping entry"):
+        art.read_cells(_artifact_with_body(tmp_path, _fenced(payload)))
+
+
+def test_read_cells_refuses_a_hand_edited_field_name(tmp_path: Path) -> None:
+    """A dropped ``locater`` typo would read back as a cell with no locator."""
+    payload = "citekey: k\ncells:\n- axis: scope\n  value: v\n  locater: §3"
+    with pytest.raises(ex.ExtractionError, match="unknown field"):
+        art.read_cells(_artifact_with_body(tmp_path, _fenced(payload)))
+
+
+# --- the shared log appender ----------------------------------------------------
+
+
+def test_append_log_entry_creates_the_directory_and_returns_its_path(
+    tmp_path: Path,
+) -> None:
+    from defendable_science.defend.record import append_log_entry
+
+    written = append_log_entry(tmp_path / "log", DATE, "stem", "body: 1\n")
+    assert written == tmp_path / "log" / f"{DATE}-stem.yml"
+    assert written.read_text(encoding="utf-8") == "body: 1\n"
+
+
+def test_the_block_is_appended_after_trailing_blank_lines_not_among_them(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text("---\nstatus:\n---\n\nProse.\n\n\n", encoding="utf-8")
+    _write(target, tmp_path / "log")
+
+    lines = target.read_text(encoding="utf-8").splitlines()
+    assert lines[lines.index(art.CELLS_BEGIN) - 1] == ""
+    assert lines[lines.index(art.CELLS_BEGIN) - 2] == "Prose."
+
+
+def test_set_batch_check_reports_an_artifact_without_frontmatter(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text("# just prose\n", encoding="utf-8")
+    with pytest.raises(ex.ExtractionError, match="no YAML frontmatter"):
+        art.set_batch_check(target, "verified")

--- a/defendable-science/tests/test_digest_artifact.py
+++ b/defendable-science/tests/test_digest_artifact.py
@@ -661,7 +661,7 @@ def test_a_comment_inside_the_replaced_block_is_refused_not_destroyed(
         "    batch-check: pending\n---\n"
     )
     target.write_text(original, encoding="utf-8")
-    with pytest.raises(ex.ExtractionError, match="carrying a comment"):
+    with pytest.raises(ex.ExtractionError, match="reads as carrying a comment"):
         _write(target, tmp_path / "log")
     assert target.read_text(encoding="utf-8") == original
 
@@ -692,3 +692,95 @@ def test_set_batch_check_reports_a_block_value_json_cannot_rewrite(
     )
     with pytest.raises(ex.ExtractionError, match="cannot be rewritten"):
         art.set_batch_check(target, "failed")
+
+
+# --- a comment is not a dedent, at any column ---------------------------------
+
+
+def _block_with_comment(comment_line: str) -> str:
+    return (
+        "---\nstatus:\n  extraction:\n"
+        f"{comment_line}\n"
+        "    cells: 8\n    batch-check: pending\n  last-updated: 2026-08-01\n---\n"
+    )
+
+
+@pytest.mark.parametrize(
+    "comment_line",
+    [
+        "# flush-left note",  # column 0
+        "  # a note at the parent's indent",  # the key's own indent
+        "    # a note at the children's indent",  # inside the block
+    ],
+)
+def test_write_refuses_a_comment_anywhere_in_the_block_it_would_replace(
+    tmp_path: Path, comment_line: str
+) -> None:
+    """A comment at any column ends the block scan if it is read as a dedent.
+
+    That would leave the scan short of the block's tail, so the refusal never
+    fires and only part of the value is replaced — the orphaned-children
+    corruption again, one column to the left.
+    """
+    target = tmp_path / f"{CITEKEY}.md"
+    original = _block_with_comment(comment_line)
+    target.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ex.ExtractionError, match="reads as carrying a comment"):
+        _write(target, tmp_path / "log")
+    assert target.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.parametrize(
+    "comment_line",
+    ["# flush-left note", "  # a note at the parent's indent"],
+)
+def test_set_batch_check_refuses_the_same_rather_than_reporting_success(
+    tmp_path: Path, comment_line: str
+) -> None:
+    target = tmp_path / f"{CITEKEY}.md"
+    original = _block_with_comment(comment_line)
+    target.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ex.ExtractionError, match="reads as carrying a comment"):
+        art.set_batch_check(target, "failed")
+    assert target.read_text(encoding="utf-8") == original
+
+
+def test_a_comment_before_the_key_does_not_hide_it_and_cause_a_duplicate(
+    tmp_path: Path,
+) -> None:
+    """Ending the *key search* on a comment inserts a second `extraction:`.
+
+    A duplicate key silently shadows the value just written, so the write would
+    report success and change nothing a reader sees.
+    """
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(
+        "---\nstatus:\n# a note about the block below\n"
+        '  extraction: {"cells": 8, "batch-check": "pending"}\n---\n',
+        encoding="utf-8",
+    )
+    art.set_batch_check(target, "verified")
+
+    text = target.read_text(encoding="utf-8")
+    assert text.count("extraction:") == 1
+    assert "# a note about the block below" in text
+    assert _status(target)["extraction"]["batch-check"] == "verified"
+
+
+def test_a_top_level_key_after_the_status_block_still_ends_the_search(
+    tmp_path: Path,
+) -> None:
+    """The dedent rule must still hold for anything that is not a comment."""
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(
+        "---\nstatus:\n  last-updated: 2026-08-01\nelsewhere:\n"
+        "  extraction: not-a-status-child\n---\n",
+        encoding="utf-8",
+    )
+    _write(target, tmp_path / "log")
+
+    fm, _ = split_frontmatter(target.read_text(encoding="utf-8"))
+    assert "  extraction: not-a-status-child" in fm
+    assert _status(target)["extraction"]["cells"] == 2

--- a/defendable-science/tests/test_digest_cli.py
+++ b/defendable-science/tests/test_digest_cli.py
@@ -961,6 +961,173 @@ def test_record_refuses_bad_locator_pattern_config(
     assert not Layout.default(root.resolve()).digest("sill1997monotonic").exists()
 
 
+# --- the shared report shape (fix: one contract across the four verbs) -------------
+
+
+def test_axes_reports_ok_and_no_error_on_the_happy_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``ok`` agrees with the exit code here exactly as it does for the others."""
+    root = _repo(tmp_path)
+    monkeypatch.chdir(root)
+    result = runner.invoke(app, ["digest", "extract", "axes", "--paper", "p1"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["error"] is None
+
+
+def test_axes_still_emits_a_report_when_the_matrix_is_unusable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A refusal is a report, and ``axes: null`` is not "a matrix with no axes"."""
+    root = _repo(tmp_path, positioning=PLACEHOLDER_POSITIONING)
+    monkeypatch.chdir(root)
+    result = runner.invoke(app, ["digest", "extract", "axes", "--paper", "p1"])
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    # The negative: a caller must not be able to read the refusal as an empty
+    # question set and go on to extract nothing against it.
+    assert payload["axes"] is None
+    assert payload["axes"] != []
+    assert "template placeholders" in payload["error"]
+    assert payload["positioning"].endswith("positioning.md")
+
+
+def test_record_still_emits_a_report_when_the_input_is_unusable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The parse failure is a run outcome, so it gets the run's report."""
+    root = _repo(tmp_path)
+    target = root / "cells.json"
+    target.write_text("[]", encoding="utf-8")
+    monkeypatch.chdir(root)
+    result = runner.invoke(
+        app,
+        ["digest", "extract", "record", "--paper", "p1", "--cells", str(target)],
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["axes"] is None
+    assert payload["recorded"] == []
+    assert payload["not_addressed"] == 0
+    assert "empty array" in payload["error"]
+
+
+def test_record_reports_no_error_when_everything_landed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    result = _record(root, GOOD_CELLS, monkeypatch=monkeypatch)
+    assert result.exit_code == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["error"] is None
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        pytest.param(["digest", "extract", "axes", "--paper", "p1"], id="axes"),
+        pytest.param(["digest", "extract", "render", "--paper", "p1"], id="render"),
+        pytest.param(["digest", "extract", "sample", "--all"], id="sample"),
+        pytest.param(
+            ["digest", "extract", "record", "--paper", "p1", "--cells", "cells.json"],
+            id="record",
+        ),
+    ],
+)
+def test_every_verb_reports_ok_agreeing_with_its_exit_code(
+    argv: list[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One contract for a caller scripting all four: JSON, and ``ok == exit 0``.
+
+    Run against a repo where each verb fails, because the failing paths are the
+    ones that used to disagree — two of them emitted no JSON at all.
+    """
+    root = _repo(tmp_path, positioning=PLACEHOLDER_POSITIONING)
+    (root / "docs" / "research" / "literature" / "digests").mkdir(parents=True)
+    (root / "cells.json").write_text(json.dumps(GOOD_CELLS), encoding="utf-8")
+    monkeypatch.chdir(root)
+    result = runner.invoke(app, argv)
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["error"]
+
+
+# --- record: the self-reference row is never an extracted paper ---------------------
+
+
+SELF_CELLS: list[dict[str, Any]] = [
+    {
+        "citekey": "**This paper**",
+        "axis": "guarantee type",
+        "value": "architectural",
+        "locator": "§1",
+    },
+    {
+        "citekey": "**This paper**",
+        "axis": "partial monotonicity",
+        "value": "yes",
+        "locator": "§2",
+    },
+]
+
+
+def test_record_refuses_the_self_row_as_a_citekey(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Otherwise the artifact lands and poisons every later ``render --all``.
+
+    Every cell here is individually valid, so nothing but this rule stops it.
+    """
+    root = _repo(tmp_path)
+    result = _record(
+        root, SELF_CELLS, "--log-dir", str(root / "log"), monkeypatch=monkeypatch
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["recorded"] == []
+    assert [r["citekey"] for r in payload["rejected"]] == ["**This paper**"]
+    # A whole-paper problem, so no axis is named — and it is the *only* reason
+    # reported, not buried under per-axis noise.
+    assert payload["rejected"][0]["axis"] is None
+    assert "author's own delta" in payload["rejected"][0]["reason"]
+    assert "**This paper**" in result.stderr
+    # Nothing on disk: no artifact to poison a later merge, no log entry.
+    digests = root / "docs" / "research" / "literature" / "digests"
+    assert not list(digests.glob("*.md"))
+    assert not (root / "log").exists()
+
+
+def test_the_self_row_is_rejected_per_paper_and_the_rest_still_records(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rejection is per paper, not per batch — and the merge still runs.
+
+    The defect this pins: caught only at ``render``, one poisoned artifact
+    refuses the *whole* batch's merge, forever, with a message about the
+    author's own delta rather than about the artifact.
+    """
+    root = _repo(tmp_path)
+    result = _record(root, [*SELF_CELLS, *GOOD_CELLS], monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert [r["citekey"] for r in payload["recorded"]] == ["sill1997monotonic"]
+    assert [r["citekey"] for r in payload["rejected"]] == ["**This paper**"]
+    layout = Layout.default(root.resolve())
+    assert layout.digest("sill1997monotonic").is_file()
+    assert not layout.digest("**This paper**").exists()
+    # And the merge the poisoned artifact would have blocked still succeeds.
+    merge = runner.invoke(app, ["digest", "extract", "render", "--paper", "p1"])
+    assert merge.exit_code == 0, merge.stdout + merge.stderr
+    assert json.loads(merge.stdout)["rendered"] == ["sill1997monotonic"]
+
+
 # --- exit codes --------------------------------------------------------------------
 
 

--- a/defendable-science/tests/test_digest_cli.py
+++ b/defendable-science/tests/test_digest_cli.py
@@ -176,7 +176,11 @@ def test_axes_positioning_option_overrides_the_layout(
         app, ["digest", "extract", "axes", "--positioning", "elsewhere.md"]
     )
     assert result.exit_code == 0
-    assert json.loads(result.stdout)["axes"] == ["only axis"]
+    payload = json.loads(result.stdout)
+    assert payload["axes"] == ["only axis"]
+    # The reported path is absolute whichever branch resolved it, even though a
+    # relative --positioning is honoured as typed.
+    assert payload["positioning"] == str(other.resolve())
 
 
 def test_axes_refuses_a_placeholder_matrix_without_a_traceback(
@@ -235,6 +239,7 @@ def test_record_writes_the_artifact_the_layout_names(
         }
     ]
     assert payload["rejected"] == []
+    assert payload["errors"] == []
     assert payload["not_addressed"] == 1
     assert payload["ok"] is True
 
@@ -347,6 +352,9 @@ def test_record_honours_the_positioning_override(
     )
     assert result.exit_code == 0, result.stderr
     assert Layout.default(root.resolve()).digest("a2020").is_file()
+    assert json.loads(result.stdout)["positioning"] == str(
+        (root / "other.md").resolve()
+    )
 
 
 # --- record: refusal (nothing may land) -------------------------------------------
@@ -511,8 +519,52 @@ def test_record_reports_a_write_failure_without_a_traceback(
     artifact.write_text("no frontmatter here\n", encoding="utf-8")
     result = _record(root, GOOD_CELLS, monkeypatch=monkeypatch)
     assert result.exit_code == 1
-    assert "digest extract record failed" in result.stderr
+    assert "digest extract record failed for sill1997monotonic" in result.stderr
     assert "Traceback" not in (result.stdout + result.stderr)
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["recorded"] == []
+    assert [e["citekey"] for e in payload["errors"]] == ["sill1997monotonic"]
+    assert payload["errors"][0]["artifact"] == str(artifact)
+    assert payload["errors"][0]["reason"]
+
+
+def test_record_reports_what_landed_when_one_paper_fails_to_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A partly-landed batch must say what landed, not only that it failed.
+
+    Aborting on the first write failure leaves the author knowing something went
+    wrong but not which papers are already recorded — and re-running the whole
+    batch to find out appends a second log entry for each of them.
+    """
+    root = _repo(tmp_path)
+    layout = Layout.default(root.resolve())
+    corrupt = layout.digest("zz2021")
+    corrupt.parent.mkdir(parents=True)
+    corrupt.write_text("no frontmatter here\n", encoding="utf-8")
+    cells = [
+        *GOOD_CELLS,
+        {"citekey": "zz2021", "axis": "guarantee type", "value": "v", "locator": "§1"},
+        {
+            "citekey": "zz2021",
+            "axis": "partial monotonicity",
+            "value": "w",
+            "locator": "§2",
+        },
+    ]
+    result = _record(
+        root, cells, "--log-dir", str(root / "log"), monkeypatch=monkeypatch
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert [r["citekey"] for r in payload["recorded"]] == ["sill1997monotonic"]
+    assert [e["citekey"] for e in payload["errors"]] == ["zz2021"]
+    assert payload["rejected"] == []
+    # The good paper really did land, exactly as the report says.
+    assert layout.digest("sill1997monotonic").is_file()
+    assert len(list((root / "log").iterdir())) == 1
 
 
 # --- record: malformed input -------------------------------------------------------
@@ -701,6 +753,15 @@ def test_write_extraction_is_reached_only_through_validate() -> None:
     Pinned structurally, not by example: a flag, an env var or an early branch
     that wrote without validating would satisfy every behavioural test that
     exercises the validated path, and fail this one.
+
+    **What this costs, so the next person does not loosen it by mistake.** The
+    test also fails for a refactor that is *not* a bypass: extracting the write
+    into a helper — even one called from exactly this loop — moves the call out
+    of `extract_record` and out of the loop over the accepted cells, and this
+    test cannot tell that apart from a second writer added elsewhere, because
+    the two have the same shape. That is deliberate. If you hit it during an
+    honest refactor, keep the write inline here; do not weaken the assertions to
+    let a call site float free of the validation that produced its arguments.
     """
     tree = ast.parse(Path(cli_mod.__file__).read_text(encoding="utf-8"))
     writes = _calls(tree, "write_extraction")

--- a/defendable-science/tests/test_digest_cli.py
+++ b/defendable-science/tests/test_digest_cli.py
@@ -694,6 +694,15 @@ def test_record_writes_the_cells_before_it_touches_triage(
             "not mappings",
             id="non-mapping-row",
         ),
+        pytest.param(
+            "a2020: &shared\n"
+            "  disposition: screened\n"
+            "b2021: *shared\n"
+            "sill1997monotonic:\n"
+            "  disposition: screened\n",
+            "same mapping",
+            id="aliased-rows",
+        ),
     ],
 )
 def test_record_reports_a_refused_triage_and_leaves_it_byte_identical(
@@ -730,6 +739,41 @@ def test_record_reports_a_refused_triage_and_leaves_it_byte_identical(
     assert [r["citekey"] for r in payload["recorded"]] == ["sill1997monotonic"]
     artifact = Layout.default(root.resolve()).digest("sill1997monotonic")
     assert len(read_cells(artifact)) == 2
+
+
+def test_record_never_fabricates_an_extraction_record_for_an_aliased_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The worst thing this branch could ship, pinned as a negative.
+
+    Rows joined by a YAML anchor are one dict after `yaml.safe_load`, so an
+    unguarded patch of ``sill1997monotonic`` would write ``extracted`` and
+    ``extraction-cells`` onto ``b2021`` and ``c2022`` as well — an extraction
+    record, in the PRISMA audit trail, for two papers this run never touched,
+    at exit 0 and with no diagnostic. The refusal is what prevents that; this
+    fails loudly if it is ever reverted.
+    """
+    root = _repo(tmp_path)
+    triage = _write_triage(
+        root,
+        "sill1997monotonic: &shared\n"
+        "  disposition: screened\n"
+        "b2021: *shared\n"
+        "c2022: *shared\n",
+    )
+    before = triage.read_bytes()
+    result = _record(root, GOOD_CELLS, monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    assert triage.read_bytes() == before
+    loaded = _triage(root)
+    for citekey in ("sill1997monotonic", "b2021", "c2022"):
+        assert "extracted" not in loaded[citekey]
+        assert "extraction-cells" not in loaded[citekey]
+    payload = json.loads(result.stdout)
+    assert payload["triage_not_updated"][0]["kind"] == "refused"
+    assert "b2021" in payload["triage_not_updated"][0]["reason"]
+    # And the ordering property still holds: the cells landed regardless.
+    assert len(read_cells(Layout.default(root.resolve()).digest("sill1997monotonic")))
 
 
 def test_record_reports_an_unwritable_triage_without_a_traceback(

--- a/defendable-science/tests/test_digest_cli.py
+++ b/defendable-science/tests/test_digest_cli.py
@@ -21,7 +21,9 @@ from typer.testing import CliRunner
 from defendable_science import cli as cli_mod
 from defendable_science.cli import app
 from defendable_science.core.frontmatter import split_frontmatter
+from defendable_science.digest import artifact as artifact_mod
 from defendable_science.digest.artifact import read_cells
+from defendable_science.literature import registry as registry_mod
 from defendable_science.scaffold.layout import Layout
 
 if TYPE_CHECKING:
@@ -565,6 +567,206 @@ def test_record_reports_what_landed_when_one_paper_fails_to_write(
     # The good paper really did land, exactly as the report says.
     assert layout.digest("sill1997monotonic").is_file()
     assert len(list((root / "log").iterdir())) == 1
+
+
+# --- record: the triage writeback --------------------------------------------------
+
+
+def _triage(root: Path) -> dict[str, Any]:
+    """Load the triage sidecar the default layout names."""
+    text = Layout.default(root.resolve()).triage.read_text(encoding="utf-8")
+    loaded = yaml.safe_load(text)
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _write_triage(root: Path, text: str) -> Path:
+    """Seed the triage sidecar with `text`, creating its directory."""
+    target = Layout.default(root.resolve()).triage
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+    return target
+
+
+def test_record_writes_the_extraction_facts_to_triage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A recorded paper leaves two factual scalars on its triage row."""
+    root = _repo(tmp_path)
+    result = _record(root, GOOD_CELLS, monkeypatch=monkeypatch)
+    assert result.exit_code == 0, result.stderr
+    row = _triage(root)["sill1997monotonic"]
+    assert row["extraction-cells"] == 2
+    # The same date the artifact carries — one value per run, not a second clock.
+    artifact = Layout.default(root.resolve()).digest("sill1997monotonic")
+    fm_lines, _body = split_frontmatter(artifact.read_text(encoding="utf-8"))
+    last_updated = yaml.safe_load("\n".join(fm_lines))["status"]["last-updated"]
+    assert row["extracted"] == str(last_updated)
+    assert isinstance(row["extracted"], str)
+    assert json.loads(result.stdout)["triage_not_updated"] == []
+
+
+def test_record_creates_a_triage_row_for_a_paper_that_had_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The sidecar need not exist yet, and existing rows must survive."""
+    root = _repo(tmp_path)
+    _write_triage(root, "other1997:\n  disposition: interesting\n")
+    assert _record(root, GOOD_CELLS, monkeypatch=monkeypatch).exit_code == 0
+    loaded = _triage(root)
+    assert loaded["other1997"] == {"disposition": "interesting"}
+    assert set(loaded["sill1997monotonic"]) == {"extracted", "extraction-cells"}
+
+
+def test_record_never_touches_disposition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`disposition` is the human's decision state machine — extraction is not.
+
+    A machine advancing ``screened -> interesting`` would be exactly the agency
+    violation this plugin exists to prevent, so the negative is pinned twice:
+    an existing value is left alone, and no key is invented where none was.
+    """
+    root = _repo(tmp_path)
+    _write_triage(
+        root,
+        "sill1997monotonic:\n"
+        "  disposition: screened\n"
+        "  rationale: matches the inclusion criteria\n"
+        "zz2021:\n"
+        "  rationale: queued\n",
+    )
+    cells = [
+        *GOOD_CELLS,
+        {"citekey": "zz2021", "axis": "guarantee type", "value": "v", "locator": "§1"},
+        {
+            "citekey": "zz2021",
+            "axis": "partial monotonicity",
+            "value": "w",
+            "locator": "§2",
+        },
+    ]
+    result = _record(root, cells, monkeypatch=monkeypatch)
+    assert result.exit_code == 0, result.stderr
+    loaded = _triage(root)
+    assert loaded["sill1997monotonic"]["disposition"] == "screened"
+    assert loaded["sill1997monotonic"]["rationale"] == "matches the inclusion criteria"
+    assert "disposition" not in loaded["zz2021"]
+    assert loaded["zz2021"]["extraction-cells"] == 2
+
+
+def test_record_writes_the_cells_before_it_touches_triage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ordering is load-bearing: a triage refusal must not discard cells."""
+    root = _repo(tmp_path)
+    calls: list[str] = []
+    real_write = artifact_mod.write_extraction
+    real_patch = registry_mod.patch_triage
+
+    def spy_write(*args: Any, **kwargs: Any) -> Any:
+        calls.append("write_extraction")
+        return real_write(*args, **kwargs)
+
+    def spy_patch(*args: Any, **kwargs: Any) -> None:
+        calls.append("patch_triage")
+        real_patch(*args, **kwargs)
+
+    monkeypatch.setattr(artifact_mod, "write_extraction", spy_write)
+    monkeypatch.setattr(registry_mod, "patch_triage", spy_patch)
+    assert _record(root, GOOD_CELLS, monkeypatch=monkeypatch).exit_code == 0
+    assert calls == ["write_extraction", "patch_triage"]
+
+
+@pytest.mark.parametrize(
+    ("sidecar", "wanted"),
+    [
+        pytest.param(
+            "# screened 2026-08-01 against the protocol\n"
+            "sill1997monotonic:\n"
+            "  disposition: screened\n"
+            "  rationale: the PRISMA audit trail lives in this comment\n",
+            "carries comments",
+            id="comments",
+        ),
+        pytest.param(
+            "other1997: include\nsill1997monotonic:\n  disposition: screened\n",
+            "not mappings",
+            id="non-mapping-row",
+        ),
+    ],
+)
+def test_record_reports_a_refused_triage_and_leaves_it_byte_identical(
+    sidecar: str, wanted: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The refusal is visible and non-zero-exit — and the cells still landed.
+
+    `patch_triage` refuses rather than destroy a hand-authored sidecar. That
+    refusal is not a write *failure*, so it gets its own report key: a reader
+    must not conclude the artifact failed when it did not.
+    """
+    root = _repo(tmp_path)
+    triage = _write_triage(root, sidecar)
+    before = triage.read_bytes()
+    result = _record(root, GOOD_CELLS, monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    assert "Traceback" not in (result.stdout + result.stderr)
+    assert "triage not updated for sill1997monotonic" in result.stderr
+    # Nothing was rewritten, and nothing stripped the comments to get around it.
+    assert triage.read_bytes() == before
+    assert not list(triage.parent.glob("*.tmp"))
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["errors"] == []
+    assert [t["citekey"] for t in payload["triage_not_updated"]] == [
+        "sill1997monotonic"
+    ]
+    assert wanted in payload["triage_not_updated"][0]["reason"]
+    assert str(triage) in payload["triage_not_updated"][0]["reason"]
+    # The extraction itself is intact: refusing the sidecar discards nothing.
+    assert [r["citekey"] for r in payload["recorded"]] == ["sill1997monotonic"]
+    artifact = Layout.default(root.resolve()).digest("sill1997monotonic")
+    assert len(read_cells(artifact)) == 2
+
+
+def test_record_reports_an_unwritable_triage_without_a_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An OS-level failure on the sidecar is reported, not raised."""
+    root = _repo(tmp_path)
+    triage = Layout.default(root.resolve()).triage
+    triage.mkdir(parents=True)  # a directory where the sidecar should be
+    result = _record(root, GOOD_CELLS, monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    assert "Traceback" not in (result.stdout + result.stderr)
+    payload = json.loads(result.stdout)
+    assert [t["citekey"] for t in payload["triage_not_updated"]] == [
+        "sill1997monotonic"
+    ]
+    assert payload["errors"] == []
+    assert Layout.default(root.resolve()).digest("sill1997monotonic").is_file()
+
+
+def test_record_honours_a_configured_triage_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path, config="literature:\n  triage: notes/decisions.yml\n")
+    assert _record(root, GOOD_CELLS, monkeypatch=monkeypatch).exit_code == 0
+    loaded = yaml.safe_load((root / "notes" / "decisions.yml").read_text("utf-8"))
+    assert loaded["sill1997monotonic"]["extraction-cells"] == 2
+    assert not Layout.default(root.resolve()).triage.exists()
+
+
+def test_record_does_not_touch_triage_for_a_paper_that_failed_to_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No cells, no claim: a failed artifact must leave no extraction facts."""
+    root = _repo(tmp_path)
+    artifact = Layout.default(root.resolve()).digest("sill1997monotonic")
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("no frontmatter here\n", encoding="utf-8")
+    assert _record(root, GOOD_CELLS, monkeypatch=monkeypatch).exit_code == 1
+    assert not Layout.default(root.resolve()).triage.exists()
 
 
 # --- record: malformed input -------------------------------------------------------

--- a/defendable-science/tests/test_digest_cli.py
+++ b/defendable-science/tests/test_digest_cli.py
@@ -1,0 +1,733 @@
+"""The ``digest extract`` CLI surface — axes, and the validating writer.
+
+The weight is on the negative assertions (spec §11): a rejected cell must leave
+**nothing** on disk, and there must be no path at this surface that records a
+cell without validating it first (spec §3.3). `test_write_extraction_is_reached_
+only_through_validate` pins that structurally, so a later bypass fails a test
+rather than shipping.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from defendable_science import cli as cli_mod
+from defendable_science.cli import app
+from defendable_science.core.frontmatter import split_frontmatter
+from defendable_science.digest.artifact import read_cells
+from defendable_science.scaffold.layout import Layout
+
+if TYPE_CHECKING:
+    from defendable_science.digest.extraction import Cell
+
+runner = CliRunner()
+
+POSITIONING = """# Positioning — p1
+
+Author prose that must survive untouched.
+
+## Concept matrix
+
+| Method | guarantee type | partial monotonicity |
+|---|---|---|
+| **This paper** | architectural | yes |
+
+More prose.
+"""
+
+PLACEHOLDER_POSITIONING = """# Positioning — p1
+
+## Concept matrix
+
+| Method | <attr 1> | <attr 2> |
+|---|---|---|
+| **This paper** | a | b |
+"""
+
+GOOD_CELLS: list[dict[str, Any]] = [
+    {
+        "citekey": "sill1997monotonic",
+        "axis": "guarantee type",
+        "value": "architectural — monotone by construction",
+        "locator": "§2, Eq. (3)",
+    },
+    {
+        "citekey": "sill1997monotonic",
+        "axis": "partial monotonicity",
+        "value": "not-addressed",
+        "justification": "scoped to fully-monotone inputs in §1; never revisited",
+    },
+]
+
+
+def _repo(
+    tmp_path: Path,
+    *,
+    config: str = "",
+    positioning: str = POSITIONING,
+) -> Path:
+    """Build a minimal onboarded repo with one paper's positioning document."""
+    (tmp_path / ".defendable-science").mkdir()
+    (tmp_path / ".defendable-science" / "config.yml").write_text(
+        config, encoding="utf-8"
+    )
+    docs = tmp_path / "docs" / "research" / "p1" / "paper"
+    docs.mkdir(parents=True)
+    (docs / "positioning.md").write_text(positioning, encoding="utf-8")
+    return tmp_path
+
+
+def _cells_file(tmp_path: Path, payload: object) -> str:
+    """Write a ``--cells`` JSON file and return its path."""
+    target = tmp_path / "cells.json"
+    target.write_text(json.dumps(payload), encoding="utf-8")
+    return str(target)
+
+
+def _record(
+    root: Path, cells: object, *extra: str, monkeypatch: pytest.MonkeyPatch
+) -> Any:
+    """Run ``digest extract record --paper p1`` over `cells` from `root`."""
+    monkeypatch.chdir(root)
+    return runner.invoke(
+        app,
+        [
+            "digest",
+            "extract",
+            "record",
+            "--paper",
+            "p1",
+            "--cells",
+            _cells_file(root, cells),
+            *extra,
+        ],
+    )
+
+
+# --- axes ----------------------------------------------------------------------
+
+
+def test_axes_prints_the_matrix_axes_as_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    monkeypatch.chdir(root)
+    result = runner.invoke(app, ["digest", "extract", "axes", "--paper", "p1"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["axes"] == ["guarantee type", "partial monotonicity"]
+    assert payload["positioning"].endswith("docs/research/p1/paper/positioning.md")
+
+
+def test_axes_resolves_the_positioning_document_from_the_layout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--paper`` names the paper; the layout supplies the path (never the cwd)."""
+    root = _repo(tmp_path, config="layout:\n  research_root: writing\n")
+    moved = root / "writing" / "p1" / "paper"
+    moved.mkdir(parents=True)
+    (moved / "positioning.md").write_text(POSITIONING, encoding="utf-8")
+    monkeypatch.chdir(root)
+    result = runner.invoke(app, ["digest", "extract", "axes", "--paper", "p1"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["positioning"] == str(moved / "positioning.md")
+
+
+def test_axes_infers_the_paper_from_the_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    monkeypatch.chdir(root / "docs" / "research" / "p1" / "paper")
+    result = runner.invoke(app, ["digest", "extract", "axes"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["axes"] == [
+        "guarantee type",
+        "partial monotonicity",
+    ]
+
+
+def test_axes_outside_a_paper_exits_2_naming_the_option(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    monkeypatch.chdir(root)
+    result = runner.invoke(app, ["digest", "extract", "axes"])
+    assert result.exit_code == 2
+    assert "--paper" in result.stderr
+
+
+def test_axes_positioning_option_overrides_the_layout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    other = root / "elsewhere.md"
+    other.write_text(
+        "## Concept matrix\n\n| Method | only axis |\n|---|---|\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(root)
+    result = runner.invoke(
+        app, ["digest", "extract", "axes", "--positioning", "elsewhere.md"]
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["axes"] == ["only axis"]
+
+
+def test_axes_refuses_a_placeholder_matrix_without_a_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path, positioning=PLACEHOLDER_POSITIONING)
+    monkeypatch.chdir(root)
+    result = runner.invoke(app, ["digest", "extract", "axes", "--paper", "p1"])
+    assert result.exit_code == 1
+    assert "template placeholders" in result.stderr
+    assert "Traceback" not in (result.stdout + result.stderr)
+
+
+def test_axes_reports_a_missing_positioning_document(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    monkeypatch.chdir(root)
+    result = runner.invoke(app, ["digest", "extract", "axes", "--paper", "p2"])
+    assert result.exit_code == 1
+    assert "positioning document not found" in result.stderr
+
+
+def test_axes_reports_an_invalid_layout_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path, config="layout:\n  nope: x\n")
+    monkeypatch.chdir(root)
+    result = runner.invoke(app, ["digest", "extract", "axes", "--paper", "p1"])
+    assert result.exit_code == 1
+    assert "unknown layout key" in result.stderr
+
+
+# --- record: the happy path ------------------------------------------------------
+
+
+def test_record_writes_the_artifact_the_layout_names(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The writer's path and ``Layout.digest`` must be the same file."""
+    root = _repo(tmp_path)
+    result = _record(root, GOOD_CELLS, monkeypatch=monkeypatch)
+    assert result.exit_code == 0, result.stderr
+    layout = Layout.default(root.resolve())
+    artifact = layout.digest("sill1997monotonic")
+    assert artifact.parent == layout.digests_dir
+    assert artifact.is_file()
+    payload = json.loads(result.stdout)
+    assert payload["recorded"] == [
+        {
+            "citekey": "sill1997monotonic",
+            "artifact": str(artifact),
+            "cells": 2,
+            "not_addressed": 1,
+            "log_entry": payload["recorded"][0]["log_entry"],
+        }
+    ]
+    assert payload["rejected"] == []
+    assert payload["not_addressed"] == 1
+    assert payload["ok"] is True
+
+
+def test_record_round_trips_through_read_cells(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    assert _record(root, GOOD_CELLS, monkeypatch=monkeypatch).exit_code == 0
+    cells: list[Cell] = read_cells(
+        Layout.default(root.resolve()).digest("sill1997monotonic")
+    )
+    assert [c.axis for c in cells] == ["guarantee type", "partial monotonicity"]
+    assert cells[0].locator == "§2, Eq. (3)"
+    assert cells[1].value == "not-addressed"
+
+
+def test_record_writes_extraction_and_never_understanding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    assert _record(root, GOOD_CELLS, monkeypatch=monkeypatch).exit_code == 0
+    text = Layout.default(root.resolve()).digest("sill1997monotonic").read_text()
+    fm_lines, _body = split_frontmatter(text)
+    status = yaml.safe_load("\n".join(fm_lines))["status"]
+    # The guarantee-inflation guard: extraction owns `extraction` and only it.
+    assert set(status) == {"extraction", "last-updated"}
+    assert status["extraction"] == {
+        "cells": 2,
+        "locators": "ok",
+        "in-sample": False,
+        "batch-check": "pending",
+    }
+
+
+def test_record_appends_the_accountability_log(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    result = _record(
+        root, GOOD_CELLS, "--log-dir", str(root / "log"), monkeypatch=monkeypatch
+    )
+    assert result.exit_code == 0
+    entries = sorted((root / "log").iterdir())
+    assert len(entries) == 1
+    assert "kind: extraction" in entries[0].read_text(encoding="utf-8")
+    assert json.loads(result.stdout)["recorded"][0]["log_entry"] == str(entries[0])
+
+
+def test_record_logs_under_the_layout_not_the_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Run from inside a paper, the log must not land in that paper's tree."""
+    root = _repo(tmp_path)
+    cells = _cells_file(root, GOOD_CELLS)
+    paper_dir = root / "docs" / "research" / "p1"
+    monkeypatch.chdir(paper_dir)
+    result = runner.invoke(app, ["digest", "extract", "record", "--cells", cells])
+    assert result.exit_code == 0, result.stderr
+    assert not (paper_dir / "docs").exists()
+    entries = sorted((root / "docs" / "research" / "defend-log").iterdir())
+    assert len(entries) == 1
+    assert json.loads(result.stdout)["recorded"][0]["log_entry"] == str(entries[0])
+
+
+def test_record_reads_the_cells_from_stdin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    monkeypatch.chdir(root)
+    result = runner.invoke(
+        app,
+        ["digest", "extract", "record", "--paper", "p1", "--cells", "-"],
+        input=json.dumps(GOOD_CELLS),
+    )
+    assert result.exit_code == 0, result.stderr
+    assert Layout.default(root.resolve()).digest("sill1997monotonic").is_file()
+
+
+def test_record_creates_the_digests_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``init`` does not scaffold ``literature/digests/``; ``record`` must."""
+    root = _repo(tmp_path)
+    assert not Layout.default(root.resolve()).digests_dir.exists()
+    assert _record(root, GOOD_CELLS, monkeypatch=monkeypatch).exit_code == 0
+    assert Layout.default(root.resolve()).digests_dir.is_dir()
+
+
+def test_record_honours_the_positioning_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    (root / "other.md").write_text(
+        "## Concept matrix\n\n| Method | only axis |\n|---|---|\n", encoding="utf-8"
+    )
+    result = _record(
+        root,
+        [
+            {
+                "citekey": "a2020",
+                "axis": "only axis",
+                "value": "v",
+                "locator": "p. 7",
+            }
+        ],
+        "--positioning",
+        "other.md",
+        monkeypatch=monkeypatch,
+    )
+    assert result.exit_code == 0, result.stderr
+    assert Layout.default(root.resolve()).digest("a2020").is_file()
+
+
+# --- record: refusal (nothing may land) -------------------------------------------
+
+_BAD_BATCHES: list[tuple[str, list[dict[str, Any]], str]] = [
+    (
+        "no locator",
+        [
+            {"citekey": "a2020", "axis": "guarantee type", "value": "v"},
+            {"citekey": "a2020", "axis": "partial monotonicity", "value": "w"},
+        ],
+        "has no locator",
+    ),
+    (
+        "vague locator",
+        [
+            {
+                "citekey": "a2020",
+                "axis": "guarantee type",
+                "value": "v",
+                "locator": "see paper",
+            },
+            {
+                "citekey": "a2020",
+                "axis": "partial monotonicity",
+                "value": "w",
+                "locator": "§1",
+            },
+        ],
+        "matches no known form",
+    ),
+    (
+        "omitted axis",
+        [
+            {
+                "citekey": "a2020",
+                "axis": "guarantee type",
+                "value": "v",
+                "locator": "§1",
+            }
+        ],
+        "is missing",
+    ),
+    (
+        "invented axis",
+        [
+            {
+                "citekey": "a2020",
+                "axis": "guarantee type",
+                "value": "v",
+                "locator": "§1",
+            },
+            {
+                "citekey": "a2020",
+                "axis": "partial monotonicity",
+                "value": "w",
+                "locator": "§2",
+            },
+            {"citekey": "a2020", "axis": "invented", "value": "x", "locator": "§3"},
+        ],
+        "is not a matrix axis",
+    ),
+    (
+        "duplicate axis",
+        [
+            {
+                "citekey": "a2020",
+                "axis": "guarantee type",
+                "value": "v",
+                "locator": "§1",
+            },
+            {
+                "citekey": "a2020",
+                "axis": "guarantee type",
+                "value": "v2",
+                "locator": "§2",
+            },
+            {
+                "citekey": "a2020",
+                "axis": "partial monotonicity",
+                "value": "w",
+                "locator": "§3",
+            },
+        ],
+        "recorded 2 times",
+    ),
+    (
+        "unjustified not-addressed",
+        [
+            {
+                "citekey": "a2020",
+                "axis": "guarantee type",
+                "value": "not-addressed",
+            },
+            {
+                "citekey": "a2020",
+                "axis": "partial monotonicity",
+                "value": "w",
+                "locator": "§2",
+            },
+        ],
+        "no justification",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("cells", "wanted"),
+    [pytest.param(c, w, id=name) for name, c, w in _BAD_BATCHES],
+)
+def test_record_refuses_and_writes_nothing(
+    cells: list[dict[str, Any]],
+    wanted: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No rule may be satisfied by a write: a rejected paper leaves no trace."""
+    root = _repo(tmp_path)
+    result = _record(
+        root, cells, "--log-dir", str(root / "log"), monkeypatch=monkeypatch
+    )
+    assert result.exit_code == 1
+    assert wanted in result.stderr
+    assert "a2020" in result.stderr
+    assert not Layout.default(root.resolve()).digest("a2020").exists()
+    assert not (root / "log").exists()
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["recorded"] == []
+    assert [r["citekey"] for r in payload["rejected"]] == ["a2020"] * len(
+        payload["rejected"]
+    )
+    assert all(r["axis"] for r in payload["rejected"])
+    assert any(wanted in r["reason"] for r in payload["rejected"])
+
+
+def test_record_rejects_per_paper_and_records_the_rest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One bad paper must not abort the sweep, and must not half-land."""
+    root = _repo(tmp_path)
+    cells = [
+        *GOOD_CELLS,
+        {"citekey": "bad2021", "axis": "guarantee type", "value": "v"},
+    ]
+    result = _record(root, cells, monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    layout = Layout.default(root.resolve())
+    assert layout.digest("sill1997monotonic").is_file()
+    assert not layout.digest("bad2021").exists()
+    payload = json.loads(result.stdout)
+    assert [r["citekey"] for r in payload["recorded"]] == ["sill1997monotonic"]
+    assert {r["citekey"] for r in payload["rejected"]} == {"bad2021"}
+
+
+def test_record_reports_a_write_failure_without_a_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    artifact = Layout.default(root.resolve()).digest("sill1997monotonic")
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("no frontmatter here\n", encoding="utf-8")
+    result = _record(root, GOOD_CELLS, monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    assert "digest extract record failed" in result.stderr
+    assert "Traceback" not in (result.stdout + result.stderr)
+
+
+# --- record: malformed input -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("payload", "wanted"),
+    [
+        pytest.param("{oops", "not valid JSON", id="not-json"),
+        pytest.param('{"citekey": "a"}', "must be a JSON array", id="not-an-array"),
+        pytest.param("[3]", "must be a JSON object", id="non-object-element"),
+        pytest.param(
+            '[{"citekey": "a", "axis": "b", "value": "c", "locater": "§1"}]',
+            "unknown field",
+            id="unknown-field",
+        ),
+        pytest.param(
+            '[{"citekey": "a", "axis": "b", "value": 3}]',
+            "must be a string",
+            id="wrong-type",
+        ),
+        pytest.param('[{"axis": "b"}]', "malformed", id="missing-field"),
+        pytest.param("[]", "empty", id="empty-array"),
+        pytest.param("   ", "empty", id="blank"),
+    ],
+)
+def test_record_refuses_a_malformed_cells_file(
+    payload: str, wanted: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    target = root / "cells.json"
+    target.write_text(payload, encoding="utf-8")
+    monkeypatch.chdir(root)
+    result = runner.invoke(
+        app,
+        ["digest", "extract", "record", "--paper", "p1", "--cells", str(target)],
+    )
+    assert result.exit_code == 1
+    assert wanted in result.stderr
+    assert "--cells" in result.stderr
+    assert "Traceback" not in (result.stdout + result.stderr)
+
+
+def test_record_reports_an_unreadable_cells_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    monkeypatch.chdir(root)
+    result = runner.invoke(
+        app, ["digest", "extract", "record", "--paper", "p1", "--cells", "nope.json"]
+    )
+    assert result.exit_code == 1
+    assert "Traceback" not in (result.stdout + result.stderr)
+    assert "nope.json" in result.stderr
+
+
+def test_record_refuses_a_placeholder_matrix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path, positioning=PLACEHOLDER_POSITIONING)
+    result = _record(root, GOOD_CELLS, monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    assert "template placeholders" in result.stderr
+
+
+# --- record: configured locator patterns --------------------------------------------
+
+
+def test_record_accepts_a_configured_locator_pattern(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(
+        tmp_path,
+        config=(
+            "literature:\n"
+            "  extraction:\n"
+            "    locator_patterns:\n"
+            '      - "para\\\\. \\\\d+"\n'
+        ),
+    )
+    cells = [
+        {
+            "citekey": "a2020",
+            "axis": "guarantee type",
+            "value": "v",
+            "locator": "para. 4",
+        },
+        {
+            "citekey": "a2020",
+            "axis": "partial monotonicity",
+            "value": "w",
+            "locator": "§2",
+        },
+    ]
+    result = _record(root, cells, monkeypatch=monkeypatch)
+    assert result.exit_code == 0, result.stderr
+    assert Layout.default(root.resolve()).digest("a2020").is_file()
+
+
+@pytest.mark.parametrize(
+    ("config", "wanted"),
+    [
+        pytest.param(
+            "literature:\n  extraction: nope\n",
+            "'literature.extraction' must be a mapping",
+            id="extraction-not-a-mapping",
+        ),
+        pytest.param(
+            "literature:\n  extraction:\n    locator_patterns: nope\n",
+            "'literature.extraction.locator_patterns' must be a list",
+            id="patterns-not-a-list",
+        ),
+        pytest.param(
+            "literature:\n  extraction:\n    locator_patterns: [3]\n",
+            "'literature.extraction.locator_patterns' must be a list",
+            id="pattern-not-a-string",
+        ),
+        pytest.param(
+            'literature:\n  extraction:\n    locator_patterns: ["([a-"]\n',
+            "invalid locator pattern '([a-'",
+            id="invalid-regex",
+        ),
+        pytest.param(
+            'literature:\n  extraction:\n    locator_patterns: ["(?P<x>a)", "(?P<x>b)"]\n',
+            "cannot be combined",
+            id="colliding-group-names",
+        ),
+        pytest.param(
+            "literature: nope\n",
+            "'literature' must be a mapping",
+            id="literature-not-a-mapping",
+        ),
+    ],
+)
+def test_record_refuses_bad_locator_pattern_config(
+    config: str, wanted: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path, config=config)
+    result = _record(root, GOOD_CELLS, monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    assert wanted in result.stderr
+    assert not Layout.default(root.resolve()).digest("sill1997monotonic").exists()
+
+
+# --- exit codes --------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        pytest.param(["digest", "extract", "record"], id="missing-required-option"),
+        pytest.param(["digest", "extract", "axes", "--nope"], id="unknown-option"),
+        pytest.param(["digest", "extract", "nope"], id="unknown-subcommand"),
+    ],
+)
+def test_a_usage_error_still_exits_2(
+    argv: list[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """2 belongs to Click. A domain outcome may never take it (#106/#119)."""
+    monkeypatch.chdir(_repo(tmp_path))
+    assert runner.invoke(app, argv).exit_code == 2
+
+
+# --- the structural guarantee (spec §3.3) --------------------------------------------
+
+
+def _callee(func: ast.expr) -> str | None:
+    """Return the called name, whether it is bare or attribute-qualified."""
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def _calls(node: ast.AST, name: str) -> list[ast.Call]:
+    """Return every call to `name` inside `node`."""
+    return [
+        n for n in ast.walk(node) if isinstance(n, ast.Call) and _callee(n.func) == name
+    ]
+
+
+def test_write_extraction_is_reached_only_through_validate() -> None:
+    """Validation and writing are one action — no bypass may be added.
+
+    Pinned structurally, not by example: a flag, an env var or an early branch
+    that wrote without validating would satisfy every behavioural test that
+    exercises the validated path, and fail this one.
+    """
+    tree = ast.parse(Path(cli_mod.__file__).read_text(encoding="utf-8"))
+    writes = _calls(tree, "write_extraction")
+    assert len(writes) == 1, "write_extraction must have exactly one call site"
+
+    functions = {n.name: n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)}
+    record_fn = functions["extract_record"]
+    assert _calls(record_fn, "write_extraction") == writes
+
+    # The accepted-cells name is whatever `validate`'s result is unpacked into.
+    validations = [
+        node
+        for node in ast.walk(record_fn)
+        if isinstance(node, ast.Assign) and _calls(node.value, "validate")
+    ]
+    assert len(validations) == 1
+    target = validations[0].targets[0]
+    assert isinstance(target, ast.Tuple)
+    accepted = target.elts[0]
+    assert isinstance(accepted, ast.Name)
+
+    # …and the single write sits inside a loop over exactly that name.
+    loops = [
+        node
+        for node in ast.walk(record_fn)
+        if isinstance(node, ast.For)
+        and accepted.id in ast.dump(node.iter)
+        and _calls(node, "write_extraction")
+    ]
+    assert len(loops) == 1

--- a/defendable-science/tests/test_digest_cli.py
+++ b/defendable-science/tests/test_digest_cli.py
@@ -723,6 +723,9 @@ def test_record_reports_a_refused_triage_and_leaves_it_byte_identical(
     ]
     assert wanted in payload["triage_not_updated"][0]["reason"]
     assert str(triage) in payload["triage_not_updated"][0]["reason"]
+    # A principled refusal, not a write that failed — a reader must be able to
+    # tell "edit this file by hand" from "the disk said no" without a regex.
+    assert payload["triage_not_updated"][0]["kind"] == "refused"
     # The extraction itself is intact: refusing the sidecar discards nothing.
     assert [r["citekey"] for r in payload["recorded"]] == ["sill1997monotonic"]
     artifact = Layout.default(root.resolve()).digest("sill1997monotonic")
@@ -743,6 +746,9 @@ def test_record_reports_an_unwritable_triage_without_a_traceback(
     assert [t["citekey"] for t in payload["triage_not_updated"]] == [
         "sill1997monotonic"
     ]
+    # `failed`, not `refused`: nothing here is a principled decision, and the
+    # remedy is not "edit the sidecar by hand".
+    assert payload["triage_not_updated"][0]["kind"] == "failed"
     assert payload["errors"] == []
     assert Layout.default(root.resolve()).digest("sill1997monotonic").is_file()
 

--- a/defendable-science/tests/test_digest_render.py
+++ b/defendable-science/tests/test_digest_render.py
@@ -410,6 +410,41 @@ def test_render_refuses_a_placeholder_matrix_without_writing(
     assert _positioning(root).read_bytes() == before
 
 
+def test_render_still_emits_a_report_when_the_merge_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A refused merge is a run outcome, so it gets the run's report too.
+
+    And the report must not claim the papers it *would* have written: the
+    document is byte-identical, so nothing was rendered.
+    """
+    placeholder = (
+        "# Positioning\n\n## Concept matrix\n\n| Method | <attr 1> |\n|---|---|\n"
+    )
+    root = _repo(tmp_path, placeholder)
+    _extract(root, "x2020", {"guarantee type": "v", "partial monotonicity": "no"})
+    before = _positioning(root).read_bytes()
+    result = _run(root, monkeypatch)
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["batch"] == ["x2020"]
+    assert payload["rendered"] == []
+    assert payload["changed"] is False
+    assert "template placeholders" in payload["error"]
+    assert _positioning(root).read_bytes() == before
+
+
+def test_render_reports_no_error_when_the_merge_lands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    _extract(root, "x2020", {"guarantee type": "v", "partial monotonicity": "no"})
+    result = _run(root, monkeypatch)
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["error"] is None
+
+
 def test_render_reports_a_write_failure_rather_than_a_traceback(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/defendable-science/tests/test_digest_render.py
+++ b/defendable-science/tests/test_digest_render.py
@@ -442,3 +442,41 @@ def test_render_is_idempotent_at_the_cli(
     assert second.exit_code == 0
     assert json.loads(second.stdout)["changed"] is False
     assert _positioning(root).read_bytes() == once
+
+
+def test_two_concept_matrix_sections_are_refused_not_guessed(tmp_path: Path) -> None:
+    """Which section is the matrix cannot be guessed; the file is not written."""
+    doubled = POSITIONING + "\n## Concept matrix\n\n| Method | other |\n|---|---|\n"
+    target = _write(tmp_path, doubled)
+    before = target.read_bytes()
+    with pytest.raises(ExtractionError, match="2 headings"):
+        render_matrix(target, {"x2020": {"guarantee type": "v"}})
+    assert target.read_bytes() == before
+
+
+def test_a_matrix_heading_inside_a_fence_is_not_a_second_matrix(
+    tmp_path: Path,
+) -> None:
+    shown = POSITIONING.replace(
+        "```markdown\n| Method | example axis |",
+        "```markdown\n## Concept matrix\n\n| Method | example axis |",
+    )
+    out = render_matrix(
+        _write(tmp_path, shown),
+        {"vanilla2020": {"guarantee type": "learned", "partial monotonicity": "no"}},
+    )
+    assert "| vanilla2020 | learned | no |" in out
+
+
+def test_the_cli_refuses_an_ambiguous_matrix_without_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    doubled = POSITIONING + "\n## Concept matrix\n\n| Method | other |\n|---|---|\n"
+    root = _repo(tmp_path, doubled)
+    _extract(root, "x2020", {"guarantee type": "v", "partial monotonicity": "no"})
+    before = _positioning(root).read_bytes()
+    result = _run(root, monkeypatch)
+    assert result.exit_code == 1
+    assert "2 headings" in result.stderr
+    assert "Traceback" not in (result.stdout + result.stderr)
+    assert _positioning(root).read_bytes() == before

--- a/defendable-science/tests/test_digest_render.py
+++ b/defendable-science/tests/test_digest_render.py
@@ -480,3 +480,37 @@ def test_the_cli_refuses_an_ambiguous_matrix_without_writing(
     assert "2 headings" in result.stderr
     assert "Traceback" not in (result.stdout + result.stderr)
     assert _positioning(root).read_bytes() == before
+
+
+def test_a_legend_table_above_the_matrix_is_refused_not_overwritten(
+    tmp_path: Path,
+) -> None:
+    """The worst pairing: the legend destroyed and the matrix never touched."""
+    with_legend = POSITIONING.replace(
+        "<!-- rows = prior work; the last row is our delta -->\n",
+        "<!-- rows = prior work; the last row is our delta -->\n\n"
+        "| symbol | meaning |\n|---|---|\n| yes | holds unconditionally |\n",
+    )
+    target = _write(tmp_path, with_legend)
+    before = target.read_bytes()
+    with pytest.raises(ExtractionError, match="holds 2 tables"):
+        render_matrix(target, {"x2020": {"guarantee type": "v"}})
+    assert target.read_bytes() == before
+
+
+def test_the_cli_refuses_a_section_holding_two_tables_without_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with_legend = POSITIONING.replace(
+        "<!-- rows = prior work; the last row is our delta -->\n",
+        "<!-- rows = prior work; the last row is our delta -->\n\n"
+        "| symbol | meaning |\n|---|---|\n| yes | holds unconditionally |\n",
+    )
+    root = _repo(tmp_path, with_legend)
+    _extract(root, "x2020", {"guarantee type": "v", "partial monotonicity": "no"})
+    before = _positioning(root).read_bytes()
+    result = _run(root, monkeypatch)
+    assert result.exit_code == 1
+    assert "holds 2 tables" in result.stderr
+    assert "Traceback" not in (result.stdout + result.stderr)
+    assert _positioning(root).read_bytes() == before

--- a/defendable-science/tests/test_digest_render.py
+++ b/defendable-science/tests/test_digest_render.py
@@ -79,12 +79,17 @@ def _matrix_block(text: str) -> str:
 def test_a_new_citekey_is_inserted_leaving_the_other_rows_alone(
     tmp_path: Path,
 ) -> None:
+    target = _write(tmp_path)
+    before = target.read_bytes()
     out = render_matrix(
-        _write(tmp_path),
+        target,
         {"vanilla2020": {"guarantee type": "learned", "partial monotonicity": "no"}},
     )
     assert "| vanilla2020 | learned | no |" in out
     assert "| sill1997 | architectural | no |" in out
+    # Purity on the *success* path too, not only on the refusals: the CLI is
+    # what decides whether anything reaches disk, so the merge must not write.
+    assert target.read_bytes() == before
 
 
 def test_a_new_row_lands_before_the_author_s_own_delta(tmp_path: Path) -> None:
@@ -513,4 +518,42 @@ def test_the_cli_refuses_a_section_holding_two_tables_without_writing(
     assert result.exit_code == 1
     assert "holds 2 tables" in result.stderr
     assert "Traceback" not in (result.stdout + result.stderr)
+    assert _positioning(root).read_bytes() == before
+
+
+def test_a_repeated_header_column_is_refused_before_it_eats_a_row_label(
+    tmp_path: Path,
+) -> None:
+    """``| Method | Method |``: the label cell collapses and a bogus row appears."""
+    doubled_column = (
+        "# Positioning\n\n## Concept matrix\n\n| Method | Method |\n|---|---|\n"
+        "| sill1997 | arch |\n"
+    )
+    target = _write(tmp_path, doubled_column)
+    before = target.read_bytes()
+    with pytest.raises(ExtractionError, match="duplicate column names"):
+        render_matrix(target, {"x2020": {"Method": "v"}})
+    assert target.read_bytes() == before
+
+
+def test_an_all_unreadable_batch_does_not_report_an_empty_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failure must not be announced as a legitimate empty result.
+
+    Every artifact was unreadable, so whether anything was extracted is
+    *unknown*. Saying "no extracted papers — run `digest extract record`" would
+    state a falsehood and prescribe the wrong repair.
+    """
+    root = _repo(tmp_path)
+    broken = _extract(root, "bad2021", {"guarantee type": "v"})
+    broken.write_text("not a digest at all\n", encoding="utf-8")
+    before = _positioning(root).read_bytes()
+    result = _run(root, monkeypatch)
+    assert result.exit_code == 1
+    assert "no extracted papers" not in result.stderr
+    assert "could not be read" in result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert [e["citekey"] for e in payload["errors"]] == ["bad2021"]
     assert _positioning(root).read_bytes() == before

--- a/defendable-science/tests/test_digest_render.py
+++ b/defendable-science/tests/test_digest_render.py
@@ -1,0 +1,444 @@
+"""The concept-matrix merge — ``render_matrix`` and ``digest extract render``.
+
+The weight is on the negatives (spec §9, §11). Render is the one operation in
+extraction mode with no safe failure mode: it writes into a file the author
+hand-wrote, so every test here that says "X survives" compares **bytes**, not a
+parsed projection, and the deletion tests are the point of the file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from typer.testing import CliRunner
+
+from defendable_science.cli import app
+from defendable_science.digest import artifact as artifact_mod
+from defendable_science.digest.extraction import Cell, ExtractionError
+from defendable_science.digest.render import (
+    MATRIX_NOT_ADDRESSED,
+    render_matrix,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+runner = CliRunner()
+
+POSITIONING = """# Positioning — p1
+
+Author prose that must survive untouched.
+
+A matrix looks like this:
+
+```markdown
+| Method | example axis |
+|---|---|
+| someone2020 | illustrative |
+```
+
+## Baselines
+
+| Baseline | Why |
+|---|---|
+| ridge | simplest floor |
+
+## Concept matrix
+
+<!-- rows = prior work; the last row is our delta -->
+
+| Method | guarantee type | partial monotonicity |
+|---|---|---|
+| sill1997 | architectural | no |
+| **This paper** | architectural | yes |
+
+## PRISMA log
+
+- 2026-08-01 — screened 120 records.
+"""
+
+
+def _write(tmp_path: Path, text: str = POSITIONING) -> Path:
+    target = tmp_path / "positioning.md"
+    target.write_text(text, encoding="utf-8")
+    return target
+
+
+def _matrix_block(text: str) -> str:
+    """Return the concept-matrix table region, for a targeted comparison."""
+    start = text.index("| Method |", text.index("## Concept matrix"))
+    return text[start : text.index("\n\n", start)]
+
+
+# --- render_matrix: the merge --------------------------------------------------
+
+
+def test_a_new_citekey_is_inserted_leaving_the_other_rows_alone(
+    tmp_path: Path,
+) -> None:
+    out = render_matrix(
+        _write(tmp_path),
+        {"vanilla2020": {"guarantee type": "learned", "partial monotonicity": "no"}},
+    )
+    assert "| vanilla2020 | learned | no |" in out
+    assert "| sill1997 | architectural | no |" in out
+
+
+def test_a_new_row_lands_before_the_author_s_own_delta(tmp_path: Path) -> None:
+    """``**This paper**`` is the matrix's punchline and stays last."""
+    out = render_matrix(
+        _write(tmp_path),
+        {"vanilla2020": {"guarantee type": "learned", "partial monotonicity": "no"}},
+    )
+    assert _matrix_block(out).splitlines()[-1].startswith("| **This paper** |")
+
+
+def test_a_new_row_is_appended_when_the_delta_row_is_not_last(tmp_path: Path) -> None:
+    """No self row at the end (here it leads): the new row simply goes last."""
+    led = POSITIONING.replace(
+        "| sill1997 | architectural | no |\n| **This paper** | architectural | yes |\n",
+        "| **This paper** | architectural | yes |\n| sill1997 | architectural | no |\n",
+    )
+    out = render_matrix(
+        _write(tmp_path, led),
+        {"vanilla2020": {"guarantee type": "learned", "partial monotonicity": "no"}},
+    )
+    assert _matrix_block(out).splitlines()[-1] == "| vanilla2020 | learned | no |"
+
+
+def test_an_existing_citekey_is_updated_in_place(tmp_path: Path) -> None:
+    out = render_matrix(
+        _write(tmp_path),
+        {"sill1997": {"guarantee type": "architectural (min-max)"}},
+    )
+    rows = [ln for ln in _matrix_block(out).splitlines() if ln.startswith("| sill1997")]
+    assert rows == ["| sill1997 | architectural (min-max) | no |"]  # column order kept
+
+
+def test_the_self_row_is_never_written(tmp_path: Path) -> None:
+    """The author's own delta is theirs; a caller asking to write it is refused."""
+    target = _write(tmp_path)
+    before = target.read_bytes()
+    with pytest.raises(ExtractionError, match=r"\*\*This paper\*\*"):
+        render_matrix(target, {"**This paper**": {"guarantee type": "rewritten"}})
+    assert target.read_bytes() == before
+
+
+def test_the_self_row_survives_a_render_of_other_papers(tmp_path: Path) -> None:
+    out = render_matrix(
+        _write(tmp_path),
+        {"vanilla2020": {"guarantee type": "learned", "partial monotonicity": "no"}},
+    )
+    assert "| **This paper** | architectural | yes |" in out
+
+
+def test_a_row_absent_from_the_rows_argument_survives(tmp_path: Path) -> None:
+    """Render never deletes: sill1997 is not in the batch and stays untouched."""
+    out = render_matrix(
+        _write(tmp_path),
+        {"vanilla2020": {"guarantee type": "learned", "partial monotonicity": "no"}},
+    )
+    assert "| sill1997 | architectural | no |" in out
+
+
+def test_rendering_nothing_deletes_nothing(tmp_path: Path) -> None:
+    out = render_matrix(_write(tmp_path), {})
+    assert "| sill1997 | architectural | no |" in out
+    assert "| **This paper** | architectural | yes |" in out
+
+
+def test_the_host_document_survives_byte_identical(tmp_path: Path) -> None:
+    """Preamble, the other table, the fenced example, the comment, the postamble."""
+    out = render_matrix(
+        _write(tmp_path),
+        {"vanilla2020": {"guarantee type": "learned", "partial monotonicity": "no"}},
+    )
+    assert out == POSITIONING.replace(
+        "| **This paper** | architectural | yes |\n",
+        "| vanilla2020 | learned | no |\n| **This paper** | architectural | yes |\n",
+    )
+
+
+def test_rendering_twice_is_idempotent(tmp_path: Path) -> None:
+    target = _write(tmp_path)
+    rows = {
+        "vanilla2020": {"guarantee type": "learned", "partial monotonicity": "no"},
+    }
+    first = render_matrix(target, rows)
+    target.write_text(first, encoding="utf-8")
+    assert render_matrix(target, rows) == first
+
+
+def test_a_pipe_or_newline_in_a_value_is_escaped(tmp_path: Path) -> None:
+    out = render_matrix(
+        _write(tmp_path),
+        {
+            "odd2021": {
+                "guarantee type": "a | b",
+                "partial monotonicity": "line one\nline two",
+            }
+        },
+    )
+    assert r"| odd2021 | a \| b | line one line two |" in out
+    # Still one well-formed table: the escaped pipe did not add a column.
+    assert len(_matrix_block(out).splitlines()) == 5
+
+
+def test_not_addressed_renders_as_a_marker_not_an_empty_cell(tmp_path: Path) -> None:
+    """An empty cell reads as "not yet extracted", a different claim."""
+    out = render_matrix(
+        _write(tmp_path),
+        {
+            "scoped2019": {
+                "guarantee type": "learned",
+                "partial monotonicity": "not-addressed",
+            }
+        },
+    )
+    assert f"| scoped2019 | learned | {MATRIX_NOT_ADDRESSED} |" in out
+    assert "| scoped2019 | learned |  |" not in out
+
+
+def test_an_axis_the_matrix_does_not_have_is_refused(tmp_path: Path) -> None:
+    target = _write(tmp_path)
+    before = target.read_bytes()
+    with pytest.raises(ExtractionError, match="not a matrix axis"):
+        render_matrix(target, {"x2020": {"invented axis": "v"}})
+    assert target.read_bytes() == before
+
+
+def test_a_duplicated_row_label_is_refused_rather_than_guessed(tmp_path: Path) -> None:
+    """Two rows for one citekey: which one is the row? Refuse, do not pick."""
+    doubled = POSITIONING.replace(
+        "| sill1997 | architectural | no |\n",
+        "| sill1997 | architectural | no |\n| sill1997 | learned | yes |\n",
+    )
+    target = _write(tmp_path, doubled)
+    with pytest.raises(ExtractionError, match="appears in 2 rows"):
+        render_matrix(target, {"sill1997": {"guarantee type": "v"}})
+
+
+def test_a_duplicate_label_elsewhere_does_not_block_an_unrelated_row(
+    tmp_path: Path,
+) -> None:
+    doubled = POSITIONING.replace(
+        "| sill1997 | architectural | no |\n",
+        "| sill1997 | architectural | no |\n| sill1997 | learned | yes |\n",
+    )
+    out = render_matrix(
+        _write(tmp_path, doubled), {"other2020": {"guarantee type": "v"}}
+    )
+    assert out.count("| sill1997 |") == 2  # both survive, untouched
+
+
+def test_a_column_beyond_the_axes_is_kept_on_an_updated_row(tmp_path: Path) -> None:
+    """An author's extra column is never dropped, and never invented into."""
+    extra = POSITIONING.replace(
+        "| Method | guarantee type | partial monotonicity |\n|---|---|---|\n"
+        "| sill1997 | architectural | no |\n"
+        "| **This paper** | architectural | yes |\n",
+        "| Method | guarantee type | partial monotonicity | notes |\n|---|---|---|---|\n"
+        "| sill1997 | architectural | no | seminal |\n"
+        "| **This paper** | architectural | yes | ours |\n",
+    )
+    out = render_matrix(
+        _write(tmp_path, extra),
+        {
+            "sill1997": {"guarantee type": "architectural (min-max)"},
+            "new2026": {"guarantee type": "learned"},
+        },
+    )
+    assert "| sill1997 | architectural (min-max) | no | seminal |" in out
+    assert "| new2026 | learned |  |  |" in out  # empty for the author to fill
+
+
+def test_a_document_with_no_concept_matrix_is_refused_not_rendered_empty(
+    tmp_path: Path,
+) -> None:
+    target = _write(tmp_path, "# Positioning\n\nprose only\n")
+    with pytest.raises(ExtractionError, match="no 'Concept matrix' section"):
+        render_matrix(target, {"x": {"a": "b"}})
+
+
+def test_a_matrix_inside_a_code_fence_is_never_written_into(tmp_path: Path) -> None:
+    """The only pipe table is an illustration: refuse, do not overwrite it."""
+    fenced = (
+        "# Positioning\n\n## Concept matrix\n\n"
+        "```markdown\n| Method | axis |\n|---|---|\n| ex | v |\n```\n"
+    )
+    target = _write(tmp_path, fenced)
+    with pytest.raises(ExtractionError, match="holds no table"):
+        render_matrix(target, {"x2020": {"axis": "v"}})
+    assert target.read_text(encoding="utf-8") == fenced
+
+
+# --- the CLI --------------------------------------------------------------------
+
+
+def _repo(tmp_path: Path, positioning: str = POSITIONING) -> Path:
+    """Build a minimal onboarded repo with one paper's positioning document."""
+    (tmp_path / ".defendable-science").mkdir()
+    (tmp_path / ".defendable-science" / "config.yml").write_text("", encoding="utf-8")
+    docs = tmp_path / "docs" / "research" / "p1" / "paper"
+    docs.mkdir(parents=True)
+    (docs / "positioning.md").write_text(positioning, encoding="utf-8")
+    return tmp_path
+
+
+def _positioning(root: Path) -> Path:
+    return root / "docs" / "research" / "p1" / "paper" / "positioning.md"
+
+
+def _extract(root: Path, citekey: str, values: Mapping[str, str]) -> Path:
+    """Record one paper's cells into its digest artifact."""
+    artifact = root / "docs" / "research" / "literature" / "digests" / f"{citekey}.md"
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    cells = [
+        Cell(
+            citekey=citekey,
+            axis=axis,
+            value=value,
+            justification="out of scope" if value == "not-addressed" else None,
+            locator=None if value == "not-addressed" else "§3",
+        )
+        for axis, value in values.items()
+    ]
+    artifact_mod.write_extraction(
+        artifact,
+        cells,
+        in_sample=False,
+        batch_check="pending",
+        log_dir=root / "docs" / "research" / "defend-log",
+        date="2026-08-28",
+    )
+    return artifact
+
+
+def _run(root: Path, monkeypatch: pytest.MonkeyPatch, *extra: str) -> Any:
+    monkeypatch.chdir(root)
+    return runner.invoke(app, ["digest", "extract", "render", "--paper", "p1", *extra])
+
+
+def test_render_merges_every_extracted_paper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    _extract(
+        root,
+        "vanilla2020",
+        {"guarantee type": "learned", "partial monotonicity": "not-addressed"},
+    )
+    result = _run(root, monkeypatch)
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["rendered"] == ["vanilla2020"]
+    assert payload["changed"] is True
+    text = _positioning(root).read_text(encoding="utf-8")
+    assert f"| vanilla2020 | learned | {MATRIX_NOT_ADDRESSED} |" in text
+    assert "| **This paper** | architectural | yes |" in text
+
+
+def test_render_restricted_to_named_citekeys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    _extract(root, "a2020", {"guarantee type": "one", "partial monotonicity": "no"})
+    _extract(root, "b2021", {"guarantee type": "two", "partial monotonicity": "no"})
+    result = _run(root, monkeypatch, "--citekey", "a2020")
+    assert result.exit_code == 0
+    text = _positioning(root).read_text(encoding="utf-8")
+    assert "| a2020 |" in text
+    assert "b2021" not in text
+
+
+def test_render_leaves_the_document_untouched_when_nothing_was_extracted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Not "rendered zero rows": no paper was extracted, and saying so is the job."""
+    root = _repo(tmp_path)
+    (root / "docs" / "research" / "literature" / "digests").mkdir(parents=True)
+    before = _positioning(root).read_bytes()
+    result = _run(root, monkeypatch)
+    assert result.exit_code == 1
+    assert "no extracted papers" in result.stderr
+    assert json.loads(result.stdout)["ok"] is False
+    assert _positioning(root).read_bytes() == before
+
+
+def test_render_reports_an_unreadable_artifact_and_still_lands_the_rest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    _extract(root, "good2020", {"guarantee type": "one", "partial monotonicity": "no"})
+    broken = _extract(
+        root, "bad2021", {"guarantee type": "two", "partial monotonicity": "no"}
+    )
+    broken.write_text("---\nstatus:\n  extraction: {}\n---\n\nno block\n", "utf-8")
+    result = _run(root, monkeypatch)
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["rendered"] == ["good2020"]
+    assert [e["citekey"] for e in payload["errors"]] == ["bad2021"]
+    assert "Traceback" not in (result.stdout + result.stderr)
+    text = _positioning(root).read_text(encoding="utf-8")
+    assert "| good2020 |" in text
+    assert "bad2021" not in text  # no row invented for a paper we could not read
+
+
+def test_render_refuses_a_placeholder_matrix_without_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    placeholder = (
+        "# Positioning\n\n## Concept matrix\n\n| Method | <attr 1> |\n|---|---|\n"
+    )
+    root = _repo(tmp_path, placeholder)
+    _extract(root, "x2020", {"guarantee type": "v", "partial monotonicity": "no"})
+    before = _positioning(root).read_bytes()
+    result = _run(root, monkeypatch)
+    assert result.exit_code == 1
+    assert "template placeholders" in result.stderr
+    assert "Traceback" not in (result.stdout + result.stderr)
+    assert _positioning(root).read_bytes() == before
+
+
+def test_render_reports_a_write_failure_rather_than_a_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    _extract(root, "x2020", {"guarantee type": "v", "partial monotonicity": "no"})
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(Path, "write_text", _boom)
+    result = _run(root, monkeypatch)
+    assert result.exit_code == 1
+    assert "read-only file system" in result.stderr
+    assert "Traceback" not in (result.stdout + result.stderr)
+
+
+def test_render_outside_a_paper_exits_2_naming_the_option(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    monkeypatch.chdir(root)
+    result = runner.invoke(app, ["digest", "extract", "render"])
+    assert result.exit_code == 2
+    assert "--paper" in result.stderr
+
+
+def test_render_is_idempotent_at_the_cli(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    _extract(root, "x2020", {"guarantee type": "v", "partial monotonicity": "no"})
+    assert _run(root, monkeypatch).exit_code == 0
+    once = _positioning(root).read_bytes()
+    second = _run(root, monkeypatch)
+    assert second.exit_code == 0
+    assert json.loads(second.stdout)["changed"] is False
+    assert _positioning(root).read_bytes() == once

--- a/defendable-science/tests/test_extraction.py
+++ b/defendable-science/tests/test_extraction.py
@@ -70,6 +70,22 @@ def test_section_present_but_no_table_refuses(tmp_path: Path) -> None:
         ex.axes_from_positioning(_write(tmp_path, "## Concept matrix\n\nTBD\n"))
 
 
+def test_the_missing_section_remedy_is_a_skill_request_not_a_shell_command(
+    tmp_path: Path,
+) -> None:
+    """`literature position` is a skill mode; there is no such CLI command.
+
+    Rendering it alone in backticks inside a CLI error reads as something to
+    paste into a terminal, where it fails — the defect class fixed across the
+    user guide in #102/#109.
+    """
+    with pytest.raises(ex.ExtractionError) as caught:
+        ex.axes_from_positioning(_write(tmp_path, "## Baselines\n\nprose\n"))
+    message = str(caught.value)
+    assert "ask the `literature` skill" in message
+    assert "`literature position" not in message
+
+
 def test_a_differently_cased_heading_still_reports_the_missing_table(
     tmp_path: Path,
 ) -> None:
@@ -90,9 +106,23 @@ def test_header_with_only_a_row_label_refuses(tmp_path: Path) -> None:
         ex.axes_from_positioning(_write(tmp_path, text))
 
 
-def test_a_blank_axis_name_refuses(tmp_path: Path) -> None:
+def test_a_table_missing_its_separator_says_so(tmp_path: Path) -> None:
+    """A header plus rows with no ``|---|`` is a table, not an absent one.
+
+    ``parse_document`` reports this as ``header=None, saw_table_shape=True``.
+    Without the discrimination the author is told the section "holds no table"
+    about a matrix sitting in front of them, with nothing to act on.
+    """
+    text = "## Concept matrix\n\n| Method | scope |\n| a | b |\n"
+    with pytest.raises(ex.ExtractionError, match=r"missing its .* separator"):
+        ex.axes_from_positioning(_write(tmp_path, text))
+
+
+def test_a_blank_axis_name_refuses_and_says_which_column(tmp_path: Path) -> None:
     text = "## Concept matrix\n\n| Method | scope |  |\n|---|---|---|\n| a | | |\n"
-    with pytest.raises(ex.ExtractionError, match="unnamed"):
+    with pytest.raises(ex.ExtractionError, match=r"unnamed columns at position\(s\)"):
+        ex.axes_from_positioning(_write(tmp_path, text))
+    with pytest.raises(ex.ExtractionError, match=r"\[3\]"):
         ex.axes_from_positioning(_write(tmp_path, text))
 
 
@@ -107,6 +137,21 @@ def test_duplicate_axis_names_refuse(tmp_path: Path) -> None:
         ex.axes_from_positioning(_write(tmp_path, text))
 
 
+def test_the_duplicate_refusal_names_only_the_repeats_and_a_remedy(
+    tmp_path: Path,
+) -> None:
+    text = (
+        "## Concept matrix\n\n| Method | scope | a | verifiability | a |\n"
+        "|---|---|---|---|---|\n| x | | | | |\n"
+    )
+    with pytest.raises(ex.ExtractionError) as caught:
+        ex.axes_from_positioning(_write(tmp_path, text))
+    message = str(caught.value)
+    assert "['a']" in message
+    assert "scope" not in message  # the innocent axes are not paraded as suspects
+    assert "rename" in message
+
+
 def test_a_ragged_matrix_refuses_as_an_extraction_error(tmp_path: Path) -> None:
     """A ragged row is the author's document to fix, reported against its path.
 
@@ -115,6 +160,6 @@ def test_a_ragged_matrix_refuses_as_an_extraction_error(tmp_path: Path) -> None:
     for the same "your positioning document is unusable" condition.
     """
     text = "## Concept matrix\n\n| Method | a | b |\n|---|---|---|\n| x | |\n"
-    with pytest.raises(ex.ExtractionError, match="ragged") as caught:
+    with pytest.raises(ex.ExtractionError, match="ragged concept-matrix row") as caught:
         ex.axes_from_positioning(_write(tmp_path, text))
     assert "positioning.md" in str(caught.value)

--- a/defendable-science/tests/test_extraction.py
+++ b/defendable-science/tests/test_extraction.py
@@ -297,6 +297,35 @@ def test_one_bad_paper_does_not_reject_a_good_one() -> None:
     assert {r.citekey for r in rejections} == {"bad"}
 
 
+def test_the_self_row_citekey_rejects_the_whole_paper() -> None:
+    """`**This paper**` is the author's own delta, never an extracted paper.
+
+    Caught here rather than only at the merge: an artifact recorded under this
+    citekey makes every later ``render --all`` refuse the *whole* batch.
+    """
+    accepted, rejections = ex.validate(_full(ex.SELF_ROW), AXES, PATTERNS)
+    assert accepted == {}
+    assert [r.citekey for r in rejections] == [ex.SELF_ROW]
+    # One reason, and a whole-paper one: no axis, and no per-axis noise on top.
+    assert rejections[0].axis is None
+    assert "author's own delta" in rejections[0].reason
+
+
+def test_the_self_row_is_rejected_per_paper_not_per_batch() -> None:
+    """The established posture: one bad paper must not take the batch with it."""
+    accepted, rejections = ex.validate(
+        [*_full("good"), *_full(ex.SELF_ROW)], AXES, PATTERNS
+    )
+    assert set(accepted) == {"good"}
+    assert {r.citekey for r in rejections} == {ex.SELF_ROW}
+
+
+def test_a_padded_self_row_citekey_is_rejected_too() -> None:
+    """Whitespace must not be a way past the rule."""
+    _, rejections = ex.validate(_full(f"  {ex.SELF_ROW} "), AXES, PATTERNS)
+    assert [r.axis for r in rejections] == [None]
+
+
 def test_not_addressed_needs_a_justification_not_a_locator() -> None:
     cells = [
         _cell(),

--- a/defendable-science/tests/test_extraction.py
+++ b/defendable-science/tests/test_extraction.py
@@ -377,3 +377,18 @@ def test_cell_from_mapping_rejects_an_unknown_field() -> None:
 def test_cell_from_mapping_rejects_a_missing_required_field() -> None:
     with pytest.raises(ex.ExtractionError, match="malformed"):
         ex.cell_from_mapping({"citekey": "k", "axis": "a"})
+
+
+def test_a_rejection_renders_as_one_line_naming_the_paper_and_the_cell() -> None:
+    """Spec §7.4: a refusal names the offending cell, never just a count."""
+    _, rejections = ex.validate(
+        [_cell(), _cell(axis="scope", locator="see paper")], AXES, PATTERNS
+    )
+    line = ex.render_rejection(rejections[0])
+    assert line.startswith("sill1997 / axis 'scope':")
+    assert "'see paper' matches no known form" in line
+
+
+def test_a_whole_paper_rejection_renders_without_inventing_an_axis() -> None:
+    line = ex.render_rejection(ex.Rejection("sill1997", None, "no cells at all"))
+    assert line == "sill1997 / no cells at all"

--- a/defendable-science/tests/test_extraction.py
+++ b/defendable-science/tests/test_extraction.py
@@ -1,0 +1,120 @@
+"""Tests for extraction's pure library: axes, cells, locators, validation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from defendable_science.digest import extraction as ex
+
+REAL = """## Concept matrix
+
+<!-- rows = methods -->
+
+| Method | guarantee type | scope | verifiability |
+|---|---|---|---|
+| *<prior work>* | | | |
+| **This paper** | | | |
+"""
+
+TEMPLATE = """## Concept matrix
+
+| Method | <attr 1> | <attr 2> | <attr 3> |
+|---|---|---|---|
+| **This paper** | | | |
+"""
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    target = tmp_path / "positioning.md"
+    target.write_text(text, encoding="utf-8")
+    return target
+
+
+def test_axes_are_the_header_minus_the_row_label(tmp_path: Path) -> None:
+    assert ex.axes_from_positioning(_write(tmp_path, REAL)) == [
+        "guarantee type",
+        "scope",
+        "verifiability",
+    ]
+
+
+def test_a_string_path_is_accepted(tmp_path: Path) -> None:
+    assert ex.axes_from_positioning(str(_write(tmp_path, REAL)))[0] == "guarantee type"
+
+
+def test_unreplaced_placeholders_refuse(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="placeholder"):
+        ex.axes_from_positioning(_write(tmp_path, TEMPLATE))
+
+
+def test_one_replaced_axis_still_refuses_if_others_are_placeholders(
+    tmp_path: Path,
+) -> None:
+    text = TEMPLATE.replace("<attr 1>", "guarantee type")
+    with pytest.raises(ex.ExtractionError, match="placeholder"):
+        ex.axes_from_positioning(_write(tmp_path, text))
+
+
+def test_no_concept_matrix_section_refuses(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="no 'Concept matrix'"):
+        ex.axes_from_positioning(_write(tmp_path, "## Baselines\n\nprose\n"))
+
+
+def test_section_present_but_no_table_refuses(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="no table"):
+        ex.axes_from_positioning(_write(tmp_path, "## Concept matrix\n\nTBD\n"))
+
+
+def test_a_differently_cased_heading_still_reports_the_missing_table(
+    tmp_path: Path,
+) -> None:
+    """The two refusals are told apart the way the parser finds the section.
+
+    ``parse_document`` matches a heading case-insensitively, so the
+    discriminator between "no section" and "section without a table" must too;
+    a case-sensitive substring test would blame the author for a missing
+    section they plainly wrote.
+    """
+    with pytest.raises(ex.ExtractionError, match="no table"):
+        ex.axes_from_positioning(_write(tmp_path, "### concept MATRIX\n\nTBD\n"))
+
+
+def test_header_with_only_a_row_label_refuses(tmp_path: Path) -> None:
+    text = "## Concept matrix\n\n| Method |\n|---|\n| a |\n"
+    with pytest.raises(ex.ExtractionError, match="no comparison axes"):
+        ex.axes_from_positioning(_write(tmp_path, text))
+
+
+def test_a_blank_axis_name_refuses(tmp_path: Path) -> None:
+    text = "## Concept matrix\n\n| Method | scope |  |\n|---|---|---|\n| a | | |\n"
+    with pytest.raises(ex.ExtractionError, match="unnamed"):
+        ex.axes_from_positioning(_write(tmp_path, text))
+
+
+def test_missing_file_refuses_actionably(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="not found"):
+        ex.axes_from_positioning(tmp_path / "absent.md")
+
+
+def test_duplicate_axis_names_refuse(tmp_path: Path) -> None:
+    text = "## Concept matrix\n\n| Method | a | a |\n|---|---|---|\n| x | | |\n"
+    with pytest.raises(ex.ExtractionError, match="duplicate"):
+        ex.axes_from_positioning(_write(tmp_path, text))
+
+
+def test_a_ragged_matrix_refuses_as_an_extraction_error(tmp_path: Path) -> None:
+    """A ragged row is the author's document to fix, reported against its path.
+
+    ``parse_document`` raises :class:`~defendable_science.core.mdtable.TableError`
+    here; letting that escape would make callers handle a second exception type
+    for the same "your positioning document is unusable" condition.
+    """
+    text = "## Concept matrix\n\n| Method | a | b |\n|---|---|---|\n| x | |\n"
+    with pytest.raises(ex.ExtractionError, match="ragged") as caught:
+        ex.axes_from_positioning(_write(tmp_path, text))
+    assert "positioning.md" in str(caught.value)

--- a/defendable-science/tests/test_extraction.py
+++ b/defendable-science/tests/test_extraction.py
@@ -392,3 +392,30 @@ def test_a_rejection_renders_as_one_line_naming_the_paper_and_the_cell() -> None
 def test_a_whole_paper_rejection_renders_without_inventing_an_axis() -> None:
     line = ex.render_rejection(ex.Rejection("sill1997", None, "no cells at all"))
     assert line == "sill1997 / no cells at all"
+
+
+def test_a_header_column_repeating_the_row_label_refuses(tmp_path: Path) -> None:
+    """A repeated column collapses the row it labels — refuse before that.
+
+    ``| Method | Method |`` parses each row into ``{header[i]: cells[i]}``, so
+    the duplicate key wins and the citekey cell is *lost*; re-emitting then
+    writes the survivor into both columns. The author's row labels would be
+    silently destroyed, in the one file with no safe failure mode.
+    """
+    text = "## Concept matrix\n\n| Method | Method |\n|---|---|\n| sill1997 | arch |\n"
+    with pytest.raises(
+        ex.ExtractionError, match=r"duplicate column names \['Method'\]"
+    ):
+        ex.axes_from_positioning(_write(tmp_path, text))
+
+
+def test_the_duplicate_column_refusal_names_only_the_repeats(tmp_path: Path) -> None:
+    text = (
+        "## Concept matrix\n\n| Method | breadth | Method |\n|---|---|---|\n| x | | |\n"
+    )
+    with pytest.raises(ex.ExtractionError) as caught:
+        ex.axes_from_positioning(_write(tmp_path, text))
+    message = str(caught.value)
+    assert "['Method']" in message
+    assert "breadth" not in message  # the innocent columns are not suspects
+    assert "rename" in message

--- a/defendable-science/tests/test_extraction.py
+++ b/defendable-science/tests/test_extraction.py
@@ -163,3 +163,203 @@ def test_a_ragged_matrix_refuses_as_an_extraction_error(tmp_path: Path) -> None:
     with pytest.raises(ex.ExtractionError, match="ragged concept-matrix row") as caught:
         ex.axes_from_positioning(_write(tmp_path, text))
     assert "positioning.md" in str(caught.value)
+
+
+# --- cells, locators, validation --------------------------------------------
+
+AXES = ["guarantee type", "scope"]
+
+
+def _cell(**kw: object) -> ex.Cell:
+    base: dict[str, object] = {
+        "citekey": "sill1997",
+        "axis": "guarantee type",
+        "value": "architectural",
+        "locator": "§2, Eq. (3)",
+    }
+    base.update(kw)
+    return ex.Cell(**base)  # type: ignore[arg-type]
+
+
+def _full(citekey: str = "sill1997") -> list[ex.Cell]:
+    return [
+        _cell(citekey=citekey, axis="guarantee type"),
+        _cell(citekey=citekey, axis="scope", locator="p. 4"),
+    ]
+
+
+PATTERNS = ex.compile_locator_patterns()
+
+
+@pytest.mark.parametrize(
+    "locator",
+    [
+        "§3",
+        "§3.2",
+        "§3.2.1",
+        "Section 3",
+        "Sec. 3",
+        "p. 7",
+        "pp. 7-9",
+        "pp. 7–9",  # noqa: RUF001 — an en dash is what a PDF page range pastes as
+        "page 7",
+        "Eq. (4)",
+        "Equation 4",
+        "Table 2",
+        "Fig. 5",
+        "Figure 5",
+        "Alg. 1",
+        "Thm. 2",
+        "Theorem 2",
+        "Lemma 3",
+        "Def. 1",
+        "§3, Eq. (4)",
+        "p. 7, Table 2",
+    ],
+)
+def test_well_formed_locators_are_accepted(locator: str) -> None:
+    assert ex.is_valid_locator(locator, PATTERNS)
+
+
+@pytest.mark.parametrize(
+    "locator",
+    [
+        "see paper",
+        "somewhere in §3",
+        "the introduction",
+        "passim",
+        "",
+        "   ",
+        "throughout",
+        "as discussed",
+    ],
+)
+def test_vague_locators_are_refused(locator: str) -> None:
+    assert not ex.is_valid_locator(locator, PATTERNS)
+
+
+def test_extra_patterns_extend_the_default_set() -> None:
+    patterns = ex.compile_locator_patterns([r"cl\. \d+"])
+    assert ex.is_valid_locator("cl. 14", patterns)
+    assert ex.is_valid_locator("§3", patterns)
+
+
+def test_an_invalid_configured_pattern_refuses_by_name() -> None:
+    """A broken config regex must name itself, not surface as a raw `re.error`."""
+    with pytest.raises(ex.ExtractionError, match=r"invalid locator pattern"):
+        ex.compile_locator_patterns(["cl\\. (\\d+"])
+
+
+def test_a_complete_paper_is_accepted() -> None:
+    accepted, rejections = ex.validate(_full(), AXES, PATTERNS)
+    assert rejections == []
+    assert sorted(c.axis for c in accepted["sill1997"]) == ["guarantee type", "scope"]
+
+
+def test_a_missing_axis_rejects_the_whole_paper() -> None:
+    accepted, rejections = ex.validate(_full()[:1], AXES, PATTERNS)
+    assert accepted == {}
+    assert any("scope" in r.reason and "missing" in r.reason for r in rejections)
+
+
+def test_an_invented_axis_rejects_the_whole_paper() -> None:
+    cells = [*_full(), _cell(axis="made up", locator="§9")]
+    accepted, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert accepted == {}
+    assert any("not a matrix axis" in r.reason for r in rejections)
+
+
+def test_a_bad_locator_rejects_the_whole_paper_not_just_the_cell() -> None:
+    cells = [_cell(), _cell(axis="scope", locator="see paper")]
+    accepted, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert accepted == {}
+    assert any("see paper" in r.reason for r in rejections)
+
+
+def test_one_bad_paper_does_not_reject_a_good_one() -> None:
+    cells = [*_full("good"), *_full("bad")[:1]]
+    accepted, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert set(accepted) == {"good"}
+    assert {r.citekey for r in rejections} == {"bad"}
+
+
+def test_not_addressed_needs_a_justification_not_a_locator() -> None:
+    cells = [
+        _cell(),
+        _cell(
+            axis="scope",
+            value=ex.NOT_ADDRESSED,
+            locator=None,
+            justification="scoped to full monotonicity in §1",
+        ),
+    ]
+    accepted, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert rejections == []
+    assert len(accepted["sill1997"]) == 2
+
+
+def test_not_addressed_without_a_justification_is_rejected() -> None:
+    cells = [_cell(), _cell(axis="scope", value=ex.NOT_ADDRESSED, locator=None)]
+    _, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert any("justification" in r.reason for r in rejections)
+
+
+def test_not_addressed_with_a_blank_justification_is_rejected() -> None:
+    cells = [
+        _cell(),
+        _cell(
+            axis="scope",
+            value=ex.NOT_ADDRESSED,
+            locator=None,
+            justification="   ",
+        ),
+    ]
+    _, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert any("justification" in r.reason for r in rejections)
+
+
+def test_a_normal_cell_with_no_locator_is_rejected() -> None:
+    cells = [_cell(), _cell(axis="scope", locator=None)]
+    _, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert any("locator" in r.reason for r in rejections)
+
+
+def test_a_duplicated_axis_for_one_paper_is_rejected() -> None:
+    cells = [*_full(), _cell(axis="scope", locator="p. 9")]
+    _, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert any("twice" in r.reason for r in rejections)
+
+
+def test_a_rejection_names_the_axis_it_is_about() -> None:
+    """A count sends the reader hunting; the named cell does not (spec §7.4)."""
+    _, rejections = ex.validate(
+        [_cell(), _cell(axis="scope", locator="see paper")], AXES, PATTERNS
+    )
+    assert [(r.citekey, r.axis) for r in rejections] == [("sill1997", "scope")]
+
+
+def test_a_missing_axis_rejection_carries_the_axis_not_none() -> None:
+    _, rejections = ex.validate(_full()[:1], AXES, PATTERNS)
+    assert [r.axis for r in rejections] == ["scope"]
+
+
+def test_cell_from_mapping_builds_a_cell() -> None:
+    cell = ex.cell_from_mapping(
+        {"citekey": "k", "axis": "a", "value": "v", "locator": "§3"}
+    )
+    assert cell == ex.Cell(citekey="k", axis="a", value="v", locator="§3")
+
+
+def test_cell_from_mapping_rejects_a_non_string_field() -> None:
+    with pytest.raises(ex.ExtractionError, match="citekey"):
+        ex.cell_from_mapping({"citekey": 7, "axis": "a", "value": "v"})
+
+
+def test_cell_from_mapping_rejects_an_unknown_field() -> None:
+    with pytest.raises(ex.ExtractionError, match="unknown"):
+        ex.cell_from_mapping({"citekey": "k", "axis": "a", "value": "v", "bogus": "x"})
+
+
+def test_cell_from_mapping_rejects_a_missing_required_field() -> None:
+    with pytest.raises(ex.ExtractionError, match="malformed"):
+        ex.cell_from_mapping({"citekey": "k", "axis": "a"})

--- a/defendable-science/tests/test_extraction.py
+++ b/defendable-science/tests/test_extraction.py
@@ -250,6 +250,20 @@ def test_an_invalid_configured_pattern_refuses_by_name() -> None:
         ex.compile_locator_patterns(["cl\\. (\\d+"])
 
 
+def test_patterns_that_clash_only_once_combined_refuse_readably() -> None:
+    """Each compiles alone; joining them does not. That must not be a traceback.
+
+    The patterns come from the user's `literature.extraction.locator_patterns`,
+    so a raw ``re.error`` would quote a character offset into a combined
+    pattern they never wrote.
+    """
+    with pytest.raises(ex.ExtractionError, match="cannot be combined") as caught:
+        ex.compile_locator_patterns([r"(?P<n>\d+)", r"(?P<n>x\d+)"])
+    message = str(caught.value)
+    assert "(?P<n>x" in message  # the offending set is named, not just the clash
+    assert "position" not in message  # no offset into a pattern nobody wrote
+
+
 def test_a_complete_paper_is_accepted() -> None:
     accepted, rejections = ex.validate(_full(), AXES, PATTERNS)
     assert rejections == []

--- a/defendable-science/tests/test_layout.py
+++ b/defendable-science/tests/test_layout.py
@@ -20,6 +20,7 @@ def test_default_layout_derives_every_path_from_the_repo_root() -> None:
     assert out.literature_dir == Path("/repo/docs/research/literature")
     assert out.references == Path("/repo/docs/research/literature/references.json")
     assert out.triage == Path("/repo/docs/research/literature/triage.yml")
+    assert out.digests_dir == Path("/repo/docs/research/literature/digests")
     assert out.datasets_manifest == Path("/repo/datasets.yml")
     assert out.thesis_dir == Path("/repo/docs/research/thesis")
     assert out.aims == Path("/repo/docs/research/thesis/aims.md")
@@ -44,6 +45,25 @@ def test_paper_paths_are_derived_from_the_paper_id() -> None:
     assert out.hypothesis_dir("depth-collapse", "2026-03-04-monotone") == Path(
         "/repo/docs/research/depth-collapse/hypotheses/2026-03-04-monotone"
     )
+    assert out.positioning("depth-collapse") == Path(
+        "/repo/docs/research/depth-collapse/paper/positioning.md"
+    )
+
+
+def test_a_digest_is_named_for_its_citekey_and_follows_the_literature_dir() -> None:
+    out = lay.resolve_layout({"layout": {"literature_dir": "refs"}}, Path("/repo"))
+
+    assert out.digests_dir == Path("/repo/refs/digests")
+    assert out.digest("smith2024monotone") == Path(
+        "/repo/refs/digests/smith2024monotone.md"
+    )
+
+
+def test_positioning_is_a_staged_paper_document() -> None:
+    out = lay.Layout.default(Path("/repo"))
+
+    assert lay.STAGED_DOCUMENTS[out.positioning("p1").name] == "paper"
+    assert out.positioning("p1").parent == out.paper_docs_dir("p1")
 
 
 def test_rel_renders_a_path_for_display_and_tolerates_an_outside_path() -> None:

--- a/defendable-science/tests/test_lit_registry.py
+++ b/defendable-science/tests/test_lit_registry.py
@@ -546,6 +546,84 @@ def test_patch_triage_still_writes_when_every_row_is_a_mapping(
     assert rows["b"].disposition == "exclude"
 
 
+# --- the write must not fabricate an audit trail -------------------------------
+#
+# Two rows joined by a YAML anchor (`b2021: *shared`) are ONE dict after
+# `yaml.safe_load`, so patching either one writes the fields onto both — and
+# `safe_dump` re-emits the alias, so the file still looks hand-authored. Through
+# `digest extract record` that invents an extraction record for a paper the run
+# never touched, at exit 0, in the PRISMA audit trail. Identity is the exact test:
+# two rows written out separately are distinct objects even when equal (#143).
+
+
+ALIASED_TRIAGE = (
+    "a2020: &shared\n"
+    "  disposition: screened\n"
+    "  rationale: same protocol arm\n"
+    "b2021: *shared\n"
+    "c2022: *shared\n"
+    "d2023:\n"
+    "  disposition: inbox\n"
+)
+
+
+def test_patch_triage_refuses_rows_that_share_one_mapping(tmp_path: Path) -> None:
+    """The refusal names every row in the shared group, and writes nothing."""
+    path = tmp_path / "t.yml"
+    path.write_text(ALIASED_TRIAGE, encoding="utf-8")
+    before = path.read_bytes()
+
+    with pytest.raises(reg.RegistryError) as caught:
+        reg.patch_triage(path, "a2020", {"extracted": "2026-08-28"})
+
+    message = str(caught.value)
+    assert "same mapping" in message
+    for citekey in ("a2020", "b2021", "c2022"):
+        assert citekey in message
+    assert "d2023" not in message
+    assert "'extracted'" in message
+    assert path.read_bytes() == before
+    assert not (tmp_path / "t.yml.tmp").exists()
+
+
+def test_patch_triage_refuses_a_shared_mapping_it_was_not_asked_to_patch(
+    tmp_path: Path,
+) -> None:
+    """The sharing is the hazard, not the target: patching `d2023` refuses too.
+
+    Rewriting the file at all re-emits the aliased group, and a later patch of
+    that group would fabricate. The whole file is refused, as with comments.
+    """
+    path = tmp_path / "t.yml"
+    path.write_text(ALIASED_TRIAGE, encoding="utf-8")
+    before = path.read_bytes()
+    with pytest.raises(reg.RegistryError, match="same mapping"):
+        reg.patch_triage(path, "d2023", {"extracted": "2026-08-28"})
+    assert path.read_bytes() == before
+
+
+def test_patch_triage_does_not_refuse_rows_that_merely_look_alike(
+    tmp_path: Path,
+) -> None:
+    """The over-correction guard: equal content is not shared content.
+
+    The check is object identity, which cannot false-positive — two rows written
+    out separately are distinct objects however identical they read.
+    """
+    path = tmp_path / "t.yml"
+    path.write_text(
+        "a2020:\n  disposition: screened\n  rationale: same protocol arm\n"
+        "b2021:\n  disposition: screened\n  rationale: same protocol arm\n",
+        encoding="utf-8",
+    )
+    reg.patch_triage(path, "a2020", {"extracted": "2026-08-28"})
+    rows = reg.load_triage(path)
+    assert rows["a2020"].raw["extracted"] == "2026-08-28"
+    # The negative this guard exists for, from the other side: the lookalike row
+    # must not acquire the field.
+    assert "extracted" not in rows["b2021"].raw
+
+
 def test_patch_triage_keeps_a_non_string_citekey_addressable(tmp_path: Path) -> None:
     """A YAML key that is not a string (``2020:``) is still a row, not a casualty."""
     path = tmp_path / "t.yml"

--- a/defendable-science/tests/test_mdtable.py
+++ b/defendable-science/tests/test_mdtable.py
@@ -229,3 +229,36 @@ def test_an_unclosed_fence_runs_to_the_end_of_the_document() -> None:
     doc = md.parse_document(text)
     assert doc.header is None
     assert doc.preamble == text
+
+
+def test_two_sections_with_the_same_heading_are_refused() -> None:
+    """Which section is *the* section cannot be guessed, so nothing is located."""
+    text = (
+        "## Concept matrix\n\n| a |\n|---|\n| 1 |\n\n"
+        "## Concept matrix\n\n| b |\n|---|\n| 2 |\n"
+    )
+    with pytest.raises(
+        md.AmbiguousSectionError, match=r"'Concept matrix' names 2 headings"
+    ):
+        md.parse_document(text, under_heading="Concept matrix")
+
+
+def test_duplicate_headings_are_matched_case_insensitively() -> None:
+    text = "## Concept matrix\n\n| a |\n|---|\n\n### concept MATRIX\n\nprose\n"
+    with pytest.raises(md.AmbiguousSectionError):
+        md.parse_document(text, under_heading="Concept matrix")
+
+
+def test_a_duplicate_heading_inside_a_fence_is_not_ambiguity() -> None:
+    """A heading *shown* in a code block is documentation, not a second section."""
+    text = (
+        "## Concept matrix\n\n| b |\n|---|\n| real |\n\n"
+        "```\n## Concept matrix\n| a |\n|---|\n| fake |\n```\n"
+    )
+    doc = md.parse_document(text, under_heading="Concept matrix")
+    assert doc.rows == [{"b": "real"}]
+
+
+def test_an_ambiguous_section_is_a_table_error() -> None:
+    # Callers that already catch TableError keep catching this one.
+    assert issubclass(md.AmbiguousSectionError, md.TableError)

--- a/defendable-science/tests/test_mdtable.py
+++ b/defendable-science/tests/test_mdtable.py
@@ -313,3 +313,32 @@ def test_a_table_after_the_windowed_section_is_not_a_second_table() -> None:
         "Method",
         "axis",
     ]
+
+
+def test_an_ambiguous_section_is_refused_before_a_ragged_row_is_reported() -> None:
+    """The refusal must name the real problem, not a table nobody asked about.
+
+    Collecting rows while scanning would raise ``ragged`` about the scratch
+    table, sending the author to count cells in a table that is not the one
+    they meant — the misdiagnosis `AmbiguousSectionError` exists to avoid.
+    """
+    text = (
+        "## Concept matrix\n\n| Method | axis |\n|---|---|\n| a | b |\n\n"
+        "Scratch:\n\n| x | y |\n|---|---|\n| 1 | 2 | 3 |\n"
+    )
+    with pytest.raises(md.AmbiguousSectionError, match="holds 2 tables"):
+        md.parse_document(text, under_heading="Concept matrix")
+
+
+def test_the_one_table_in_a_section_is_still_checked_for_ragged_rows() -> None:
+    text = "## Concept matrix\n\n| a | b |\n|---|---|\n| 1 |\n"
+    with pytest.raises(md.TableError, match="ragged concept-matrix row"):
+        md.parse_document(
+            text, under_heading="Concept matrix", row_label="concept-matrix"
+        )
+
+
+def test_an_unwindowed_ragged_table_after_the_first_is_still_ignored() -> None:
+    """`backlog.py`'s guarantee: a later sloppy table is not this caller's problem."""
+    text = "| a | b |\n|---|---|\n| 1 | 2 |\n\nprose\n\n| x |\n|---|\n| 1 | 2 |\n"
+    assert md.parse_document(text).header == ["a", "b"]

--- a/defendable-science/tests/test_mdtable.py
+++ b/defendable-science/tests/test_mdtable.py
@@ -262,3 +262,54 @@ def test_a_duplicate_heading_inside_a_fence_is_not_ambiguity() -> None:
 def test_an_ambiguous_section_is_a_table_error() -> None:
     # Callers that already catch TableError keep catching this one.
     assert issubclass(md.AmbiguousSectionError, md.TableError)
+
+
+def test_a_windowed_section_holding_two_tables_is_refused() -> None:
+    """A legend above the matrix: writing into the first would destroy it."""
+    text = (
+        "## Concept matrix\n\nLegend:\n\n| symbol | meaning |\n|---|---|\n"
+        "| + | holds |\n\nThe matrix:\n\n| Method | axis |\n|---|---|\n| a | b |\n"
+    )
+    with pytest.raises(md.AmbiguousSectionError, match=r"holds 2 tables"):
+        md.parse_document(text, under_heading="Concept matrix")
+
+
+def test_a_second_table_inside_a_fence_is_not_a_second_table() -> None:
+    """The over-correction guard: an illustration must not force a refusal."""
+    text = (
+        "## Concept matrix\n\n```\n| shown | only |\n|---|---|\n| x | y |\n```\n\n"
+        "| Method | axis |\n|---|---|\n| a | b |\n"
+    )
+    doc = md.parse_document(text, under_heading="Concept matrix")
+    assert doc.header == ["Method", "axis"]
+    assert doc.rows == [{"Method": "a", "axis": "b"}]
+
+
+def test_a_windowed_section_with_one_table_is_unaffected() -> None:
+    doc = md.parse_document(TWO_TABLES, under_heading="Concept matrix")
+    assert doc.header == ["Method", "guarantee", "scope"]
+
+
+def test_an_unwindowed_document_with_several_tables_still_takes_the_first() -> None:
+    """The regression that protects `backlog.py`: no refusal without a window.
+
+    A whole-document call legitimately meets many tables — a backlog file's
+    prose routinely holds more than one — so the refusal is scoped to calls
+    that named a section. Simplifying it to apply everywhere breaks them.
+    """
+    doc = md.parse_document(TWO_TABLES)
+    assert doc.header == ["Baseline", "Why"]
+    assert doc.rows == [{"Baseline": "ridge", "Why": "simplest floor"}]
+    # And the round trip still preserves the second table verbatim.
+    assert md.splice(doc.preamble, doc.postamble, doc.header, doc.rows) == TWO_TABLES
+
+
+def test_a_table_after_the_windowed_section_is_not_a_second_table() -> None:
+    text = (
+        "## Concept matrix\n\n| Method | axis |\n|---|---|\n| a | b |\n\n"
+        "## Baselines\n\n| Baseline | Why |\n|---|---|\n| ridge | floor |\n"
+    )
+    assert md.parse_document(text, under_heading="Concept matrix").header == [
+        "Method",
+        "axis",
+    ]

--- a/defendable-science/tests/test_mdtable.py
+++ b/defendable-science/tests/test_mdtable.py
@@ -1,0 +1,131 @@
+"""Tests for the shared host-preserving markdown-table core."""
+
+from __future__ import annotations
+
+import pytest
+
+from defendable_science.core import mdtable as md
+
+TWO_TABLES = """# Positioning
+
+## Baselines
+
+| Baseline | Why |
+|---|---|
+| ridge | simplest floor |
+
+## Concept matrix
+
+<!-- rows = methods -->
+
+| Method | guarantee | scope |
+|---|---|---|
+| sill1997 | architectural | full |
+
+## Notes
+
+trailing prose
+"""
+
+
+def test_parse_document_takes_the_first_table_by_default() -> None:
+    doc = md.parse_document(TWO_TABLES)
+    assert doc.header == ["Baseline", "Why"]
+
+
+def test_under_heading_targets_that_section_s_table() -> None:
+    doc = md.parse_document(TWO_TABLES, under_heading="Concept matrix")
+    assert doc.header == ["Method", "guarantee", "scope"]
+    assert doc.rows == [
+        {"Method": "sill1997", "guarantee": "architectural", "scope": "full"}
+    ]
+
+
+def test_under_heading_round_trips_the_whole_document() -> None:
+    doc = md.parse_document(TWO_TABLES, under_heading="Concept matrix")
+    assert doc.header is not None
+    out = md.splice(doc.preamble, doc.postamble, doc.header, doc.rows)
+    assert out == TWO_TABLES
+
+
+def test_under_heading_preserves_the_other_table_verbatim() -> None:
+    doc = md.parse_document(TWO_TABLES, under_heading="Concept matrix")
+    assert "| ridge | simplest floor |" in doc.preamble
+    assert "trailing prose" in doc.postamble
+
+
+def test_under_heading_absent_yields_no_table() -> None:
+    doc = md.parse_document(TWO_TABLES, under_heading="Nonexistent")
+    assert doc.header is None
+    assert doc.preamble == TWO_TABLES
+
+
+def test_under_heading_section_with_no_table_yields_no_table() -> None:
+    doc = md.parse_document(TWO_TABLES, under_heading="Notes")
+    assert doc.header is None
+
+
+def test_under_heading_stops_at_the_next_heading() -> None:
+    text = "## A\n\nprose\n\n## B\n\n| X |\n|---|\n| 1 |\n"
+    assert md.parse_document(text, under_heading="A").header is None
+    assert md.parse_document(text, under_heading="B").header == ["X"]
+
+
+def test_under_heading_matches_any_heading_level() -> None:
+    text = "### Concept matrix\n\n| M |\n|---|\n| a |\n"
+    assert md.parse_document(text, under_heading="Concept matrix").header == ["M"]
+
+
+def test_under_heading_is_case_insensitive() -> None:
+    doc = md.parse_document(TWO_TABLES, under_heading="  concept MATRIX ")
+    assert doc.header == ["Method", "guarantee", "scope"]
+
+
+def test_window_does_not_swallow_the_next_section_s_rows() -> None:
+    # A heading that itself contains a pipe would otherwise be read as a data
+    # row of the previous section's table.
+    text = "## A\n\n| X |\n|---|\n| 1 |\n## B | C\n\nprose\n"
+    doc = md.parse_document(text, under_heading="A")
+    assert doc.rows == [{"X": "1"}]
+    assert doc.postamble == "## B | C\n\nprose\n"
+
+
+def test_ragged_row_raises_with_the_default_label() -> None:
+    text = "| a | b |\n|---|---|\n| 1 |\n"
+    with pytest.raises(md.TableError, match="ragged table row"):
+        md.parse_document(text)
+
+
+def test_ragged_row_uses_the_caller_s_label() -> None:
+    text = "| a | b |\n|---|---|\n| 1 |\n"
+    with pytest.raises(md.TableError, match="ragged concept-matrix row"):
+        md.parse_document(text, row_label="concept-matrix")
+
+
+def test_separator_before_any_header_is_ignored() -> None:
+    assert md.parse_document("|---|---|\n").header is None
+
+
+def test_table_shape_without_a_separator_is_flagged() -> None:
+    doc = md.parse_document("| a | b |\n| 1 | 2 |\n")
+    assert doc.header is None
+    assert doc.saw_table_shape
+
+
+def test_escape_cell_neutralizes_pipes_and_newlines() -> None:
+    assert md.escape_cell("a|b\nc") == r"a\|b c"
+
+
+def test_split_cells_without_borders() -> None:
+    assert md.split_cells("a | b | c") == ["a", "b", "c"]
+
+
+def test_is_separator_rejects_an_empty_cell() -> None:
+    assert md.is_separator(["---", ":-:"])
+    assert not md.is_separator([""])
+    assert not md.is_separator([])
+
+
+def test_splice_terminates_a_preamble_that_lacks_a_newline() -> None:
+    out = md.splice("intro", "", ["a"], [{"a": "1"}])
+    assert out == "intro\n| a |\n|---|\n| 1 |\n"

--- a/defendable-science/tests/test_mdtable.py
+++ b/defendable-science/tests/test_mdtable.py
@@ -129,3 +129,103 @@ def test_is_separator_rejects_an_empty_cell() -> None:
 def test_splice_terminates_a_preamble_that_lacks_a_newline() -> None:
     out = md.splice("intro", "", ["a"], [{"a": "1"}])
     assert out == "intro\n| a |\n|---|\n| 1 |\n"
+
+
+# --- fenced code blocks (task-8 ruling AG) --------------------------------------
+
+FENCED_EXAMPLE = """# Positioning
+
+A matrix looks like this:
+
+```markdown
+| Method | example axis |
+|---|---|
+| someone2020 | illustrative |
+```
+
+## Concept matrix
+
+| Method | guarantee |
+|---|---|
+| sill1997 | architectural |
+"""
+
+
+def test_a_fenced_pipe_table_before_the_real_one_is_not_selected() -> None:
+    doc = md.parse_document(FENCED_EXAMPLE)
+    assert doc.header == ["Method", "guarantee"]
+    assert doc.rows == [{"Method": "sill1997", "guarantee": "architectural"}]
+
+
+def test_splicing_never_writes_into_a_fenced_example_table() -> None:
+    """The write lands on the real table; the fence is byte-identical."""
+    doc = md.parse_document(FENCED_EXAMPLE)
+    assert doc.header is not None
+    rows = [*doc.rows, {"Method": "new2026", "guarantee": "learned"}]
+    out = md.splice(doc.preamble, doc.postamble, doc.header, rows)
+    fence = FENCED_EXAMPLE[
+        FENCED_EXAMPLE.index("```markdown") : FENCED_EXAMPLE.index("## Concept")
+    ]
+    assert fence in out
+    assert out == FENCED_EXAMPLE.replace(
+        "| sill1997 | architectural |\n",
+        "| sill1997 | architectural |\n| new2026 | learned |\n",
+    )
+
+
+def test_a_document_whose_only_table_is_fenced_has_no_table() -> None:
+    text = "# Doc\n\n```\n| a | b |\n|---|---|\n| 1 | 2 |\n```\n\nprose\n"
+    doc = md.parse_document(text)
+    assert doc.header is None
+    assert doc.preamble == text
+    assert not doc.saw_table_shape
+
+
+def test_a_heading_inside_a_fence_does_not_open_a_section() -> None:
+    text = (
+        "# Doc\n\n```\n## Concept matrix\n\n| a |\n|---|\n| fake |\n```\n\n"
+        "## Concept matrix\n\n| b |\n|---|\n| real |\n"
+    )
+    doc = md.parse_document(text, under_heading="Concept matrix")
+    assert doc.header == ["b"]
+    assert doc.rows == [{"b": "real"}]
+
+
+def test_a_heading_inside_a_fence_does_not_close_a_section() -> None:
+    text = "## A\n\n```\n## B\n```\n\n| x |\n|---|\n| 1 |\n"
+    doc = md.parse_document(text, under_heading="A")
+    assert doc.header == ["x"]
+
+
+def test_a_tilde_fence_is_honoured() -> None:
+    text = "~~~\n| a | b |\n|---|---|\n~~~\n\n| c |\n|---|\n| 1 |\n"
+    assert md.parse_document(text).header == ["c"]
+
+
+def test_a_fence_is_closed_only_by_its_own_character() -> None:
+    # The ~~~ line is content inside the backtick fence, not a close, so the
+    # pipe table that follows it is still fenced.
+    text = "```\n~~~\n| a | b |\n|---|---|\n```\n\n| c |\n|---|\n| 1 |\n"
+    assert md.parse_document(text).header == ["c"]
+
+
+def test_a_shorter_closing_fence_does_not_close() -> None:
+    text = "````\n```\n| a | b |\n|---|---|\n````\n\n| c |\n|---|\n| 1 |\n"
+    assert md.parse_document(text).header == ["c"]
+
+
+def test_a_longer_closing_fence_closes() -> None:
+    text = "```\ntext\n`````\n\n| c |\n|---|\n| 1 |\n"
+    assert md.parse_document(text).header == ["c"]
+
+
+def test_a_closing_fence_may_not_carry_an_info_string() -> None:
+    text = "```\n``` still open\n| a | b |\n|---|---|\n```\n\n| c |\n|---|\n| 1 |\n"
+    assert md.parse_document(text).header == ["c"]
+
+
+def test_an_unclosed_fence_runs_to_the_end_of_the_document() -> None:
+    text = "# Doc\n\n```\n| a | b |\n|---|---|\n| 1 | 2 |\n"
+    doc = md.parse_document(text)
+    assert doc.header is None
+    assert doc.preamble == text

--- a/defendable-science/tests/test_sampling.py
+++ b/defendable-science/tests/test_sampling.py
@@ -327,8 +327,9 @@ def test_a_failed_verdict_marks_every_member_and_touches_no_cell(
     for citekey in sorted(BATCH):
         status = _block(root, citekey)
         assert status["extraction"]["batch-check"] == "failed"
-        # in-sample stays a fact about the paper; batch-check is about the run.
-        assert status["extraction"]["in-sample"] is False
+        # The two keys do not move together: `batch-check` is the verdict on the
+        # run, `in-sample` is whether a human looked at *this* paper's cells.
+        assert status["extraction"]["in-sample"] is (citekey in EXPECTED_SAMPLE)
         # The guarantee-inflation guard: extraction never claims comprehension.
         assert "understanding" not in status
         # Byte-identical cells: repairing the caught cell would convert a
@@ -346,6 +347,75 @@ def test_a_verified_verdict_marks_every_member(
     assert result.exit_code == 0, result.stdout + result.stderr
     for citekey in BATCH:
         assert _block(root, citekey)["extraction"]["batch-check"] == "verified"
+
+
+def test_in_sample_marks_exactly_the_papers_the_draw_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The two invocations must agree about who was checked.
+
+    The verdict call re-draws with the same deterministic selector over the same
+    membership set, so the papers marked ``in-sample: true`` are the ones the
+    human was actually shown — not a second, differently-drawn set.
+    """
+    root = _repo(tmp_path)
+    drawn = json.loads(_run(root, *_citekey_args(), monkeypatch=monkeypatch).stdout)
+    shown = [p["citekey"] for p in drawn["sampled"]]
+    # Drawing alone establishes nothing, so it must claim nothing.
+    assert all(_block(root, k)["extraction"]["in-sample"] is False for k in BATCH)
+
+    _run(root, *_citekey_args(), "--verdict", "verified", monkeypatch=monkeypatch)
+
+    marked = [k for k in sorted(BATCH) if _block(root, k)["extraction"]["in-sample"]]
+    assert marked == shown
+
+
+def test_in_sample_follows_an_explicit_size_on_both_invocations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    drawn = json.loads(
+        _run(root, *_citekey_args(), "--size", "5", monkeypatch=monkeypatch).stdout
+    )
+    _run(
+        root,
+        *_citekey_args(),
+        "--size",
+        "5",
+        "--verdict",
+        "verified",
+        monkeypatch=monkeypatch,
+    )
+    marked = [k for k in sorted(BATCH) if _block(root, k)["extraction"]["in-sample"]]
+    assert marked == drawn["sample"]
+    assert len(marked) == 5
+
+
+def test_a_sampled_paper_whose_cells_could_not_be_read_is_not_marked_checked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The human cannot have checked cells the command could not show them."""
+    root = _repo(tmp_path, ["a1", "b2"])
+    target = _digest(root, "a1")
+    fm_lines, _body = split_frontmatter(target.read_text(encoding="utf-8"))
+    target.write_text(
+        "---\n" + "\n".join(fm_lines) + "\n---\n\nprose only\n", encoding="utf-8"
+    )
+    result = _run(
+        root,
+        "--citekey",
+        "a1",
+        "--citekey",
+        "b2",
+        "--verdict",
+        "failed",
+        monkeypatch=monkeypatch,
+    )
+    assert result.exit_code == 1
+    assert _block(root, "a1")["extraction"]["in-sample"] is False
+    # The verdict on the run still lands — that is what a failed batch means.
+    assert _block(root, "a1")["extraction"]["batch-check"] == "failed"
+    assert _block(root, "b2")["extraction"]["in-sample"] is True
 
 
 def test_an_unknown_verdict_is_refused(

--- a/defendable-science/tests/test_sampling.py
+++ b/defendable-science/tests/test_sampling.py
@@ -300,6 +300,35 @@ def test_all_reports_an_unreadable_artifact_rather_than_skipping_it(
     assert [e["citekey"] for e in payload["errors"]] == ["broken"]
 
 
+def test_all_refuses_to_draw_at_all_when_an_artifact_is_unreadable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unknowable membership set must not be sampled around (§3.5).
+
+    The draw is a deterministic function of the membership set, so quietly
+    dropping an unreadable artifact would *change which papers get checked* —
+    sample-shopping through what looks like a routine file problem, in the one
+    feature built to prevent it.
+    """
+    good = ["a1", "b2", "c3", "d4"]
+    root = _repo(tmp_path, good)
+    digests = root / "docs" / "research" / "literature" / "digests"
+    (digests / "broken.md").write_text(
+        "---\nstatus: [unclosed\n---\n", encoding="utf-8"
+    )
+    result = _run(root, "--all", "--verdict", "verified", monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["sample"] == []
+    assert payload["batch"] == []
+    assert payload["updated"] == []
+    assert "cannot be determined" in result.stderr
+    for citekey in good:
+        assert _block(root, citekey)["extraction"]["batch-check"] == "pending"
+        assert _block(root, citekey)["extraction"]["in-sample"] is False
+
+
 @pytest.mark.parametrize("args", [[], ["--all", "--citekey", "a1"]])
 def test_exactly_one_of_citekey_and_all_is_required(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, args: list[str]
@@ -391,16 +420,87 @@ def test_in_sample_follows_an_explicit_size_on_both_invocations(
     assert len(marked) == 5
 
 
+def _break_body(root: Path, citekey: str) -> None:
+    """Strip a recorded artifact's cells block, keeping its frontmatter."""
+    target = _digest(root, citekey)
+    fm_lines, _body = split_frontmatter(target.read_text(encoding="utf-8"))
+    target.write_text(
+        "---\n" + "\n".join(fm_lines) + "\n---\n\nprose only\n", encoding="utf-8"
+    )
+
+
+def test_a_verified_verdict_is_refused_when_a_drawn_paper_was_never_shown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``verified`` is a claim, and the claim's evidence must exist.
+
+    Exit 1 alone is not enough: the exit code is transient and the artifact is
+    what every downstream reader consults.
+    """
+    root = _repo(tmp_path, ["a1", "b2"])
+    _break_body(root, "a1")
+    result = _run(
+        root,
+        "--citekey",
+        "a1",
+        "--citekey",
+        "b2",
+        "--verdict",
+        "verified",
+        monkeypatch=monkeypatch,
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["updated"] == []
+    assert payload["log_entries"] == []
+    assert "refusing to record a verified batch" in result.stderr
+    for citekey in ("a1", "b2"):
+        assert _block(root, citekey)["extraction"]["batch-check"] == "pending"
+        assert _block(root, citekey)["extraction"]["in-sample"] is False
+
+
+def test_a_failed_verdict_still_lands_when_a_drawn_paper_was_never_shown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A finding about the batch is not blocked by a broken artifact."""
+    root = _repo(tmp_path, ["a1", "b2"])
+    _break_body(root, "a1")
+    result = _run(
+        root,
+        "--citekey",
+        "a1",
+        "--citekey",
+        "b2",
+        "--verdict",
+        "failed",
+        monkeypatch=monkeypatch,
+    )
+    assert result.exit_code == 1
+    for citekey in ("a1", "b2"):
+        assert _block(root, citekey)["extraction"]["batch-check"] == "failed"
+
+
+def test_the_report_names_the_drawn_papers_it_could_not_show(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``size`` counts the draw; ``sampled`` lists what was shown; the gap is named."""
+    root = _repo(tmp_path, ["a1", "b2"])
+    _break_body(root, "a1")
+    payload = json.loads(
+        _run(root, "--citekey", "a1", "--citekey", "b2", monkeypatch=monkeypatch).stdout
+    )
+    assert payload["size"] == 2
+    assert payload["sample"] == ["a1", "b2"]
+    assert [p["citekey"] for p in payload["sampled"]] == ["b2"]
+    assert payload["not_shown"] == ["a1"]
+
+
 def test_a_sampled_paper_whose_cells_could_not_be_read_is_not_marked_checked(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The human cannot have checked cells the command could not show them."""
     root = _repo(tmp_path, ["a1", "b2"])
-    target = _digest(root, "a1")
-    fm_lines, _body = split_frontmatter(target.read_text(encoding="utf-8"))
-    target.write_text(
-        "---\n" + "\n".join(fm_lines) + "\n---\n\nprose only\n", encoding="utf-8"
-    )
+    _break_body(root, "a1")
     result = _run(
         root,
         "--citekey",

--- a/defendable-science/tests/test_sampling.py
+++ b/defendable-science/tests/test_sampling.py
@@ -1,0 +1,461 @@
+"""The deterministic sampled check — the kernel and its CLI surface (spec §8).
+
+Determinism is the anti-gaming property the whole of extraction mode rests on,
+so the pins here are deliberately *literal*: `test_select_sample_pins_the_draw`
+names the three papers a specific batch must always draw, and
+`test_select_sample_is_stable_across_processes` re-draws them in fresh
+interpreters under different ``PYTHONHASHSEED`` values. A test that merely drew
+twice in one process would pass over a `hash()`-seeded implementation, which
+re-rolls the sample on every run — exactly the hole this feature must not have.
+
+The negatives carry the rest (spec §11): a ``failed`` verdict leaves every cell
+byte-identical, lands on **unsampled** members too, and never writes
+``status.understanding``; an artifact with no ``status.extraction`` block is not
+part of an extraction batch; and ``--all`` over an empty digests directory is a
+loud failure, not a passed sample of size zero.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from defendable_science.cli import app
+from defendable_science.core.frontmatter import split_frontmatter
+from defendable_science.digest import artifact as artifact_mod
+from defendable_science.digest.extraction import Cell, ExtractionError
+from defendable_science.digest.sampling import default_size, select_sample
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+#: A fixed batch, used for every literal pin below.
+BATCH = [
+    "sill1997monotonic",
+    "daniels2010monotone",
+    "you2017deep",
+    "gupta2016monotonic",
+    "liu2020certified",
+    "wehenkel2019unconstrained",
+    "runje2023constrained",
+    "nolte2023expressive",
+]
+
+#: What `BATCH` must draw, always, in every process. Changing the seeding
+#: algorithm changes this list — which is the point: it is a contract with
+#: every survey already checked against it, not an implementation detail.
+EXPECTED_SAMPLE = [
+    "nolte2023expressive",
+    "runje2023constrained",
+    "sill1997monotonic",
+]
+
+
+# --- the kernel -----------------------------------------------------------------
+
+
+def test_select_sample_pins_the_draw_for_a_fixed_batch() -> None:
+    assert select_sample(BATCH, 3) == EXPECTED_SAMPLE
+
+
+def test_select_sample_ignores_the_input_order() -> None:
+    """The batch is a set; the order it arrives in must not steer the draw."""
+    assert select_sample(list(reversed(BATCH)), 3) == EXPECTED_SAMPLE
+
+
+def test_select_sample_collapses_duplicates() -> None:
+    assert select_sample(["a", "a", "b"], 3) == ["a", "b"]
+
+
+def test_select_sample_is_stable_across_processes() -> None:
+    """Two fresh interpreters, two different hash seeds, one sample.
+
+    `hash()` on a `str` is salted per process, so seeding from it would pass
+    every same-process test and still re-roll the sample on each run.
+    """
+    script = (
+        "import json;"
+        "from defendable_science.digest.sampling import select_sample;"
+        f"print(json.dumps(select_sample({BATCH!r}, 3)))"
+    )
+    drawn = [
+        json.loads(
+            subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                check=True,
+                env={**os.environ, "PYTHONHASHSEED": seed},
+            ).stdout
+        )
+        for seed in ("0", "1")
+    ]
+    assert drawn == [EXPECTED_SAMPLE, EXPECTED_SAMPLE]
+
+
+def test_a_different_batch_draws_a_different_sample() -> None:
+    """Adding one paper re-draws the batch — the sample is of *this* set."""
+    assert select_sample([*BATCH, "zzz2024extra"], 3) != EXPECTED_SAMPLE
+
+
+def test_a_batch_smaller_than_the_size_is_sampled_whole() -> None:
+    assert select_sample(["a", "b"], 3) == ["a", "b"]
+
+
+def test_select_sample_refuses_an_empty_batch() -> None:
+    with pytest.raises(ExtractionError, match="empty batch"):
+        select_sample([], 3)
+
+
+def test_select_sample_refuses_a_size_below_one() -> None:
+    with pytest.raises(ExtractionError, match="at least 1"):
+        select_sample(BATCH, 0)
+
+
+@pytest.mark.parametrize(
+    ("n", "expected"),
+    [(0, 0), (1, 1), (2, 2), (3, 3), (12, 3), (30, 3), (40, 4), (41, 5), (100, 10)],
+)
+def test_default_size(n: int, expected: int) -> None:
+    assert default_size(n) == expected
+    assert default_size(n) <= n
+
+
+# --- the CLI surface -------------------------------------------------------------
+
+
+def _cells(citekey: str) -> list[Cell]:
+    """Build two recorded cells for `citekey`, one of them an absence."""
+    return [
+        Cell(
+            citekey=citekey,
+            axis="guarantee type",
+            value="architectural",
+            locator="§2, Eq. (3)",
+        ),
+        Cell(
+            citekey=citekey,
+            axis="partial monotonicity",
+            value="not-addressed",
+            justification="scoped to fully-monotone inputs in §1",
+        ),
+    ]
+
+
+def _repo(tmp_path: Path, citekeys: list[str] = BATCH) -> Path:
+    """Build an onboarded repo with one extracted artifact per citekey."""
+    (tmp_path / ".defendable-science").mkdir()
+    (tmp_path / ".defendable-science" / "config.yml").write_text("", encoding="utf-8")
+    digests = tmp_path / "docs" / "research" / "literature" / "digests"
+    digests.mkdir(parents=True)
+    for citekey in citekeys:
+        artifact_mod.write_extraction(
+            digests / f"{citekey}.md",
+            _cells(citekey),
+            in_sample=False,
+            batch_check="pending",
+            log_dir=tmp_path / "seed-log",
+            date="2026-08-28",
+        )
+    return tmp_path
+
+
+def _run(root: Path, *args: str, monkeypatch: pytest.MonkeyPatch) -> Any:
+    monkeypatch.chdir(root)
+    return runner.invoke(app, ["digest", "extract", "sample", *args])
+
+
+def _citekey_args(citekeys: list[str] = BATCH) -> list[str]:
+    return [arg for key in citekeys for arg in ("--citekey", key)]
+
+
+def _digest(root: Path, citekey: str) -> Path:
+    return root / "docs" / "research" / "literature" / "digests" / f"{citekey}.md"
+
+
+def _block(root: Path, citekey: str) -> dict[str, Any]:
+    """Return the artifact's whole ``status:`` mapping."""
+    fm_lines, _body = split_frontmatter(
+        _digest(root, citekey).read_text(encoding="utf-8")
+    )
+    status: dict[str, Any] = yaml.safe_load("\n".join(fm_lines))["status"]
+    return status
+
+
+def _cells_bytes(root: Path, citekey: str) -> str:
+    """Return the artifact's generated cells block, verbatim."""
+    text = _digest(root, citekey).read_text(encoding="utf-8")
+    begin = text.index(artifact_mod.CELLS_BEGIN)
+    end = text.index(artifact_mod.CELLS_END) + len(artifact_mod.CELLS_END)
+    return text[begin:end]
+
+
+def test_sample_reports_the_draw_and_changes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    before = {k: _digest(root, k).read_bytes() for k in BATCH}
+    result = _run(root, *_citekey_args(), monkeypatch=monkeypatch)
+    assert result.exit_code == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["sample"] == EXPECTED_SAMPLE
+    assert payload["batch"] == sorted(BATCH)
+    assert payload["size"] == 3
+    assert payload["verdict"] is None
+    # Drawing is not recording: nothing on disk moved.
+    assert {k: _digest(root, k).read_bytes() for k in BATCH} == before
+
+
+def test_sample_reports_each_drawn_paper_s_cells_for_the_human(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The human is shown axis, value and locator — that is the check (§8)."""
+    root = _repo(tmp_path)
+    result = _run(root, *_citekey_args(), monkeypatch=monkeypatch)
+    payload = json.loads(result.stdout)
+    assert [p["citekey"] for p in payload["sampled"]] == EXPECTED_SAMPLE
+    first = payload["sampled"][0]["cells"][0]
+    assert first["axis"] == "guarantee type"
+    assert first["value"] == "architectural"
+    assert first["locator"] == "§2, Eq. (3)"
+
+
+def test_sample_honours_an_explicit_size(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    result = _run(root, *_citekey_args(), "--size", "5", monkeypatch=monkeypatch)
+    assert result.exit_code == 0
+    assert len(json.loads(result.stdout)["sample"]) == 5
+
+
+def test_sample_refuses_a_size_below_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    result = _run(root, *_citekey_args(), "--size", "0", monkeypatch=monkeypatch)
+    assert result.exit_code == 2
+
+
+def test_all_collects_only_artifacts_carrying_an_extraction_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A depth-mode digest was never extracted, so it is not in the batch."""
+    root = _repo(tmp_path, ["a1", "b2"])
+    digests = root / "docs" / "research" / "literature" / "digests"
+    (digests / "depthonly.md").write_text(
+        "---\nstatus:\n  understanding: {status: complete}\n---\n\nprose\n",
+        encoding="utf-8",
+    )
+    (digests / "notes.txt").write_text("not a digest\n", encoding="utf-8")
+    result = _run(root, "--all", monkeypatch=monkeypatch)
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout)["batch"] == ["a1", "b2"]
+
+
+def test_all_over_an_empty_digests_directory_fails_loudly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Zero extraction artifacts is a failed run, never a passed empty sample."""
+    root = _repo(tmp_path, [])
+    result = _run(root, "--all", monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["sample"] == []
+    assert "no extracted papers" in result.stderr
+
+
+def test_all_without_a_digests_directory_fails_loudly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path, [])
+    (root / "docs" / "research" / "literature" / "digests").rmdir()
+    result = _run(root, "--all", monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["ok"] is False
+
+
+def test_all_reports_an_unreadable_artifact_rather_than_skipping_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A malformed artifact is not evidence that it was never extracted."""
+    root = _repo(tmp_path, ["a1"])
+    digests = root / "docs" / "research" / "literature" / "digests"
+    (digests / "broken.md").write_text("no frontmatter here\n", encoding="utf-8")
+    result = _run(root, "--all", monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert [e["citekey"] for e in payload["errors"]] == ["broken"]
+
+
+@pytest.mark.parametrize("args", [[], ["--all", "--citekey", "a1"]])
+def test_exactly_one_of_citekey_and_all_is_required(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, args: list[str]
+) -> None:
+    root = _repo(tmp_path, ["a1"])
+    result = _run(root, *args, monkeypatch=monkeypatch)
+    assert result.exit_code == 2
+
+
+def test_a_failed_verdict_marks_every_member_and_touches_no_cell(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed sample is evidence about the batch, not about one paper (§8)."""
+    root = _repo(tmp_path)
+    cells_before = {k: _cells_bytes(root, k) for k in BATCH}
+    result = _run(
+        root, *_citekey_args(), "--verdict", "failed", monkeypatch=monkeypatch
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["verdict"] == "failed"
+    assert payload["updated"] == sorted(BATCH)
+    unsampled = [k for k in sorted(BATCH) if k not in EXPECTED_SAMPLE]
+    assert unsampled  # the assertion below is only meaningful if some exist
+    for citekey in sorted(BATCH):
+        status = _block(root, citekey)
+        assert status["extraction"]["batch-check"] == "failed"
+        # in-sample stays a fact about the paper; batch-check is about the run.
+        assert status["extraction"]["in-sample"] is False
+        # The guarantee-inflation guard: extraction never claims comprehension.
+        assert "understanding" not in status
+        # Byte-identical cells: repairing the caught cell would convert a
+        # population signal into a tidy-looking local fix.
+        assert _cells_bytes(root, citekey) == cells_before[citekey]
+
+
+def test_a_verified_verdict_marks_every_member(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    result = _run(
+        root, *_citekey_args(), "--verdict", "verified", monkeypatch=monkeypatch
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    for citekey in BATCH:
+        assert _block(root, citekey)["extraction"]["batch-check"] == "verified"
+
+
+def test_an_unknown_verdict_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    result = _run(
+        root, *_citekey_args(), "--verdict", "pending", monkeypatch=monkeypatch
+    )
+    assert result.exit_code == 2
+
+
+def test_the_verdict_logs_a_check_record_for_each_sampled_paper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Per-cell records land in the shared accountability log (§8)."""
+    root = _repo(tmp_path)
+    nested = root / "docs" / "research" / "literature"
+    result = _run(
+        root, *_citekey_args(), "--verdict", "verified", monkeypatch=monkeypatch
+    )
+    assert result.exit_code == 0
+    log_dir = root / "docs" / "research" / "defend-log"
+    written = sorted(p.name for p in log_dir.glob("*.yml"))
+    assert len(written) == len(EXPECTED_SAMPLE)
+    entry = yaml.safe_load(
+        next(log_dir.glob(f"*{EXPECTED_SAMPLE[0]}.yml")).read_text(encoding="utf-8")
+    )[0]
+    assert entry["kind"] == "extraction-check"
+    assert entry["verdict"] == "verified"
+    assert entry["citekey"] == EXPECTED_SAMPLE[0]
+    assert entry["batch"] == sorted(BATCH)
+    assert [c["axis"] for c in entry["cells"]] == [
+        "guarantee type",
+        "partial monotonicity",
+    ]
+    assert json.loads(result.stdout)["log_entries"]
+    assert nested.is_dir()
+
+
+def test_the_log_default_is_anchored_to_the_layout_not_the_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Run from inside a subdirectory; the evidence still lands in the log."""
+    root = _repo(tmp_path)
+    inner = root / "docs" / "research" / "literature" / "digests"
+    monkeypatch.chdir(inner)
+    result = runner.invoke(
+        app,
+        ["digest", "extract", "sample", *_citekey_args(), "--verdict", "verified"],
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert not (inner / "defend-log").exists()
+    assert list((root / "docs" / "research" / "defend-log").glob("*.yml"))
+
+
+def test_an_explicit_log_dir_is_honoured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    target = tmp_path / "elsewhere"
+    result = _run(
+        root,
+        *_citekey_args(),
+        "--verdict",
+        "verified",
+        "--log-dir",
+        str(target),
+        monkeypatch=monkeypatch,
+    )
+    assert result.exit_code == 0
+    assert len(list(target.glob("*.yml"))) == len(EXPECTED_SAMPLE)
+
+
+def test_a_member_without_an_artifact_is_reported_and_the_rest_still_land(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path, ["a1", "b2"])
+    result = _run(
+        root,
+        "--citekey",
+        "a1",
+        "--citekey",
+        "b2",
+        "--citekey",
+        "ghost",
+        "--verdict",
+        "failed",
+        monkeypatch=monkeypatch,
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert [e["citekey"] for e in payload["errors"]] == ["ghost"]
+    assert payload["updated"] == ["a1", "b2"]
+    assert _block(root, "a1")["extraction"]["batch-check"] == "failed"
+
+
+def test_a_sampled_paper_with_no_cells_block_is_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An artifact whose cells cannot be read is an error, not an empty check."""
+    root = _repo(tmp_path, ["a1"])
+    target = _digest(root, "a1")
+    fm_lines, _body = split_frontmatter(target.read_text(encoding="utf-8"))
+    target.write_text(
+        "---\n" + "\n".join(fm_lines) + "\n---\n\nprose only\n", encoding="utf-8"
+    )
+    result = _run(root, "--citekey", "a1", monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["errors"][0]["citekey"] == "a1"

--- a/defendable-science/tests/test_sampling.py
+++ b/defendable-science/tests/test_sampling.py
@@ -212,6 +212,8 @@ def test_sample_reports_the_draw_and_changes_nothing(
     assert payload["batch"] == sorted(BATCH)
     assert payload["size"] == 3
     assert payload["verdict"] is None
+    assert payload["verdict_requested"] is None
+    assert payload["error"] is None
     # Drawing is not recording: nothing on disk moved.
     assert {k: _digest(root, k).read_bytes() for k in BATCH} == before
 
@@ -274,6 +276,7 @@ def test_all_over_an_empty_digests_directory_fails_loudly(
     assert payload["ok"] is False
     assert payload["sample"] == []
     assert "no extracted papers" in result.stderr
+    assert "no extracted papers" in payload["error"]
 
 
 def test_all_without_a_digests_directory_fails_loudly(
@@ -323,7 +326,10 @@ def test_all_refuses_to_draw_at_all_when_an_artifact_is_unreadable(
     assert payload["sample"] == []
     assert payload["batch"] == []
     assert payload["updated"] == []
+    assert payload["verdict"] is None
+    assert payload["verdict_requested"] == "verified"
     assert "cannot be determined" in result.stderr
+    assert "cannot be determined" in payload["error"]
     for citekey in good:
         assert _block(root, citekey)["extraction"]["batch-check"] == "pending"
         assert _block(root, citekey)["extraction"]["in-sample"] is False
@@ -349,7 +355,10 @@ def test_a_failed_verdict_marks_every_member_and_touches_no_cell(
     )
     assert result.exit_code == 0, result.stdout + result.stderr
     payload = json.loads(result.stdout)
+    # A verdict that landed is reported under both keys; they only differ when
+    # the request was refused.
     assert payload["verdict"] == "failed"
+    assert payload["verdict_requested"] == "failed"
     assert payload["updated"] == sorted(BATCH)
     unsampled = [k for k in sorted(BATCH) if k not in EXPECTED_SAMPLE]
     assert unsampled  # the assertion below is only meaningful if some exist
@@ -454,6 +463,14 @@ def test_a_verified_verdict_is_refused_when_a_drawn_paper_was_never_shown(
     assert payload["updated"] == []
     assert payload["log_entries"] == []
     assert "refusing to record a verified batch" in result.stderr
+    # The report must not read as a verified batch on its own terms: a key
+    # called `verdict` is what a careless reader takes for the outcome, so it
+    # carries what was *recorded* — nothing — and the request lives elsewhere.
+    assert payload["verdict"] is None
+    assert payload["verdict"] != "verified"
+    assert payload["verdict_requested"] == "verified"
+    assert payload["ok"] is False
+    assert "refusing to record a verified batch" in payload["error"]
     for citekey in ("a1", "b2"):
         assert _block(root, citekey)["extraction"]["batch-check"] == "pending"
         assert _block(root, citekey)["extraction"]["in-sample"] is False
@@ -612,6 +629,22 @@ def test_a_member_without_an_artifact_is_reported_and_the_rest_still_land(
     assert [e["citekey"] for e in payload["errors"]] == ["ghost"]
     assert payload["updated"] == ["a1", "b2"]
     assert _block(root, "a1")["extraction"]["batch-check"] == "failed"
+
+
+def test_a_verdict_that_landed_on_nobody_is_not_reported_as_recorded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`verdict` names what was written; no member took it, so it is null."""
+    root = _repo(tmp_path, [])
+    result = _run(
+        root, "--citekey", "ghost", "--verdict", "failed", monkeypatch=monkeypatch
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["updated"] == []
+    assert payload["verdict"] is None
+    assert payload["verdict_requested"] == "failed"
 
 
 def test_a_sampled_paper_with_no_cells_block_is_reported(

--- a/docs/design/00-meta-spec.md
+++ b/docs/design/00-meta-spec.md
@@ -386,7 +386,7 @@ defendable-science/                                  # plugin repo root
 │   ├── dataset/SKILL.md                  # init/register/fetch/verify/mirror/audit
 │   ├── progress/SKILL.md                 # status | dashboard (cross-cutting, read-only)
 │   ├── defend/SKILL.md                  # claim|cited-work|methodology; self + guardrail (cross-cutting)
-│   └── digest/SKILL.md                  # inbound paper comprehension; self + defend escalation (cross-cutting)
+│   └── digest/SKILL.md                  # depth: inbound paper comprehension (self + defend escalation) | extract: breadth reading into located matrix cells (cross-cutting)
 ├── resources/                            # cross-skill shared material
 │   ├── contracts/
 │   │   ├── experiment-backend.md         # the 4-capability contract

--- a/docs/guides/literature.md
+++ b/docs/guides/literature.md
@@ -85,7 +85,12 @@ overwritten.
 **`triage.yml` is your decision layer**, keyed by citekey, one mapping per paper:
 `role` (anchor / rival / prior-art / support / contrast / neighbor),
 `disposition` (`inbox → screened → interesting → acting → acted-on → dismissed`),
-`rationale`, `priority`, `notes`, reviewer, date.
+`rationale`, `priority`, `notes`, reviewer, date. Two further fields are written
+by the tooling rather than by hand: `extracted` (the date `digest extract
+record` last recorded cells for the paper) and `extraction-cells` (how many).
+Extraction writes those two and **nothing else** — in particular it never
+touches `disposition`, which is your decision state machine, not a fact about a
+run.
 
 ```yaml
 sill1997monotonic:

--- a/docs/superpowers/plans/2026-08-28-digest-extraction-mode.md
+++ b/docs/superpowers/plans/2026-08-28-digest-extraction-mode.md
@@ -1,0 +1,967 @@
+# Digest Extraction Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `digest` a breadth mode that fills a concept-matrix row per paper from `positioning.md`'s own comparison axes, with an enforced per-cell locator and a human-verified deterministic sample — so a 40-paper survey is tractable without pretending it was read at depth.
+
+**Architecture:** Promote the host-preserving markdown-table core out of `exploration/backlog.py` into `core/mdtable.py`, then build a pure validation library on top of it (axes, cells, locators). A new `digest` CLI group fuses validation to writing so no path records an unvalidated cell. Extraction writes `status.extraction` — never `status.understanding` — and the concept-matrix row is a *projection* of durable per-paper cells, not an independently authored artifact.
+
+**Tech Stack:** Python 3.11+, Typer, `pyyaml`, pytest with a 100% statement+branch coverage gate. No new runtime dependencies.
+
+**Spec:** [`docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md`](../specs/2026-08-28-digest-extraction-mode-design.md) — read it first; this plan argues from it and cites its sections.
+
+## Global Constraints
+
+- **All package work runs from the `defendable-science/` subdirectory.** Every `uv run` command assumes that cwd.
+- **100% statement + branch coverage is a hard gate** (`fail_under = 100`, ADR-0028). `# pragma: no cover` only for genuinely unreachable code, with a stated reason. Five pragmas exist in the package and all predate this work — add none.
+- Python 3.11+, line length 88, strict mypy, `ruff check` + `ruff format` clean.
+- **MyST field-list docstrings** on every public API (`:param:` / `:returns:` / `:raises:`; types come from annotations, never repeated in prose).
+- **stdlib `dataclasses` for value objects. Pydantic is deliberately rejected** — do not reintroduce it.
+- **No new runtime dependencies.**
+- **Failure honesty:** never let a failure or uncertain condition be reported as a legitimate empty/negative/complete result. Distinguish "failed" from "legitimately empty"; no raw tracebacks at the CLI boundary.
+- **Domain-neutrality:** no ML-, venue-, or consumer-specific assumptions in shipped code. The locator pattern set ships as a *default* and is configurable for exactly this reason (spec §3.4).
+- **Never commit to `main`.** Work continues on `skills/digest-extraction-mode`.
+- **Commits:** author `Davor Runje <davor@synthpop.ai>`, `--no-gpg-sign` (mandated by `.claude/skills/create-pr/STYLE.md` — SSH signing is unavailable in these sessions), and a `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>` trailer.
+- **Exit codes:** `0` success, `1` anything rejected or incomplete, `2` reserved for Click/Typer usage errors. Do not reuse `2` for a domain outcome — #106/#119 was exactly that mistake and it cost a PR to undo.
+
+## Resolved during planning — a gap in the spec
+
+Spec §6.1 says the axes come from "`positioning.md`'s matrix header". It does not say *which* table. `_parse_document` locates the **first** table in a document, and a real `positioning.md` may grow others. Extraction targeting the wrong table would be silent and awful.
+
+**Resolution:** the promoted `parse_document` gains an optional `under_heading` parameter that bounds the search to one section. Extraction always passes `under_heading="Concept matrix"`. This is additive — `backlog.py` passes nothing and is unaffected.
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `defendable_science/core/mdtable.py` | **NEW.** Host-preserving markdown-table parse/render/splice. Promoted from `backlog.py`, plus `under_heading`. |
+| `defendable_science/exploration/backlog.py` | **MODIFY.** Re-imports the promoted names; backlog logic untouched. |
+| `defendable_science/digest/__init__.py` | **NEW.** Package docstring only. |
+| `defendable_science/digest/extraction.py` | **NEW.** Axes derivation, `Cell`, locator patterns, validation. Pure — no I/O. |
+| `defendable_science/digest/artifact.py` | **NEW.** `status.extraction` patching, cells persistence, log entries. |
+| `defendable_science/digest/render.py` | **NEW.** The `positioning.md` matrix merge. |
+| `defendable_science/digest/sampling.py` | **NEW.** Deterministic sample selection. |
+| `defendable_science/defend/record.py` | **MODIFY.** Generalise `_append_log` so one writer owns the log directory. |
+| `defendable_science/cli.py` | **MODIFY.** New `digest` Typer group with four subcommands. |
+| `skills/digest/SKILL.md`, `skills/progress/SKILL.md` | **MODIFY.** Two contracts, the guardrail carve-out, the tier ladder, the second progress row. |
+
+## PR boundaries
+
+- **PR 1 — table core promotion:** Task 1. Review criterion: `backlog` behaviour unchanged.
+- **PR 2 — validation library:** Tasks 2–3. Pure, no writes, exhaustively testable.
+- **PR 3 — artifact + CLI:** Tasks 4–6.
+- **PR 4 — sampling, render, docs:** Tasks 7–10.
+
+---
+
+## Task 1: Promote the markdown-table core to `core/mdtable.py`
+
+**Files:**
+- Create: `defendable_science/core/mdtable.py`
+- Create: `tests/test_mdtable.py`
+- Modify: `defendable_science/exploration/backlog.py`
+- Modify: `tests/test_backlog.py` (only if a test reaches a moved private name)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Row = dict[str, str]`; `@dataclass Document(preamble: str = "", header: list[str] | None = None, rows: list[Row] = [], postamble: str = "", saw_table_shape: bool = False)`; `escape_cell(cell: str) -> str`; `split_cells(line: str) -> list[str]`; `is_separator(cells: list[str]) -> bool`; `parse_document(text: str, *, under_heading: str | None = None) -> Document`; `render_table(header: list[str], rows: list[Row]) -> str`; `splice(preamble: str, postamble: str, header: list[str], rows: list[Row]) -> str`.
+
+> **Why this is a promotion and not a copy.** #94 and #95 were both bugs in this exact machinery — a writer that discarded surrounding prose, and one that hardcoded a column schema. They are fixed. Copying the code into a second module is how that class of bug gets reintroduced in a place nobody thinks to check. One implementation, two consumers.
+
+- [ ] **Step 1: Move the code verbatim**
+
+Create `defendable_science/core/mdtable.py` with this module docstring, then move `Row`, `_Document`, `_escape`, `_split_cells`, `_is_separator`, `_collect_rows`, `_parse_document`, `_render_table`, `_splice` out of `exploration/backlog.py` **unchanged**, renaming the public ones by dropping the leading underscore (`_Document` → `Document`, `_escape` → `escape_cell`, `_split_cells` → `split_cells`, `_is_separator` → `is_separator`, `_parse_document` → `parse_document`, `_render_table` → `render_table`, `_splice` → `splice`). Keep `_collect_rows` private.
+
+```python
+"""Host-preserving markdown-table I/O (GFM), shared across front-ends.
+
+A table lives inside a document a human wrote. This module reads the table
+without losing the prose around it and writes it back without touching
+anything it did not author — the property issues #94 and #95 were filed for
+when an earlier writer discarded the host document and hardcoded a column
+schema. Columns are read from the file's own header, never assumed.
+"""
+```
+
+- [ ] **Step 2: Re-import in `backlog.py`**
+
+Replace the moved definitions with explicit re-exports. The `X as X` form is **required** — strict mypy's `no_implicit_reexport` rejects the plain form for names other modules reach through this one:
+
+```python
+from defendable_science.core.mdtable import Document as Document
+from defendable_science.core.mdtable import Row as Row
+from defendable_science.core.mdtable import escape_cell as escape_cell
+from defendable_science.core.mdtable import is_separator as is_separator
+from defendable_science.core.mdtable import parse_document as parse_document
+from defendable_science.core.mdtable import render_table as render_table
+from defendable_science.core.mdtable import splice as splice
+from defendable_science.core.mdtable import split_cells as split_cells
+```
+
+Update `backlog.py`'s internal call sites to the new names. If ruff reports `F401` for any name, it is genuinely unused there — delete it from the import rather than adding a `noqa`.
+
+- [ ] **Step 3: Run the existing suite — `backlog` behaviour must be unchanged**
+
+Run: `uv run pytest tests/test_backlog.py -q`
+Expected: PASS with no test modified. If a test fails because it reached a moved private name, update only the name it reaches — never an assertion.
+
+- [ ] **Step 4: Write the failing test for `under_heading`**
+
+Create `tests/test_mdtable.py`:
+
+```python
+"""Tests for the shared host-preserving markdown-table core."""
+
+from __future__ import annotations
+
+from defendable_science.core import mdtable as md
+
+TWO_TABLES = """# Positioning
+
+## Baselines
+
+| Baseline | Why |
+|---|---|
+| ridge | simplest floor |
+
+## Concept matrix
+
+<!-- rows = methods -->
+
+| Method | guarantee | scope |
+|---|---|---|
+| sill1997 | architectural | full |
+
+## Notes
+
+trailing prose
+"""
+
+
+def test_parse_document_takes_the_first_table_by_default() -> None:
+    doc = md.parse_document(TWO_TABLES)
+    assert doc.header == ["Baseline", "Why"]
+
+
+def test_under_heading_targets_that_section_s_table() -> None:
+    doc = md.parse_document(TWO_TABLES, under_heading="Concept matrix")
+    assert doc.header == ["Method", "guarantee", "scope"]
+    assert doc.rows == [{"Method": "sill1997", "guarantee": "architectural",
+                         "scope": "full"}]
+
+
+def test_under_heading_round_trips_the_whole_document() -> None:
+    doc = md.parse_document(TWO_TABLES, under_heading="Concept matrix")
+    assert doc.header is not None
+    out = md.splice(doc.preamble, doc.postamble, doc.header, doc.rows)
+    assert out == TWO_TABLES
+
+
+def test_under_heading_preserves_the_other_table_verbatim() -> None:
+    doc = md.parse_document(TWO_TABLES, under_heading="Concept matrix")
+    assert "| ridge | simplest floor |" in doc.preamble
+    assert "trailing prose" in doc.postamble
+
+
+def test_under_heading_absent_yields_no_table() -> None:
+    doc = md.parse_document(TWO_TABLES, under_heading="Nonexistent")
+    assert doc.header is None
+    assert doc.preamble == TWO_TABLES
+
+
+def test_under_heading_section_with_no_table_yields_no_table() -> None:
+    doc = md.parse_document(TWO_TABLES, under_heading="Notes")
+    assert doc.header is None
+
+
+def test_under_heading_stops_at_the_next_heading() -> None:
+    text = "## A\n\nprose\n\n## B\n\n| X |\n|---|\n| 1 |\n"
+    assert md.parse_document(text, under_heading="A").header is None
+    assert md.parse_document(text, under_heading="B").header == ["X"]
+
+
+def test_under_heading_matches_any_heading_level() -> None:
+    text = "### Concept matrix\n\n| M |\n|---|\n| a |\n"
+    assert md.parse_document(text, under_heading="Concept matrix").header == ["M"]
+```
+
+- [ ] **Step 5: Run to verify it fails**
+
+Run: `uv run pytest tests/test_mdtable.py -v --no-cov`
+Expected: the `under_heading` tests FAIL with `TypeError: parse_document() got an unexpected keyword argument 'under_heading'`.
+
+- [ ] **Step 6: Implement `under_heading`**
+
+Bound the existing scan to one section rather than slicing the text, so `preamble`/`postamble` still cover the whole document and `splice` round-trips unchanged:
+
+```python
+_HEADING = re.compile(r"^#{1,6}\s+(?P<title>.+?)\s*$")
+
+
+def _section_bounds(lines: list[str], title: str) -> tuple[int, int] | None:
+    """Return ``(start, end)`` line indices for the section under `title`.
+
+    The section runs from the line after its heading to the line before the
+    next heading of any level, or to the end of the document.
+
+    :param lines: The document's lines.
+    :param title: The heading text to find, compared case-insensitively.
+    :returns: The bounds, or ``None`` when no such heading exists.
+    """
+    want = title.strip().casefold()
+    start: int | None = None
+    for i, line in enumerate(lines):
+        match = _HEADING.match(line)
+        if match is None:
+            continue
+        if start is not None:
+            return start, i
+        if match.group("title").strip().casefold() == want:
+            start = i + 1
+    return None if start is None else (start, len(lines))
+```
+
+Then give `parse_document` the parameter, defaulting the window to the whole document:
+
+```python
+def parse_document(text: str, *, under_heading: str | None = None) -> Document:
+    """Locate the markdown table in `text`, keeping the prose around it.
+
+    :param text: The host document.
+    :param under_heading: When given, only consider a table inside the section
+        under that heading. A document may hold several tables, and the caller
+        usually means one of them specifically.
+    :returns: The located document; ``header`` is ``None`` when the window
+        holds no table, in which case `preamble` is the whole of `text`.
+    """
+    lines = text.splitlines(keepends=True)
+    window = (0, len(lines))
+    if under_heading is not None:
+        bounds = _section_bounds(lines, under_heading)
+        if bounds is None:
+            return Document(preamble=text)
+        window = bounds
+    # …existing scan, but iterating only over lines[window[0]:window[1]] and
+    # offsetting the indices it records by window[0], so preamble/postamble are
+    # still measured against the whole document.
+```
+
+Keep the body's existing logic; only the iteration bounds and index offset change.
+
+- [ ] **Step 7: Run to verify it passes**
+
+Run: `uv run pytest tests/test_mdtable.py tests/test_backlog.py -v --no-cov`
+Expected: PASS, both files.
+
+- [ ] **Step 8: Full gate**
+
+Run: `uv run pytest -q && uv run ruff check && uv run ruff format --check && uv run mypy`
+Expected: PASS, coverage 100%.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add defendable_science/core/mdtable.py defendable_science/exploration/backlog.py tests/test_mdtable.py
+git -c user.name="Davor Runje" -c user.email="davor@synthpop.ai" commit --no-gpg-sign -m "refactor(core): promote the markdown-table core to core/mdtable.py
+
+One host-preserving table implementation, two consumers. #94 and #95 were both
+bugs in this machinery; copying it into a second module is how that class comes
+back somewhere nobody checks.
+
+Adds an additive under_heading parameter: a document may hold several tables
+and a caller usually means one specifically. backlog passes nothing.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Derive the question set from the concept matrix
+
+**Files:**
+- Create: `defendable_science/digest/__init__.py` (docstring only)
+- Create: `defendable_science/digest/extraction.py`
+- Create: `tests/test_extraction.py`
+
+**Interfaces:**
+- Consumes: `parse_document`, `Document` from Task 1.
+- Produces: `class ExtractionError(ValueError)`; `PLACEHOLDER_RE: re.Pattern[str]`; `CONCEPT_MATRIX_HEADING = "Concept matrix"`; `SELF_ROW = "**This paper**"`; `def axes_from_positioning(path: str | Path) -> list[str]`.
+
+> **The two refusals are the point of this task.** `positioning.md` ships `| Method | <attr 1> | <attr 2> | <attr 3> |`. Extracting 40 papers against `<attr 1>` would produce 320 confidently-shaped, meaningless cells. Refusing costs the author one message; not refusing costs them the run.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_extraction.py`:
+
+```python
+"""Tests for extraction's pure library: axes, cells, locators, validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from defendable_science.digest import extraction as ex
+
+REAL = """## Concept matrix
+
+<!-- rows = methods -->
+
+| Method | guarantee type | scope | verifiability |
+|---|---|---|---|
+| *<prior work>* | | | |
+| **This paper** | | | |
+"""
+
+TEMPLATE = """## Concept matrix
+
+| Method | <attr 1> | <attr 2> | <attr 3> |
+|---|---|---|---|
+| **This paper** | | | |
+"""
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    target = tmp_path / "positioning.md"
+    target.write_text(text, encoding="utf-8")
+    return target
+
+
+def test_axes_are_the_header_minus_the_row_label(tmp_path: Path) -> None:
+    assert ex.axes_from_positioning(_write(tmp_path, REAL)) == [
+        "guarantee type", "scope", "verifiability"
+    ]
+
+
+def test_unreplaced_placeholders_refuse(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="placeholder"):
+        ex.axes_from_positioning(_write(tmp_path, TEMPLATE))
+
+
+def test_one_replaced_axis_still_refuses_if_others_are_placeholders(
+    tmp_path: Path,
+) -> None:
+    text = TEMPLATE.replace("<attr 1>", "guarantee type")
+    with pytest.raises(ex.ExtractionError, match="placeholder"):
+        ex.axes_from_positioning(_write(tmp_path, text))
+
+
+def test_no_concept_matrix_section_refuses(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="no 'Concept matrix'"):
+        ex.axes_from_positioning(_write(tmp_path, "## Baselines\n\nprose\n"))
+
+
+def test_section_present_but_no_table_refuses(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="no table"):
+        ex.axes_from_positioning(_write(tmp_path, "## Concept matrix\n\nTBD\n"))
+
+
+def test_header_with_only_a_row_label_refuses(tmp_path: Path) -> None:
+    text = "## Concept matrix\n\n| Method |\n|---|\n| a |\n"
+    with pytest.raises(ex.ExtractionError, match="no comparison axes"):
+        ex.axes_from_positioning(_write(tmp_path, text))
+
+
+def test_missing_file_refuses_actionably(tmp_path: Path) -> None:
+    with pytest.raises(ex.ExtractionError, match="not found"):
+        ex.axes_from_positioning(tmp_path / "absent.md")
+
+
+def test_duplicate_axis_names_refuse(tmp_path: Path) -> None:
+    text = "## Concept matrix\n\n| Method | a | a |\n|---|---|---|\n| x | | |\n"
+    with pytest.raises(ex.ExtractionError, match="duplicate"):
+        ex.axes_from_positioning(_write(tmp_path, text))
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/test_extraction.py -v --no-cov`
+Expected: FAIL — `ModuleNotFoundError: No module named 'defendable_science.digest'`
+
+- [ ] **Step 3: Implement**
+
+Create `defendable_science/digest/__init__.py`:
+
+```python
+"""Reading an external paper: depth-first comprehension, and breadth extraction."""
+```
+
+Create `defendable_science/digest/extraction.py`:
+
+```python
+"""Extraction mode's pure library — axes, cells, locators, validation.
+
+No I/O beyond reading the positioning document: everything here is a function
+of its inputs, so the rules can be tested exhaustively without touching a
+registry, a PDF, or an artifact. The writer that fuses validation to recording
+lives in :mod:`defendable_science.digest.artifact`; nothing here writes.
+
+Design: ``docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from defendable_science.core.mdtable import parse_document
+
+#: The heading whose table holds the comparison axes.
+CONCEPT_MATRIX_HEADING = "Concept matrix"
+
+#: The matrix's self-reference row — the author's own delta, never a paper.
+SELF_ROW = "**This paper**"
+
+#: An unreplaced template placeholder, e.g. ``<attr 1>`` or ``<prior work>``.
+PLACEHOLDER_RE = re.compile(r"^<[^>]*>$")
+
+
+class ExtractionError(ValueError):
+    """Raised when extraction cannot proceed and must not guess."""
+
+
+def axes_from_positioning(path: str | Path) -> list[str]:
+    """Read the comparison axes from a positioning document's concept matrix.
+
+    The axes are the matrix header minus its first column, which labels the
+    row rather than naming an attribute.
+
+    :param path: The positioning document.
+    :returns: The axes, in the matrix's own column order.
+    :raises ExtractionError: If the file is missing; if it has no
+        ``Concept matrix`` section, or that section has no table; if the
+        header carries unreplaced template placeholders; if there are no
+        axes beyond the row label; or if two axes share a name.
+    """
+    target = Path(path)
+    if not target.is_file():
+        raise ExtractionError(f"{target}: positioning document not found")
+    text = target.read_text(encoding="utf-8")
+    doc = parse_document(text, under_heading=CONCEPT_MATRIX_HEADING)
+    if doc.header is None:
+        if f"# {CONCEPT_MATRIX_HEADING}" not in text:
+            raise ExtractionError(
+                f"{target}: no '{CONCEPT_MATRIX_HEADING}' section — run "
+                "`literature position --level paper` first"
+            )
+        raise ExtractionError(
+            f"{target}: the '{CONCEPT_MATRIX_HEADING}' section holds no table"
+        )
+    axes = [c.strip() for c in doc.header[1:]]
+    placeholders = [a for a in axes if PLACEHOLDER_RE.match(a)]
+    if placeholders:
+        raise ExtractionError(
+            f"{target}: the concept matrix still carries template "
+            f"placeholders {placeholders} — replace them with the attributes "
+            "your delta turns on before extracting against them"
+        )
+    if not axes:
+        raise ExtractionError(
+            f"{target}: the concept matrix has no comparison axes, only a "
+            "row label"
+        )
+    seen = {a for a in axes}
+    if len(seen) != len(axes):
+        raise ExtractionError(f"{target}: duplicate axis names in {axes}")
+    return axes
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/test_extraction.py -v --no-cov`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Confirm module coverage**
+
+Run: `uv run pytest tests/test_extraction.py --cov=defendable_science.digest.extraction --cov-branch --cov-report=term-missing --no-cov-on-fail`
+Expected: 100%. Any uncovered branch is a refusal with no test — add the test, not a pragma.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add defendable_science/digest tests/test_extraction.py
+git -c user.name="Davor Runje" -c user.email="davor@synthpop.ai" commit --no-gpg-sign -m "feat(digest): derive extraction's question set from the concept matrix
+
+Refuses on unreplaced template placeholders. Extracting 40 papers against
+'<attr 1>' would produce 320 confidently-shaped meaningless cells; refusing
+costs the author one message.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Cells, locator patterns, and the validation rules
+
+**Files:**
+- Modify: `defendable_science/digest/extraction.py`
+- Modify: `tests/test_extraction.py`
+
+**Interfaces:**
+- Consumes: `ExtractionError`, `axes_from_positioning` from Task 2.
+- Produces:
+  - `NOT_ADDRESSED = "not-addressed"`
+  - `DEFAULT_LOCATOR_PATTERNS: tuple[str, ...]`
+  - `@dataclass(frozen=True) class Cell: citekey: str; axis: str; value: str; locator: str | None = None; justification: str | None = None`
+  - `def cell_from_mapping(item: Mapping[str, Any]) -> Cell`
+  - `def compile_locator_patterns(extra: list[str] | None = None) -> list[re.Pattern[str]]`
+  - `def is_valid_locator(locator: str, patterns: list[re.Pattern[str]]) -> bool`
+  - `@dataclass class Rejection: citekey: str; axis: str | None; reason: str`
+  - `def validate(cells: list[Cell], axes: list[str], patterns: list[re.Pattern[str]]) -> tuple[dict[str, list[Cell]], list[Rejection]]` — returns accepted cells grouped by citekey, and rejections. **A citekey with any rejection appears in neither group's accepted map** (spec §7.2 rule 4: rejection is per paper, whole).
+
+> **Rule 2 is the one to get right.** Requiring *every* axis to be present is what makes `not-addressed` necessary at all. Without it an agent that finds an axis hard simply omits the cell, and a short row looks like a clean row. With it, the dodge is forced into `not-addressed`, which is counted and visible.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_extraction.py`:
+
+```python
+AXES = ["guarantee type", "scope"]
+
+
+def _cell(**kw: object) -> ex.Cell:
+    base: dict[str, object] = {
+        "citekey": "sill1997", "axis": "guarantee type",
+        "value": "architectural", "locator": "§2, Eq. (3)",
+    }
+    base.update(kw)
+    return ex.Cell(**base)  # type: ignore[arg-type]
+
+
+def _full(citekey: str = "sill1997") -> list[ex.Cell]:
+    return [
+        _cell(citekey=citekey, axis="guarantee type"),
+        _cell(citekey=citekey, axis="scope", locator="p. 4"),
+    ]
+
+
+PATTERNS = ex.compile_locator_patterns()
+
+
+@pytest.mark.parametrize(
+    "locator",
+    ["§3", "§3.2", "§3.2.1", "Section 3", "Sec. 3", "p. 7", "pp. 7-9",
+     "page 7", "Eq. (4)", "Equation 4", "Table 2", "Fig. 5", "Figure 5",
+     "Alg. 1", "Thm. 2", "Theorem 2", "Lemma 3", "Def. 1", "§3, Eq. (4)",
+     "p. 7, Table 2"],
+)
+def test_well_formed_locators_are_accepted(locator: str) -> None:
+    assert ex.is_valid_locator(locator, PATTERNS)
+
+
+@pytest.mark.parametrize(
+    "locator",
+    ["see paper", "somewhere in §3", "the introduction", "passim", "",
+     "   ", "throughout", "as discussed"],
+)
+def test_vague_locators_are_refused(locator: str) -> None:
+    assert not ex.is_valid_locator(locator, PATTERNS)
+
+
+def test_extra_patterns_extend_the_default_set() -> None:
+    patterns = ex.compile_locator_patterns([r"cl\. \d+"])
+    assert ex.is_valid_locator("cl. 14", patterns)
+    assert ex.is_valid_locator("§3", patterns)
+
+
+def test_a_complete_paper_is_accepted() -> None:
+    accepted, rejections = ex.validate(_full(), AXES, PATTERNS)
+    assert rejections == []
+    assert sorted(c.axis for c in accepted["sill1997"]) == ["guarantee type", "scope"]
+
+
+def test_a_missing_axis_rejects_the_whole_paper() -> None:
+    accepted, rejections = ex.validate(_full()[:1], AXES, PATTERNS)
+    assert accepted == {}
+    assert any("scope" in r.reason and "missing" in r.reason for r in rejections)
+
+
+def test_an_invented_axis_rejects_the_whole_paper() -> None:
+    cells = [*_full(), _cell(axis="made up", locator="§9")]
+    accepted, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert accepted == {}
+    assert any("not a matrix axis" in r.reason for r in rejections)
+
+
+def test_a_bad_locator_rejects_the_whole_paper_not_just_the_cell() -> None:
+    cells = [_cell(), _cell(axis="scope", locator="see paper")]
+    accepted, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert accepted == {}
+    assert any("see paper" in r.reason for r in rejections)
+
+
+def test_one_bad_paper_does_not_reject_a_good_one() -> None:
+    cells = [*_full("good"), *_full("bad")[:1]]
+    accepted, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert set(accepted) == {"good"}
+    assert {r.citekey for r in rejections} == {"bad"}
+
+
+def test_not_addressed_needs_a_justification_not_a_locator() -> None:
+    cells = [
+        _cell(),
+        _cell(axis="scope", value=ex.NOT_ADDRESSED, locator=None,
+              justification="scoped to full monotonicity in §1"),
+    ]
+    accepted, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert rejections == []
+    assert len(accepted["sill1997"]) == 2
+
+
+def test_not_addressed_without_a_justification_is_rejected() -> None:
+    cells = [_cell(), _cell(axis="scope", value=ex.NOT_ADDRESSED, locator=None)]
+    _, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert any("justification" in r.reason for r in rejections)
+
+
+def test_not_addressed_with_a_blank_justification_is_rejected() -> None:
+    cells = [_cell(), _cell(axis="scope", value=ex.NOT_ADDRESSED, locator=None,
+                            justification="   ")]
+    _, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert any("justification" in r.reason for r in rejections)
+
+
+def test_a_normal_cell_with_no_locator_is_rejected() -> None:
+    cells = [_cell(), _cell(axis="scope", locator=None)]
+    _, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert any("locator" in r.reason for r in rejections)
+
+
+def test_a_duplicated_axis_for_one_paper_is_rejected() -> None:
+    cells = [*_full(), _cell(axis="scope", locator="p. 9")]
+    _, rejections = ex.validate(cells, AXES, PATTERNS)
+    assert any("twice" in r.reason for r in rejections)
+
+
+def test_cell_from_mapping_rejects_a_non_string_field() -> None:
+    with pytest.raises(ex.ExtractionError, match="citekey"):
+        ex.cell_from_mapping({"citekey": 7, "axis": "a", "value": "v"})
+
+
+def test_cell_from_mapping_rejects_an_unknown_field() -> None:
+    with pytest.raises(ex.ExtractionError, match="unknown"):
+        ex.cell_from_mapping(
+            {"citekey": "k", "axis": "a", "value": "v", "bogus": "x"}
+        )
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/test_extraction.py -v --no-cov`
+Expected: FAIL — `AttributeError: module ... has no attribute 'compile_locator_patterns'`
+
+- [ ] **Step 3: Implement**
+
+Append to `defendable_science/digest/extraction.py`. Anchor every pattern with `\A…\Z` so `"somewhere in §3"` cannot pass on a partial match — that is the whole point of shape validation:
+
+```python
+#: The distinguished value for an axis the paper does not address.
+NOT_ADDRESSED = "not-addressed"
+
+#: Locator forms accepted out of the box. Extended or replaced via
+#: ``literature.extraction.locator_patterns`` — a set built around §/Eq./Thm.
+#: encodes one citation culture, and this plugin forbids domain assumptions.
+DEFAULT_LOCATOR_PATTERNS: tuple[str, ...] = (
+    r"§\s*\d+(\.\d+)*",
+    r"(Section|Sec\.)\s*\d+(\.\d+)*",
+    r"(pp?\.|pages?)\s*\d+(\s*[-–]\s*\d+)?",
+    r"(Eq\.|Equation)\s*\(?\d+\)?",
+    r"(Table|Tbl\.)\s*\d+",
+    r"(Fig\.|Figure)\s*\d+",
+    r"(Alg\.|Algorithm)\s*\d+",
+    r"(Thm\.|Theorem|Lemma|Cor\.|Corollary|Def\.|Definition|Prop\.|Proposition)\s*\d+",
+)
+```
+
+`compile_locator_patterns(extra)` compiles each default plus each extra into a **comma-joinable** anchored alternation, so `"§3, Eq. (4)"` passes while `"somewhere in §3"` does not:
+
+```python
+def compile_locator_patterns(extra: list[str] | None = None) -> list[re.Pattern[str]]:
+    """Compile the locator pattern set into anchored, comma-joinable matchers.
+
+    Each pattern is anchored whole-string and permitted to repeat in a
+    comma-separated list, so ``"§3, Eq. (4)"`` is accepted while
+    ``"somewhere in §3"`` is not — a partial match would defeat the check.
+
+    :param extra: Additional raw patterns from configuration.
+    :returns: One compiled pattern matching any comma-joined combination.
+    :raises ExtractionError: If a configured pattern is not valid regex.
+    """
+    raw = [*DEFAULT_LOCATOR_PATTERNS, *(extra or [])]
+    for pattern in extra or []:
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            raise ExtractionError(
+                f"invalid locator pattern {pattern!r} in config: {exc}"
+            ) from exc
+    one = "|".join(f"(?:{p})" for p in raw)
+    joined = rf"\A\s*(?:{one})(?:\s*,\s*(?:{one}))*\s*\Z"
+    return [re.compile(joined, re.IGNORECASE)]
+
+
+def is_valid_locator(locator: str, patterns: list[re.Pattern[str]]) -> bool:
+    """Return whether `locator` is well-formed against the pattern set.
+
+    Proves the locator's *shape*, never its correctness — a cell may cite §3
+    when the claim is in §5, and what catches that is ``defend --target
+    cited-work`` later, which is why the locator is mandatory at all.
+
+    :param locator: The recorded locator.
+    :param patterns: Compiled patterns from :func:`compile_locator_patterns`.
+    :returns: Whether it matches.
+    """
+    return any(p.match(locator) is not None for p in patterns)
+```
+
+Then `Cell`, `cell_from_mapping` (mirroring `record.point_record_from_mapping`'s field-type enforcement, rejecting unknown keys), `Rejection`, and `validate` implementing the four rules of spec §7.2 — collecting rejections per paper and omitting any paper with a rejection from the accepted map.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/test_extraction.py -v --no-cov`
+Expected: PASS.
+
+- [ ] **Step 5: Full gate and commit**
+
+Run: `uv run pytest -q && uv run ruff check && uv run ruff format --check && uv run mypy`
+
+```bash
+git add defendable_science/digest/extraction.py tests/test_extraction.py
+git -c user.name="Davor Runje" -c user.email="davor@synthpop.ai" commit --no-gpg-sign -m "feat(digest): cells, anchored locator patterns, and the validation rules
+
+Patterns are anchored whole-string and comma-joinable, so '§3, Eq. (4)' passes
+and 'somewhere in §3' does not — an unanchored match would accept the vague
+filler the rule exists to catch.
+
+Completeness is rule 2 and it is load-bearing: without it an agent that finds
+an axis hard omits the cell, and a short row looks like a clean row.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: The artifact writer and the shared log appender
+
+**Files:**
+- Create: `defendable_science/digest/artifact.py`
+- Create: `tests/test_digest_artifact.py`
+- Modify: `defendable_science/defend/record.py` (generalise `_append_log`)
+
+**Interfaces:**
+- Consumes: `Cell`, `NOT_ADDRESSED` from Task 3; `patch_status_child` / `DEFAULT_LOG_DIR` from `defend/record.py`.
+- Produces:
+  - `def append_log_entry(log_dir: Path, date: str, stem: str, body: str) -> Path` (in `defend/record.py`, generalised from `_append_log`)
+  - `@dataclass class ExtractionStatus: cells: int; locators: str; in_sample: bool; batch_check: str`
+  - `def write_extraction(artifact: Path, cells: list[Cell], *, in_sample: bool, batch_check: str, log_dir: Path, date: str) -> Path`
+  - `def set_batch_check(artifact: Path, verdict: str) -> None`
+
+Behaviours to cover, each with its own test:
+
+1. A fresh artifact is created with the seed frontmatter plus `status.extraction`, and a cells block in the body.
+2. An **existing** artifact with a depth-mode `status.understanding` block keeps it byte-identical; only `status.extraction` is added or replaced.
+3. `status.understanding` is **never** written by this module — assert it directly, by writing extraction to an artifact that has none and confirming none appears. This is the guarantee-inflation guard of spec §3.2.
+4. `in-sample` and `batch-check` are separate keys with the meanings of spec §5 — a paper not in the sample in a failed batch reads `in-sample: false`, `batch-check: failed`.
+5. Re-running extraction on the same paper replaces its cells rather than appending a second block.
+6. The log entry lands in `log_dir` with a unique name and contains every cell including `not-addressed` ones with their justifications.
+7. `set_batch_check` updates only that key and leaves cells and `understanding` untouched.
+
+- [ ] **Step 1: Generalise the log appender**
+
+In `defend/record.py`, split `_append_log` so one function owns naming and uniqueness and both callers render their own YAML:
+
+```python
+def append_log_entry(log_dir: Path, date: str, stem: str, body: str) -> Path:
+    """Write a uniquely-named log file under `log_dir`, returning its path.
+
+    One writer owns the accountability-log directory so its naming stays
+    consistent across the examination kinds that write into it.
+
+    :param log_dir: The accountability-log directory.
+    :param date: ISO date, used as the filename prefix.
+    :param stem: The artifact stem, used as the filename body.
+    :param body: The rendered YAML to write.
+    :returns: The path written.
+    """
+    log_dir.mkdir(parents=True, exist_ok=True)
+    target = log_dir / f"{date}-{stem}.yml"
+    n = 2
+    while target.exists():
+        target = log_dir / f"{date}-{stem}-{n}.yml"
+        n += 1
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def _append_log(log_dir: Path, entry: LogEntry) -> Path:
+    """Write a per-examination log file (unique name), returning its path."""
+    return append_log_entry(
+        log_dir, entry.date, Path(entry.artifact).stem, _log_yaml(entry)
+    )
+```
+
+- [ ] **Step 2: Confirm `defend` is unchanged**
+
+Run: `uv run pytest tests/test_record.py -q`
+Expected: PASS with no test modified.
+
+- [ ] **Step 3: Write the failing tests, implement, and verify**
+
+Write `tests/test_digest_artifact.py` covering behaviours 1–7 above, run it to see it fail, implement `defendable_science/digest/artifact.py`, and run it to green. Reuse `record.patch_status_child` for frontmatter patching rather than writing a second YAML-frontmatter editor — `defend/record.py:135` already handles the indentation and trailing-comment cases correctly.
+
+- [ ] **Step 4: Full gate and commit**
+
+Run: `uv run pytest -q && uv run ruff check && uv run ruff format --check && uv run mypy`
+
+```bash
+git add defendable_science/digest/artifact.py defendable_science/defend/record.py tests/test_digest_artifact.py
+git -c user.name="Davor Runje" -c user.email="davor@synthpop.ai" commit --no-gpg-sign -m "feat(digest): the extraction artifact writer, and one log-directory writer
+
+status.extraction never touches status.understanding: progress reports any
+digests/*.md with an understanding block as 'digested & understood', so sharing
+the key would count an extracted-but-unread paper as read.
+
+in-sample and batch-check are separate because they answer different questions;
+a single field would have to say 'failed' for a paper never checked.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `digest extract axes` and `digest extract record`
+
+**Files:**
+- Modify: `defendable_science/cli.py`
+- Create: `tests/test_digest_cli.py`
+
+**Interfaces:**
+- Consumes: everything from Tasks 2–4.
+- Produces the CLI surface of spec §3.1.
+
+Follow `cli.py`'s existing group patterns — `_load_config_or_exit`, `_cache_root`, config validation that exits 1 naming the bad key, `typer.echo(..., err=True)`, `json.dumps(..., indent=2)` on stdout.
+
+Behaviours to cover:
+
+1. `digest extract axes` prints the axes as JSON; a placeholder-bearing matrix exits 1 with the refusal message, not a traceback.
+2. `digest extract record --cells FILE` validates and writes in one action; there is **no** flag or path that writes without validating.
+3. Any rejection exits 1 and names the offending cells — citekey, axis, and reason — never just a count.
+4. A malformed cells JSON (not an array, a non-object element, an unknown field) exits 1 with an actionable message.
+5. `--cells -` reads stdin.
+6. Config plumbing reads `literature.extraction.locator_patterns`; an invalid regex there exits 1 naming the pattern; a non-list value exits 1 naming the key.
+7. Exit codes are `0` / `1`, with `2` left to Click. **Add a test asserting a usage error still exits 2** — #106/#119 was precisely this collision and it cost a PR.
+
+- [ ] **Step 1–4:** Write the failing tests, run to see them fail, implement, run to green, then the full gate.
+- [ ] **Step 5: Commit** with the same authorship convention.
+
+---
+
+## Task 6: Triage writeback and the comment-refusal path
+
+**Files:**
+- Modify: `defendable_science/digest/artifact.py`, `defendable_science/cli.py`
+- Modify: `tests/test_digest_artifact.py`, `tests/test_digest_cli.py`
+
+Behaviours:
+
+1. A successful extraction sets the paper's triage fields via `registry.patch_triage`.
+2. **A `triage.yml` carrying YAML comments makes `patch_triage` raise `RegistryError`. The cells must still be recorded.** The run reports `triage not updated for ⟨citekeys⟩; set ⟨fields⟩ by hand`, exits 1 because something genuinely did not complete, and leaves the sidecar **byte-identical**. Assert all three.
+3. The same holds for `patch_triage`'s non-mapping-row refusal.
+4. No path strips comments to work around the refusal — the refusal's own rationale is that those `rationale` fields are the PRISMA audit trail.
+
+- [ ] **Steps:** failing tests → implement → green → full gate → commit.
+
+---
+
+## Task 7: Deterministic sampling
+
+**Files:**
+- Create: `defendable_science/digest/sampling.py`, `tests/test_sampling.py`
+- Modify: `defendable_science/cli.py`
+
+**Interfaces:**
+- Produces: `def select_sample(citekeys: list[str], size: int) -> list[str]`; `def default_size(n: int) -> int` returning `min(n, max(3, ceil(n / 10)))`.
+
+> **Determinism is the anti-gaming property, not a convenience.** A freshly-random draw per run lets anyone re-roll until an easy sample comes up. Seed from the sorted citekey set so the same batch always draws the same papers.
+
+Behaviours:
+
+1. The same citekey set yields the same sample across calls, processes, and orderings of the input list (sort before seeding).
+2. A different citekey set yields a different sample (not a guarantee for all inputs — assert on a specific pair).
+3. `default_size` returns `3` for small batches, `4` for 40, and never exceeds the batch size.
+4. A batch smaller than the sample size samples everything.
+5. `digest extract sample` reports which papers were drawn and exits 0; recording the human's verdict sets `batch-check` on **every** artifact in the batch, sampled or not (spec §8).
+6. A `failed` verdict does **not** modify any cell — assert the cells are byte-identical after.
+
+- [ ] **Steps:** failing tests → implement → green → full gate → commit.
+
+---
+
+## Task 8: `digest extract render` — the matrix merge
+
+**Files:**
+- Create: `defendable_science/digest/render.py`, `tests/test_digest_render.py`
+- Modify: `defendable_science/cli.py`
+
+**Interfaces:**
+- Consumes: `parse_document`, `splice` from Task 1; the artifact reader from Task 4.
+- Produces: `def render_matrix(positioning: Path, rows: dict[str, dict[str, str]]) -> str`.
+
+> **Render never deletes a row.** It is the one operation here with no safe failure mode: a bug that drops rows loses the author's work silently, and #94 is a live reminder. Insert or update only; a paper leaving the survey is removed by hand.
+
+Behaviours, each its own test:
+
+1. A new citekey is inserted as a row; existing rows are untouched.
+2. An existing citekey's row is updated in place, preserving column order.
+3. **`**This paper**` is never touched** — it is the author's own delta.
+4. **A row present in the file but absent from `rows` survives** — no deletion, ever.
+5. Preamble, postamble, the section comment, and any *other* table in the document survive byte-identical.
+6. Rendering twice is idempotent.
+7. A cell value containing `|` or a newline is escaped so the table stays well-formed.
+8. `not-addressed` cells render as a distinguishable marker rather than an empty cell — an empty cell reads as "not yet extracted", which is a different claim.
+
+- [ ] **Steps:** failing tests → implement → green → full gate → commit.
+
+---
+
+## Task 9: Skill and progress documentation
+
+**Files:**
+- Modify: `skills/digest/SKILL.md`, `skills/progress/SKILL.md`
+- Modify: `resources/ensure-tooling.md` (compat pin per ADR-0026), `CHANGELOG.md`
+
+Required content:
+
+1. **`skills/digest/SKILL.md`** states both modes and their contracts verbatim from spec §4, and **carves the "verified, never self-attested" guardrail** so it reads as covering depth mode only. Extraction says something weaker and must say it in its own words.
+2. The tier ladder table of spec §4.1.
+3. The `not-addressed` convention and the fact that its count is the anti-gaming signal.
+4. That the **human** checks the sample, and why (spec §3.5) — if the agent checked its own extraction the mode would certify nothing.
+5. That `render` never deletes a row and that a hand-edited row label is overwritten, since the row is a projection.
+6. **`skills/progress/SKILL.md`** gains the second row: `extracted N / digested M`, explicitly not summed.
+7. Every documented command verified against the shipped CLI with `--help`. A documented flag that does not exist is the defect class this repo spent a week removing.
+
+- [ ] **Steps:** write → `./tools/validate-plugin.sh` → `uvx pre-commit run --all-files` (**actually run them**; a prior task in this project reported a green gate it had not exercised) → commit.
+
+---
+
+## Task 10: File the follow-ups
+
+Per spec §13, using the local `create-issue` skill:
+
+1. **`defend --target cited-work` consuming extraction cells directly** — the locators exist precisely so it can, and wiring it is what closes the loop from extraction to verification.
+2. **Rendering a matrix row from depth-mode digests** — a depth digest also produces locatable claims, and today they cannot feed the matrix.
+
+- [ ] File both; report the issue numbers.
+
+---
+
+## Self-review
+
+**Spec coverage.** §3.1 → Tasks 5, 7, 8 (the four subcommands); §3.2 → Task 4 behaviour 3, Task 9 item 6; §3.3 → Task 5 behaviour 2; §3.4 → Task 3; §3.5 → Task 7; §4 → Task 9; §5 → Task 4; §6.1 → Task 2; §6.2 → Task 1; §6.3 → Task 5; §6.4 → Task 5; §6.5 → Task 3; §7 → Tasks 3, 5; §7.5 → Task 6; §8 → Task 7; §9 → Task 8; §10 → Tasks 5, 6; §11 → distributed; §12 → the PR boundaries; §13 → Task 10.
+
+**One spec gap found and resolved in-plan:** which table in `positioning.md` the axes come from. Recorded above the file structure; handled by Task 1's `under_heading`.
+
+**Known shape of this plan, stated rather than hidden.** Tasks 1–3 and the interface blocks throughout carry complete code. Tasks 4–9 enumerate behaviours with the reasoning for each, and give code only where the shape is not obvious from the codebase's existing patterns (the log appender, the pattern compiler). That is deliberate: those tasks are dense in fixtures whose setup is mechanical once Tasks 1–3 exist, and the previous plan in this project used the same shape successfully. An executor wanting literal code for 4–9 should write the first test of each, confirm the fixture shape, then follow the list.
+
+**Type consistency.** `Row` and `Document` come from Task 1 and are used unchanged after. `Cell`, `Rejection`, `NOT_ADDRESSED`, `ExtractionError` come from Tasks 2–3. `validate` returns `tuple[dict[str, list[Cell]], list[Rejection]]` and every later reference uses that shape. `append_log_entry(log_dir, date, stem, body)` is defined in Task 4 and used only there. `batch_check` / `in_sample` are the field names throughout, matching spec §5's `batch-check` / `in-sample` YAML keys (underscore in Python, hyphen in YAML — stated here because that mismatch is exactly the kind of thing that drifts).

--- a/docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md
+++ b/docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md
@@ -78,13 +78,23 @@ namespace aligned:
 ```
 defendable-science digest extract axes    [--positioning PATH]
 defendable-science digest extract record  --cells FILE|-   [--positioning PATH]
-defendable-science digest extract sample  --batch FILE|-   [--size N]
+defendable-science digest extract sample  (--citekey KEY ... | --all)  [--size N]
+                                          [--verdict verified|failed]
 defendable-science digest extract render  [--positioning PATH]
 ```
 
 `axes` prints the question set (§6.1) so the agent knows what to extract before reading
 anything. `record` is the validating writer of §3.3. `sample` draws the deterministic sample and
 drives the check. `render` performs the `positioning.md` merge of §9.
+
+*Amended during implementation.* `sample` takes its batch as repeated `--citekey` options or
+`--all` (every artifact under `digests/` carrying a `status.extraction` block), not the
+`--batch FILE|-` this section first sketched. A file of citekeys is a caller-supplied
+membership set, and since the draw is a deterministic function of membership, handing the
+caller that file hands them the sample — the anti-gaming property of §8 defeated by its own
+input. Recording the human's verdict is a second invocation of the same command with
+`--verdict`, on the same membership, rather than an interactive prompt: the questioning is the
+skill's job, and the CLI stays scriptable and testable.
 
 *Rejected:* a third `literature` mode (would make `literature` open PDFs for the first time and
 sits badly against its "propose and surface, never adjudicate" guardrail); a new fourth skill
@@ -190,8 +200,16 @@ comments on `in-sample` and `batch-check` explaining each. That made the documen
 **unwritable**: an annotated child inside a block mapping is refused by the frontmatter writer,
 which will not silently destroy a comment it cannot round-trip. A reader copying this example
 verbatim would have hit that refusal. The explanations now live in prose below — `in-sample`
-records whether *this* paper was drawn into the sample, and `batch-check` is the verdict on the
-whole extraction run, one of `pending` | `verified` | `failed`.
+records whether a human actually checked *this* paper's cells, and `batch-check` is the verdict
+on the whole extraction run, one of `pending` | `verified` | `failed`.
+
+*Amended again, during implementation.* `in-sample` first read "was drawn into the sample", the
+nomination meaning. It is set at **verdict** time, not draw time, so it means *a human checked
+these cells* — a draw never followed by a verdict has established nothing, and a field that
+says otherwise overstates the record. It is also monotone within a set of cells: nothing sets it
+back to `false`, so it accumulates across re-samples of the same batch. That is safe because
+`record` rewrites the whole block with `in-sample: false` on every re-extraction, so the flag
+can never outlive the cells it certified.
 
 Two fields rather than one, because they answer different questions and conflating them
 produces nonsense. `in-sample` is a fact about this paper. `batch-check` is the verdict on the
@@ -355,6 +373,22 @@ signal about the population into a tidy-looking local fix.
 
 Per-cell check records append to the same accountability log depth mode writes to, so the
 evidence is independently reviewable later without re-running the session.
+
+*Amended during implementation — two refusals this section did not anticipate.* Both come from
+the same asymmetry: `failed` is a **finding** and must land whatever else went wrong, but
+`verified` is a **claim** and may only be written for what was actually established.
+
+- **A `verified` verdict is refused when the drawn sample's cells could not all be read.** The
+  run exits 1 and writes nothing. Otherwise the durable record reads `batch-check: verified`
+  with no paper marked checked — a self-contradictory state whose only honest signal is a
+  transient exit code that no later reader ever sees.
+- **`--all` aborts before drawing or writing if membership cannot be fully determined.** An
+  unreadable artifact would otherwise be dropped from the population silently, and since the
+  draw is a deterministic function of membership, *making one file unreadable re-rolls the
+  sample* — sample-shopping through a route that looks like a routine file problem. A verdict
+  is a statement about a population, so a run that cannot determine the population has nothing
+  to say about it. The `--citekey` path needs no such guard: membership is explicit there, and
+  a missing member is reported against its own citekey.
 
 ## 9. Writeback into `positioning.md`
 

--- a/docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md
+++ b/docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md
@@ -463,8 +463,18 @@ It splits into four independently reviewable pieces:
 
 1. `defend --target cited-work` consuming extraction cells directly — the locators exist
    precisely so it can, and wiring it is what closes the loop from extraction to verification.
+   **Filed as [#141](https://github.com/davorrunje/defendable-science/issues/141).**
 2. Rendering a matrix row for a paper whose cells came from depth mode rather than extraction —
    a depth digest also produces locatable claims, and today they cannot feed the matrix.
+   **Filed as [#142](https://github.com/davorrunje/defendable-science/issues/142).**
+
+*Added during implementation — four defects the reviews surfaced, none of which this section
+anticipated:* [#143](https://github.com/davorrunje/defendable-science/issues/143) (`patch_triage`
+and YAML anchors), [#144](https://github.com/davorrunje/defendable-science/issues/144) (orphan
+`.tmp` on a failed atomic replace), [#145](https://github.com/davorrunje/defendable-science/issues/145)
+(fence-handling gaps in `core/mdtable.py` and the extraction heading probe), and
+[#146](https://github.com/davorrunje/defendable-science/issues/146) (the extraction log entry
+named from the artifact stem rather than the citekey).
 
 ## 14. Open questions
 

--- a/docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md
+++ b/docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md
@@ -328,8 +328,15 @@ Default: `§3` / `§3.2` / `§3.2.1`, `Section 3` / `Sec. 3`, `p. 7` / `pp. 7-9`
 `Eq. (4)` / `Equation 4`, `Table 2`, `Fig. 5` / `Figure 5`, `Alg. 1`, `Thm. 2` / `Theorem 2` /
 `Lemma 3` / `Def. 1`, and comma-joined combinations (`§3, Eq. (4)`).
 
-Extended or replaced via `literature.extraction.locator_patterns` in
-`.defendable-science/config.yml`.
+Extended via `literature.extraction.locator_patterns` in `.defendable-science/config.yml`.
+
+*Amended during implementation — "or replaced" was never built, and should not be.*
+`compile_locator_patterns` appends the configured patterns to the defaults; there is
+deliberately no way to drop one. Widening only ever admits a locator shape that would
+otherwise have been rejected, so it cannot cause a false negative on a locator the author
+meant; allowing removal would let a misconfiguration reject locators the author wrote, which
+is the failure with no signal. A pattern set that cannot be combined raises `ExtractionError`
+rather than silently narrowing.
 
 ### 7.4 Refusal
 

--- a/docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md
+++ b/docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md
@@ -398,6 +398,14 @@ per-branch delta and section comments survive by construction.
 - **Rows are keyed by citekey** in the first column, so re-rendering is idempotent. Cost to
   state in the skill: a hand-edited row label is overwritten on the next render. That is the
   price of the row being a projection.
+
+  *Amended during implementation — this is not what happens, and the skill must say the true
+  thing.* Row lookup is exact label equality, so a hand-edited label does not get overwritten;
+  it stops matching, and the next render adds a **second** row for the same paper. Safer than
+  the documented behaviour, since nothing the author wrote is lost, but noisier, and the remedy
+  is different: restore the label rather than re-edit it. Two further costs the section did not
+  name — the matrix is re-emitted canonically, so an author's column padding is collapsed and
+  GFM alignment specifiers (`|:---:|`) are dropped.
 - **`**This paper**` is never touched** — it is the author's own delta.
 - **Render never deletes a row.** Insert or update only; if a paper leaves the survey, the
   author removes its row by hand. Automatic deletion is the one operation here with no safe

--- a/docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md
+++ b/docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md
@@ -1,0 +1,424 @@
+# Design — `digest` extraction mode (breadth reading for a survey)
+
+**Date:** 2026-08-28
+**Author:** Davor Runje
+**Status:** Approved design; not yet implemented.
+**Scope:** [#100](https://github.com/davorrunje/defendable-science/issues/100) — Gap 2 of
+[#97](https://github.com/davorrunje/defendable-science/issues/97), restated against the
+literature registry layer that Gap 1 built.
+
+> Sits alongside the depth-first loop in [`skills/digest/SKILL.md`](../../../skills/digest/SKILL.md).
+> Builds on the registry layer specified in
+> [`2026-08-27-literature-asset-acquisition-design.md`](2026-08-27-literature-asset-acquisition-design.md)
+> and on the host-preserving markdown-table reader that landed with #94/#95.
+> Governed by the meta-spec's **agency** principle (§2.1) and the repo's failure-honesty rule.
+
+## 1. Problem
+
+`digest` is depth-first by design: probe → detect gap → teach → re-probe, per load-bearing
+point, per paper. It is the right tool for a paper whose claims you will *assert*, and it costs
+on the order of an hour or two each.
+
+A survey has a different need. The monotonicity run behind #97 resolved 73 works and proposed 40
+for inclusion. At depth-mode cost that is a semester. But the survey does not need comprehension
+of 40 papers — it needs, for each one, the cells of the concept-centric matrix that
+`literature position --level paper` has already defined. Eight specific questions, then stop.
+
+So the plugin's reading skill is unusable for the exact task its sibling skill sets up, and
+`position`'s own output already specifies the question set a breadth mode would ask.
+
+**What changed since #97 filed this.** Gap 1 built the registry layer — `load_registry`,
+`patch_asset`, `load_triage`, `patch_triage`, `Asset.files` — so extraction now has real
+interfaces to resolve PDFs and write back through. And #94/#95 replaced the markdown-table
+machinery in `exploration/backlog.py` with a host-preserving, header-driven reader, which is
+what makes writing into an author's `positioning.md` safe rather than reckless.
+
+## 2. Goals and non-goals
+
+**Goals.**
+
+1. An extraction mode driven by `positioning.md`'s own matrix columns.
+2. Mandatory per-cell locators, **enforced** — extraction refuses to record a cell without one.
+3. Batch operation over a triage-filtered set.
+4. Writeback through the registry APIs, with an explicit human-surfaced path for the
+   `patch_triage` comment refusal.
+5. A sampled comprehension check whose contract is explicitly weaker than depth mode's, and
+   which cannot be mistaken for it.
+6. The tier ladder (screen → extract → digest → reproduce) documented, so a survey author knows
+   which tool to reach for.
+
+**Non-goals.**
+
+- PDF parsing in the CLI. The agent reads PDFs natively; the CLI never needs a parser, and
+  adding one would breach the light-dependency posture (same reasoning as the acquisition
+  spec's §2).
+- Verifying a locator's *correctness*. Shape validation proves a locator is well-formed, not
+  that the claim is where it says. What catches that is `defend --target cited-work`, which is
+  why the locator is mandatory in the first place.
+- Automatic deletion of matrix rows. See §6.
+- Gap 3 (survey-shaped templates) — tracked separately as #101.
+
+## 3. Decisions
+
+Five, settled during brainstorming, each recorded here with the reasoning because each has a
+plausible alternative.
+
+### 3.1 Extraction is a second mode of `digest`, not a third `literature` mode
+
+`literature` is deliberately a graph-and-metadata capability: its entire surface is OpenAlex/S2
+plus the registry, and it never opens a PDF. Extraction is *reading a paper and producing claims
+about it*, which is `digest`'s domain, and the sampled check reuses `digest`'s probe mechanic.
+#97's own framing agrees ("filed as a `digest` mode because the reading loop is the reusable
+part").
+
+**Consequence to handle:** `digest` has no CLI group of its own today — it borrows
+`defend record`. Extraction's commands therefore land as a new `digest` group, keeping skill and
+namespace aligned:
+
+```
+defendable-science digest extract axes    [--positioning PATH]
+defendable-science digest extract record  --cells FILE|-   [--positioning PATH]
+defendable-science digest extract sample  --batch FILE|-   [--size N]
+defendable-science digest extract render  [--positioning PATH]
+```
+
+`axes` prints the question set (§6.1) so the agent knows what to extract before reading
+anything. `record` is the validating writer of §3.3. `sample` draws the deterministic sample and
+drives the check. `render` performs the `positioning.md` merge of §9.
+
+*Rejected:* a third `literature` mode (would make `literature` open PDFs for the first time and
+sits badly against its "propose and surface, never adjudicate" guardrail); a new fourth skill
+(cleanest contract separation, but adds a reading-adjacent surface to a plugin whose value
+depends on a researcher holding the whole shape in their head).
+
+### 3.2 A separate frontmatter key and a separate `progress` row
+
+`progress status literature` scans `docs/research/literature/digests/*.md` and reports each
+paper as `{digested & understood / gaps unresolved}` from its `understanding` block
+(`skills/progress/SKILL.md:140-143`). So a paper that had eight cells extracted and was never
+read would be counted as "digested & understood" — the guarantee-inflation #97 warns against,
+and a concrete harm rather than a theoretical one.
+
+Extraction writes `status.extraction`, **never** `status.understanding`, and `progress` gains a
+second, clearly-labelled row so a survey author sees "extracted 40 / digested 3" rather than one
+blended number.
+
+*Rejected:* one key with a `mode:` discriminator — the two contracts would share a field name,
+and anything reading it without knowing about `mode` silently inflates the weaker into the
+stronger.
+
+### 3.3 Validation and writing are one command
+
+A SKILL.md sentence saying "you must include a locator" enforces nothing on the agent following
+it, and #100 asks for enforcement, not documentation. So the validating command is also the
+*only* writer: there is no code path that records an unvalidated cell.
+
+This is the same move that made `_bind` the single writer of an asset spine in Gap 1 — fusing
+the check to the write so the two cannot drift apart.
+
+*Rejected:* extending `defend record` with an extraction target (maximum reuse, but that
+command's job is certifying understanding, and it would then also write a key that deliberately
+means something weaker); a separate validator the skill is told to run (the skill could write
+without validating, which returns the constraint to documented-as-expected).
+
+### 3.4 Locators are shape-validated against a configurable pattern set
+
+A non-empty-string check is satisfied by "see paper", and an agent filling 320 cells will
+discover that immediately. Shape validation catches the vague-filler failure mode cheaply.
+
+The pattern set **ships as a default and is configurable**, for the same reason
+`venue_resolvers` is: a set built around `§`, `Eq.`, `Thm.` encodes a maths-and-CS citation
+culture, and a survey of clinical trials or case law locates claims differently. A fixed set
+would be a domain assumption in a plugin that forbids them.
+
+### 3.5 The human checks the sample; selection is deterministic
+
+In depth mode the human reads and the agent probes them. In extraction the agent reads — that is
+the premise. So if the agent also checks the sample, extraction certifies nothing: it is
+self-attestation, which `digest`'s "verified, never self-attested" guardrail forbids and the
+agency principle rules out.
+
+Selection is seeded from the sorted citekey set, so the agent cannot steer it toward papers it
+found easy, **and re-running the same batch re-checks the same papers** — a freshly-random
+sample per run would let anyone re-roll until an easy draw came up, hollowing the check out.
+
+## 4. The contract, stated exactly
+
+Two modes, two claims, and the wording matters because the whole point is that they are not
+interchangeable.
+
+| Mode | Certifies |
+|---|---|
+| `depth` (today) | the reader understands this paper |
+| `extract` (new) | the agent extracted these cells, each carrying a locator; the human verified a deterministic sample of them against the sources |
+
+`skills/digest/SKILL.md` states both, and **carves the "verified, never self-attested"
+guardrail explicitly** so it reads as covering depth mode only. Extraction says something
+weaker and must say it in its own words rather than by omission.
+
+### 4.1 The tier ladder
+
+Documented in the skill so the depth/breadth choice is guided rather than invented:
+
+| tier | activity | tool |
+|---|---|---|
+| screen | abstract + venue → in/out | `literature position` triage |
+| extract | fill the matrix row | `digest` extraction mode |
+| digest | verified comprehension | `digest` depth mode |
+| reproduce | run it | experiment backend |
+
+## 5. Artifacts
+
+**One artifact per paper, two status keys.** Extraction writes to the same
+`docs/research/literature/digests/<citekey>.md` depth mode uses:
+
+```yaml
+---
+status:
+  understanding: {status: pending, unresolved: []}    # depth mode; untouched by extract
+  extraction:
+    cells: 8
+    locators: ok
+    in-sample: false                # was THIS paper drawn into the sample?
+    batch-check: pending            # pending | verified | failed — the BATCH's verdict
+  last-updated: 2026-08-28
+---
+```
+
+Two fields rather than one, because they answer different questions and conflating them
+produces nonsense. `in-sample` is a fact about this paper. `batch-check` is the verdict on the
+extraction run it belongs to — and since a failed sample is evidence about the *population*
+(§8), an unsampled paper in a failed batch must also read `failed`. A single `sampled:` field
+would have to say `failed` for a paper that was never checked, which reads as a finding about
+that paper and is exactly the kind of misleading status this design exists to avoid.
+
+The file becomes *the paper's reading record at whatever depth it has been read*. A survey
+extracts 40 papers, so 40 artifacts exist carrying cells and no prose body; three later get
+digested properly and grow an `understanding` block and a written summary. Nothing is
+duplicated, nothing is migrated, and the two claims coexist visibly because they are genuinely
+different claims about the same paper.
+
+**The cells are the durable record; the matrix row is a projection.** Each cell — axis, value,
+locator — lives in the per-paper artifact as structured content. `positioning.md`'s row is
+rendered from those, never authored independently.
+
+That does real work beyond tidiness: it gives `defend --target cited-work` something exact to
+check later without parsing a markdown table out of the author's prose, and it means a change to
+how the matrix is rendered never risks the underlying evidence.
+
+## 6. The extraction loop
+
+### 6.1 Question set
+
+The axes are `positioning.md`'s matrix header minus the first column. Two refusals:
+
+- **Unreplaced placeholders.** The template ships `| Method | <attr 1> | <attr 2> | <attr 3> |`.
+  If the header still carries `<attr N>`, the author has not chosen their comparison axes, and
+  extracting 40 papers against `<attr 1>` is worse than useless. Stop and say so.
+- **No table at all.** Same.
+
+The `**This paper**` row is a self-reference, never a paper to extract.
+
+### 6.2 Table machinery is promoted
+
+#94/#95 left `exploration/backlog.py` with a genuinely generic core — `_Document(preamble,
+header, rows, postamble)`, `_parse_document`, `_render_table`, `_splice`, `_escape`,
+`_split_cells`, `_is_separator` — all header-driven and level-agnostic. `Backlog` is
+`columns_for(level)` sitting on top.
+
+That core moves to **`core/mdtable.py`** and `backlog.py` re-imports, exactly as `core/fixity.py`
+and `core/mirror.py` were promoted in Gap 1. One markdown-table implementation in the repo, not
+two — which is what stops #94's class of bug being reintroduced somewhere new.
+
+### 6.3 PDF resolution
+
+Each paper resolves via `Asset.files[0]` to `blob_path(cache_dir, sha256)`, and the bytes are
+**verified against the recorded checksum before the agent reads them**. Nearly free, and it
+closes an obvious hole: extracting from a corrupt or truncated PDF produces confidently-wrong
+claims carrying valid-looking locators, which is precisely what the locator requirement exists
+to prevent.
+
+### 6.4 A paper with no asset
+
+Skipped, reported with the reason and its `landing_urls`, mirroring `fetch --all`'s `manual[]`
+bucket. The real run had roughly ten of fifty paywalled, so blocking the batch on them would
+make extraction unusable.
+
+**A skipped paper gets no `status.extraction` block at all.** An artifact that says nothing is
+honest; one that says "extracted: 0 cells" reads like a finding about the paper.
+
+### 6.5 `not-addressed`
+
+"The paper does not address this axis" is a legitimate and common cell value, and demanding a
+locator for it is incoherent — there is no section to point at. But making it locator-exempt
+hands the agent an obvious way out: 8 axes × 40 papers is 320 chances to write "not addressed"
+and skip the hard part.
+
+So `not-addressed` is a distinguished value requiring a **justification** in place of a locator
+— checked only for presence and non-emptiness, since no automated check can judge whether an
+absence is real — and the report **counts them per paper and in aggregate**. The count is the anti-gaming
+signal: a paper with 8/8 not-addressed is visible at a glance, and so is a run where 60% of all
+cells came back empty. That is cheaper and more honest than trying to make the checker
+adjudicate whether an absence is real, which it cannot do without reading the paper itself.
+
+## 7. Enforcement
+
+### 7.1 The cells file
+
+A JSON array, path or `-` for stdin, mirroring `defend record --points`:
+
+```json
+[
+  {"citekey": "sill1997monotonic", "axis": "guarantee type",
+   "value": "architectural — monotone by construction", "locator": "§2, Eq. (3)"},
+
+  {"citekey": "sill1997monotonic", "axis": "partial monotonicity",
+   "value": "not-addressed",
+   "justification": "scoped to fully-monotone inputs in §1; never revisited"}
+]
+```
+
+A `Cell` dataclass rather than reusing `PointRecord` — the fields genuinely differ (axis/value
+against point/source_quote/reader_answer) — but `defend/record.py`'s accountability-log
+machinery is reused as a library, so extraction lands in the same log depth mode writes to.
+
+### 7.2 Validation rules
+
+1. Every axis carries a locator matching the pattern set, **or** is `not-addressed` with a
+   justification.
+2. **Every axis in the matrix header is present for each paper.** Without this, `not-addressed`
+   is unnecessary — an agent finding an axis hard just omits the cell, and a short row looks
+   like a clean row. Completeness forces every axis to be *accounted for* and pushes the dodge
+   into `not-addressed`, which is counted and visible.
+3. No invented axes; an axis absent from the header is refused, since it would silently widen
+   the matrix.
+4. **Rejection is per paper, not per batch.** A paper with a bad cell is rejected whole, no
+   partial row is written, and the run continues. Same posture as `fetch_all`: one bad entry
+   does not abort a 40-paper sweep, and nothing half-lands.
+
+### 7.3 Locator pattern set
+
+Default: `§3` / `§3.2` / `§3.2.1`, `Section 3` / `Sec. 3`, `p. 7` / `pp. 7-9` / `page 7`,
+`Eq. (4)` / `Equation 4`, `Table 2`, `Fig. 5` / `Figure 5`, `Alg. 1`, `Thm. 2` / `Theorem 2` /
+`Lemma 3` / `Def. 1`, and comma-joined combinations (`§3, Eq. (4)`).
+
+Extended or replaced via `literature.extraction.locator_patterns` in
+`.defendable-science/config.yml`.
+
+### 7.4 Refusal
+
+Exit `0` all recorded, `1` anything rejected or incomplete, `2` left to Click (see #106/#119 —
+reusing 2 for a domain outcome collides with usage errors and makes both unreadable).
+
+Refusals name the offending cells, not just a count. "3 cells rejected" sends the reader
+hunting; `sill1997monotonic / partial monotonicity: locator "see paper" matches no known form`
+does not.
+
+### 7.5 The `patch_triage` comment refusal
+
+If the sidecar carries YAML comments, the triage writeback refuses (`registry.py`'s
+`_has_comments`), because `pyyaml` cannot round-trip them and the `rationale` fields *are* the
+PRISMA audit trail.
+
+That must not discard the extraction. Cells are already durably in the per-paper artifact, so
+the run reports `triage not updated for ⟨citekeys⟩; set ⟨fields⟩ by hand`, exits 1 because
+something genuinely did not complete, and leaves the human's annotations intact. This honours
+`patch_triage`'s docstring rather than working around it.
+
+## 8. The sampled check
+
+**Selection.** Sort the batch's citekeys, hash that list to seed the PRNG, draw `k`. Size is a
+parameter defaulting to `max(3, 10%)`.
+
+**The check.** For each cell in a sampled paper, the human is shown the axis, the recorded
+value, and the locator, and asked one thing: *does the source at that locator actually say
+this?* Not "do you understand this paper" — extraction never claimed that, and asking it would
+smuggle depth mode's guarantee back in through the UX.
+
+**A failed sample is evidence about the batch, not one paper.** If the human finds a cell that
+misrepresents its source, the honest inference is not "fix that cell" — a process that produced
+one confidently-wrong cell in a sample of three probably produced more in the other
+thirty-seven. Every artifact in the run — sampled or not — gets `batch-check: failed`, the report says so in
+those terms, and nothing downstream may treat the batch as verified until it is re-extracted or
+fully checked.
+
+Silently repairing the one caught cell would be the worst outcome available: it converts a
+signal about the population into a tidy-looking local fix.
+
+Per-cell check records append to the same accountability log depth mode writes to, so the
+evidence is independently reviewable later without re-running the session.
+
+## 9. Writeback into `positioning.md`
+
+A merge, not a rewrite, via `core/mdtable.py`. The author's taxonomy prose, PRISMA log,
+per-branch delta and section comments survive by construction.
+
+- **Rows are keyed by citekey** in the first column, so re-rendering is idempotent. Cost to
+  state in the skill: a hand-edited row label is overwritten on the next render. That is the
+  price of the row being a projection.
+- **`**This paper**` is never touched** — it is the author's own delta.
+- **Render never deletes a row.** Insert or update only; if a paper leaves the survey, the
+  author removes its row by hand. Automatic deletion is the one operation here with no safe
+  failure mode — a bug that drops rows loses the author's work silently, and #94 is a live
+  reminder of how that goes.
+
+## 10. Error handling
+
+Consistent with the rest of the capability: `RegistryError` and the `patch_triage` refusal
+surface with the citekey and the fields that needed setting; a corrupt or missing PDF is a skip
+with a reason, never a silent empty row; no tracebacks at the CLI boundary.
+
+## 11. Testing
+
+100% statement + branch coverage, hermetic. The weight goes on **negative** assertions: this
+project has been bitten four times by defects that passed a 100%-coverage suite because every
+test asserted what *should* happen.
+
+- A cell with no locator, or with `"see paper"`, cannot be recorded.
+- An omitted axis cannot produce a written row (the anti-omission guard, §7.2 rule 2).
+- An invented axis is refused.
+- Re-running the same batch selects the **same** sample — no sample-shopping.
+- Render preserves preamble, postamble, `**This paper**`, and every row it did not write; it
+  never deletes.
+- A paper with no asset gets **no** `status.extraction` block.
+- Extraction **never** writes `status.understanding` — the guarantee-inflation guard, tested
+  directly.
+- A failed sample sets `batch-check: failed` on **every** artifact in the run, including
+  unsampled ones, and does not quietly repair the caught cell.
+- The `patch_triage` comment refusal leaves the sidecar byte-identical and the cells recorded.
+
+Fixtures: a synthetic `positioning.md` with author prose around a three-axis matrix, and one
+with unreplaced `<attr N>` placeholders to pin the refusal.
+
+## 12. Implementation shape
+
+Larger than it looks — a CLI group, a promoted module, a new artifact contract, a `progress`
+change, and a human-in-the-loop step. Comparable to the acquisition work, which ran 17 tasks.
+It splits into four independently reviewable pieces:
+
+1. **Promote the table core** to `core/mdtable.py`; `backlog.py` re-imports. Pure refactor —
+   the review criterion is that `backlog` behaviour is unchanged.
+2. **Question set + cells model + validation** — matrix header parsing with its two refusals,
+   the `Cell` dataclass, the locator pattern set, the validation rules, as a pure library with
+   no writer. This does not weaken §3.3: the fusion of validation to writing is a property of
+   the CLI surface built in piece 3, which has no path to a write that bypasses this library.
+   Separating them here is what lets the rules be tested exhaustively without touching a file.
+3. **The `digest extract` CLI group** — record (validate + write, inseparably), the artifact
+   contract, the triage refusal path.
+4. **Sampling, render, and docs** — deterministic selection, the check loop, the
+   `positioning.md` merge, `skills/digest/SKILL.md`'s two contracts and the tier ladder, the
+   `progress` second row.
+
+## 13. Follow-ups to file
+
+1. `defend --target cited-work` consuming extraction cells directly — the locators exist
+   precisely so it can, and wiring it is what closes the loop from extraction to verification.
+2. Rendering a matrix row for a paper whose cells came from depth mode rather than extraction —
+   a depth digest also produces locatable claims, and today they cannot feed the matrix.
+
+## 14. Open questions
+
+None blocking. One judgement recorded for the implementer: the sample size default
+(`max(3, 10%)`) is a guess, not a derived figure. It should be a parameter from day one so a
+real survey can calibrate it, and the skill should say plainly that it is a convention rather
+than a statistical guarantee.

--- a/docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md
+++ b/docs/superpowers/specs/2026-08-28-digest-extraction-mode-design.md
@@ -179,11 +179,19 @@ status:
   extraction:
     cells: 8
     locators: ok
-    in-sample: false                # was THIS paper drawn into the sample?
-    batch-check: pending            # pending | verified | failed — the BATCH's verdict
+    in-sample: false
+    batch-check: pending
   last-updated: 2026-08-28
 ---
 ```
+
+*Amended 2026-08-28, during implementation.* This block originally carried inline `#`
+comments on `in-sample` and `batch-check` explaining each. That made the documented shape
+**unwritable**: an annotated child inside a block mapping is refused by the frontmatter writer,
+which will not silently destroy a comment it cannot round-trip. A reader copying this example
+verbatim would have hit that refusal. The explanations now live in prose below — `in-sample`
+records whether *this* paper was drawn into the sample, and `batch-check` is the verdict on the
+whole extraction run, one of `pending` | `verified` | `failed`.
 
 Two fields rather than one, because they answer different questions and conflating them
 produces nonsense. `in-sample` is a fact about this paper. `batch-check` is the verdict on the

--- a/resources/ensure-tooling.md
+++ b/resources/ensure-tooling.md
@@ -68,6 +68,11 @@ environment changes** (installing `uv`/Python is the user's call), **honest stop
   which moved the bound past `0.2.x`, together with `research-init`'s
   `defendable-science init` and the repo-validation `check` alongside it — so the
   bound already covers all of them and does not move again for them. The
+  `digest extract axes | record | sample | render` group that extraction mode
+  calls lands in that same unreleased `0.3.0` line, so it needs **no** further
+  move of the lower bound; it does mean a consumer on a published `0.2.x` will
+  not have those verbs, which is exactly what the `>=0.3.0` floor already tells
+  them. The
   package's own releases (PEP 440, `v*` tags → PyPI) proceed on their own
   cadence.
 - **rclone** (the private-mirror engine) is a separate single static binary — **not

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -204,15 +204,31 @@ defendable-science digest extract render [--citekey KEY ...] [--paper ID] [--pos
 when omitted (ADR-0039); pass them only when running from outside a paper
 directory or against a document the layout does not own.
 
+**One report shape across the four.** Every verb prints a JSON report on
+**every** outcome, refusals included, and every report carries:
+
+- `ok` — `true` exactly when the command exited 0. Never read success off any
+  other key.
+- `error` — `null`, or the one whole-run failure that stopped the command
+  (an unusable matrix, an unusable input, an unknowable batch, a refused
+  merge). Per-item failures live in each verb's own buckets (`rejected[]`,
+  `errors[]`, `triage_not_updated[]`) and are **not** duplicated here.
+
+Exit 2 is Click's, and only Click's: a usage error (an unknown option, a
+missing required one, `--paper` unresolvable) prints a usage message, not a
+report. Anything else prints one.
+
 ### 1. `axes` — get the question set, before reading anything
 
 ```
 defendable-science digest extract axes
 ```
 
-Prints `{"positioning": …, "axes": [...]}` — the matrix header minus its first
-column. Run it **first**. It refuses (exit 1) rather than letting a batch be
-read against a matrix that is not ready. The refusals, in full: **no
+Prints `{"ok": true, "positioning": …, "axes": [...], "error": null}` — the
+matrix header minus its first column. Run it **first**. It refuses (exit 1)
+rather than letting a batch be read against a matrix that is not ready; the
+refusal still prints a report, with `axes: null` — **never `[]`**, which would
+say the matrix has no axes rather than that this run could not read it. The refusals, in full: **no
 positioning document at that path**; no concept-matrix section; more than one
 section carrying that heading; no table in the section; **more than one table
 inside the section**; a missing `|---|` separator; ragged rows; unreplaced
@@ -260,7 +276,12 @@ the only writer. The rules:
    counted.
 3. An axis that is not in the header is refused — it would silently widen the
    matrix.
-4. **Rejection is per paper, not per batch.** A paper with one bad cell is
+4. **`**This paper**` is refused as a citekey.** It is the matrix's
+   self-reference row — the author's own delta, not an extracted paper. Record
+   it by hand in the positioning document. (`render` refuses it too, but by
+   then the artifact exists and refuses the *whole* batch's merge, so the
+   refusal belongs here.)
+5. **Rejection is per paper, not per batch.** A paper with one bad cell is
    rejected whole (no partial row, no artifact, no log entry) and the rest of
    the batch still lands.
 
@@ -303,6 +324,10 @@ conflate**:
 
 Report all three. "3 cells rejected" sends the reader hunting; name the paper
 and the axis.
+
+A run that could not read the matrix or parse `--cells` at all validated
+nothing, so it fills none of the three: it reports `error` with the reason,
+`axes: null`, and empty buckets. That is not a clean run.
 
 **What `record` writes to `triage.yml`**: exactly two factual fields per
 recorded paper — `extracted: <date>` and `extraction-cells: <int>`. It **never
@@ -351,6 +376,12 @@ Reading the sample report: `size` counts the papers *drawn*, `sampled[]` lists
 the ones whose cells could actually be shown, and `not_shown[]` names the
 difference. Do not diff two lists to find it, and do not report a draw as a
 check.
+
+**`verdict` is what was recorded; `verdict_requested` is what was asked for.**
+They are two keys because they come apart: a refused `verified` verdict, or one
+no member could be written, reports `verdict: null` next to
+`verdict_requested: "verified"`, with `updated: []` and the reason in `error`.
+Read the outcome off `verdict` (and `ok`), never off the request.
 
 **A failed sample is evidence about the batch, not about one paper.** A process
 that produced one confidently-wrong cell in a sample of three probably produced
@@ -422,12 +453,18 @@ cases — plus three of its own:
   re-extract against the new axes — so surface it rather than guessing;
 - two rows in the file already carrying the **same** citekey — which row is
   *the* row cannot be guessed, so merge or delete the duplicates by hand first;
-- asking to render the `**This paper**` row, which is the author's own delta.
+- asking to render the `**This paper**` row, which is the author's own delta —
+  a backstop only, since `record` refuses that citekey before an artifact for
+  it can exist.
 
 A paper whose artifact cannot be read is reported in `errors[]` and its row
 left alone — the rest of the batch still lands, because skipping it changes
 nothing on disk while refusing the whole merge would strand every other
 paper's cells.
+
+A refused merge still prints its report, with the reason in `error` and
+`rendered: []` — the document is byte-identical, so no paper was merged, and
+the report must not name the ones this run *would* have written.
 
 ### The extraction artifact
 

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -37,7 +37,8 @@ render, or roll it up as anything stronger.
 
 The two modes write **different frontmatter keys** on the same artifact
 (`status.understanding` vs `status.extraction`) precisely so nothing downstream
-can read one as the other.
+can read one as the other. The reasoning, with the rejected alternatives, is
+ADR-0040 (`../../decisions/0040-digest-extraction-mode.md`).
 
 ### The tier ladder
 

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: digest
-description: Use when you want to read an external paper with verified comprehension — an interactive probe-teach-reprobe loop that builds and checks your understanding of a paper's problem, method, key result, assumptions, and limitations, then emits a grounded digest. Also offered as a deeper remediation path when defend's cited-work probe finds you can't explain what a citation actually says.
+description: Use when you want to read an external paper with verified comprehension — an interactive probe-teach-reprobe loop that builds and checks your understanding of a paper's problem, method, key result, assumptions, and limitations, then emits a grounded digest. Also offered as a deeper remediation path when defend's cited-work probe finds you can't explain what a citation actually says. Has a second, breadth mode — extraction — for survey-scale reading: it fills the concept matrix's cells from many papers, each cell carrying a source locator, and certifies something deliberately weaker than comprehension.
 ---
 
 The `digest` skill is the **inbound** counterpart to `defend`: it verifies the
@@ -19,6 +19,42 @@ grounded in a mirrored PDF) and shares its accountability-log mechanism with
 `defend` (ADR-0033) — the same evidentiary `points` record, not a bare
 pass/fail.
 
+## Two modes, two claims
+
+`digest` has a **depth** mode and an **extraction** mode. They are not
+interchangeable, and the whole reason both exist is that they certify different
+things:
+
+| Mode | Certifies |
+|---|---|
+| `depth` (the probe → teach → re-probe loop below) | the reader understands this paper |
+| `extract` (breadth reading for a survey) | the agent extracted these cells, each carrying a locator; the human verified a deterministic sample of them against the sources |
+
+Extraction does **not** certify comprehension — not the agent's, and certainly
+not the reader's. It certifies that cells were recorded with locators, and that
+a human spot-checked a sample of them against the actual papers. Never state,
+render, or roll it up as anything stronger.
+
+The two modes write **different frontmatter keys** on the same artifact
+(`status.understanding` vs `status.extraction`) precisely so nothing downstream
+can read one as the other.
+
+### The tier ladder
+
+Which tool to reach for, cheapest first. A survey does not need the bottom of
+this ladder for every paper — it needs the right rung per paper.
+
+| tier | activity | tool |
+|---|---|---|
+| screen | abstract + venue → in/out | `literature position` triage |
+| extract | fill the matrix row | `digest` extraction mode |
+| digest | verified comprehension | `digest` depth mode |
+| reproduce | run it | experiment backend |
+
+Depth mode costs an hour or two per paper; forty papers at that cost is a
+semester. Extraction exists so a survey can fill its comparison matrix without
+either paying that or pretending it did.
+
 ## When to use
 
 - **Self-invoked.** You've picked a paper to read — off a `scout`-produced
@@ -29,12 +65,16 @@ pass/fail.
   explain what the source says, or your citation misrepresents/overstates it.
   `defend` **offers** to hand off into a full `digest` session on that paper —
   deeper remediation than teaching the one sentence inline.
+- **Extraction mode**, when you have a screened set of papers and a concept
+  matrix waiting for rows — a survey, a related-work section, a positioning
+  document. You want each paper's cells, located, not each paper understood.
+  See *Extraction mode*, below.
 
 Do **not** use `digest` to grade the paper's own claims, or to decide whether
 it's novel/worth citing — that's `literature`'s `position` mode and the
 human's call (see Guardrails).
 
-## How it works
+## How it works — depth mode
 
 The core is the same retrieval-practice loop as `defend`, run per load-bearing
 point until it holds or you elect to stop and record the gap.
@@ -137,8 +177,286 @@ source paper, named by citekey so it joins trivially with
 **Triage update.** On completion, update the paper's `triage.yml` row —
 `notes` and a `seeded` link back to the digest, `disposition` advanced if
 warranted. This is a direct edit to the YAML (there is no CLI for
-`triage.yml` today; `literature`'s CLI only exposes the graph primitives),
-consistent with current practice.
+`triage.yml` today for depth mode; `literature`'s CLI only exposes the graph
+primitives), consistent with current practice. Extraction mode is the one
+exception: `digest extract record` writes `extracted` and `extraction-cells`
+itself — and only those, never `disposition`.
+
+## Extraction mode
+
+Breadth reading, driven by the concept matrix `literature position --level
+paper` already wrote. The matrix's own column headers are the question set:
+read each paper against exactly those axes, then stop. No probing, no teaching,
+no comprehension claim.
+
+All four commands live under one CLI group (bootstrap first via
+[`../../resources/ensure-tooling.md`](../../resources/ensure-tooling.md)):
+
+```
+defendable-science digest extract axes   [--paper ID] [--positioning PATH]
+defendable-science digest extract record --cells FILE|-  [--paper ID] [--positioning PATH] [--log-dir PATH]
+defendable-science digest extract sample (--citekey KEY ...| --all) [--size N] [--verdict verified|failed] [--log-dir PATH]
+defendable-science digest extract render [--citekey KEY ...] [--paper ID] [--positioning PATH]
+```
+
+`--paper` and `--positioning` are inferred from the recorded layout and the cwd
+when omitted (ADR-0039); pass them only when running from outside a paper
+directory or against a document the layout does not own.
+
+### 1. `axes` — get the question set, before reading anything
+
+```
+defendable-science digest extract axes
+```
+
+Prints `{"positioning": …, "axes": [...]}` — the matrix header minus its first
+column. Run it **first**. It refuses (exit 1) rather than letting a batch be
+read against a matrix that is not ready: no concept-matrix section, more than
+one section with that heading, no table in the section, a missing `|---|`
+separator, ragged rows, unreplaced `<attr N>` placeholders, an unnamed column,
+no axes beyond the row label, or two columns sharing a name. Every refusal
+names the file and the repair. Fix the matrix with the human; do not work
+around it.
+
+The `**This paper**` row is the author's own delta, never a paper to extract.
+
+### 2. Read, then `record` — validation and writing are one action
+
+Resolve each paper's PDF through the `literature` registry exactly as depth
+mode's step 1 does (`fetch` / `confirm`), so the bytes you read are the
+checksummed mirrored ones. A paper with no obtainable PDF is **skipped and
+reported** — it gets no `status.extraction` block at all, because an artifact
+saying "extracted: 0 cells" reads like a finding about the paper.
+
+Cells go in as a JSON array (a file path, or `-` for stdin):
+
+```json
+[
+  {"citekey": "sill1997monotonic", "axis": "guarantee type",
+   "value": "architectural — monotone by construction", "locator": "§2, Eq. (3)"},
+
+  {"citekey": "sill1997monotonic", "axis": "partial monotonicity",
+   "value": "not-addressed",
+   "justification": "scoped to fully-monotone inputs in §1; never revisited"}
+]
+```
+
+```
+defendable-science digest extract record --cells cells.json
+```
+
+There is **no way to write a cell without validating it** — the validator is
+the only writer. The rules:
+
+1. Every cell carries a `locator` whose *shape* matches the configured pattern
+   set, **or** has `value: "not-addressed"` with a non-empty `justification`.
+   Shape validation proves the locator is well-formed, not that the claim is
+   where it says — that is `defend --target cited-work`'s job, which is the
+   whole reason the locator is mandatory.
+2. **Every axis in the header must be present for each paper.** Omission is not
+   an option; an axis you cannot fill goes to `not-addressed`, where it is
+   counted.
+3. An axis that is not in the header is refused — it would silently widen the
+   matrix.
+4. **Rejection is per paper, not per batch.** A paper with one bad cell is
+   rejected whole (no partial row, no artifact, no log entry) and the rest of
+   the batch still lands.
+
+Default locator shapes: `§3` / `§3.2.1`, `Section 3` / `Sec. 3`, `p. 7` /
+`pp. 7-9`, `Eq. (4)` / `Equation 4`, `Table 2`, `Fig. 5`, `Alg. 1`, `Thm. 2` /
+`Lemma 3` / `Def. 1`, and comma-joined combinations. Extend or replace them
+under `literature.extraction.locator_patterns` in
+`.defendable-science/config.yml` — a set built around `§` and `Eq.` encodes one
+citation culture, and a survey of trials or case law locates claims
+differently.
+
+**`not-addressed` and the anti-gaming count.** "The paper does not address this
+axis" is a legitimate, common cell value, and demanding a locator for it is
+incoherent — there is no section to point at. So it takes a justification
+instead, checked only for presence: no automated check can judge whether an
+absence is real. What keeps it honest is that the report **counts them, per
+paper and in aggregate** (`recorded[].not_addressed` and the top-level
+`not_addressed`). A paper with 8/8 not-addressed, or a run where 60% of all
+cells came back empty, is visible at a glance. Surface those counts to the
+human; do not bury them.
+
+**Reading the report.** Exit 0 only when everything landed. Exit 1 for anything
+else, and the report has **three separate buckets that a reader must not
+conflate**:
+
+- `rejected[]` — cells that failed validation. Nothing was written for that
+  paper. Fix the cells and re-run.
+- `errors[]` — papers whose artifact write failed part-way through the batch.
+  Disjoint from `recorded[]`: `recorded` names what landed, `errors` names what
+  did not. The batch is not aborted, so both lists can be non-empty in one run.
+- `triage_not_updated[]` — the cells landed, but the paper's `triage.yml` row
+  did not. Each entry carries a `kind`:
+  - `"refused"` — the sidecar has YAML comments, and the triage writer will not
+    destroy PRISMA rationales it cannot round-trip. **The human edits the
+    sidecar by hand**; the message names the fields.
+  - `"failed"` — the write itself did not happen (an OS-level failure). Repair
+    and re-run.
+
+Report all three. "3 cells rejected" sends the reader hunting; name the paper
+and the axis.
+
+**What `record` writes to `triage.yml`**: exactly two factual fields per
+recorded paper — `extracted: <date>` and `extraction-cells: <int>`. It **never
+writes `disposition`**. The disposition state machine is the human's decision;
+a machine advancing it is precisely the agency violation this plugin exists to
+prevent.
+
+### 3. `sample` — the human checks; the agent never checks its own work
+
+In depth mode the human reads and the agent probes them. In extraction the
+agent reads. So if the agent also checked the sample, extraction would certify
+**nothing** — it would be self-attestation, which this skill's guardrail
+forbids and the agency principle rules out. The human checks the sample. That
+is the only thing standing behind extraction's claim.
+
+Two invocations, deliberately.
+
+```
+defendable-science digest extract sample --all              # draw
+defendable-science digest extract sample --all --verdict verified   # record the answer
+```
+
+The batch is either explicit (`--citekey KEY`, repeatable) or discovered
+(`--all` — every digest artifact carrying a `status.extraction` block). Exactly
+one of the two is required.
+
+**The draw writes nothing.** It reports, for each drawn paper, every cell's
+axis, value and locator — which is exactly what the human is shown. Ask them
+one question, per cell: *does the source at that locator actually say this?*
+Not "do you understand this paper": extraction never claimed that, and asking
+it would smuggle depth mode's guarantee back in through the conversation.
+
+**Selection is deterministic**, seeded from the sorted citekey set. The same
+batch draws the same papers, in every process, forever — so the agent cannot
+steer the draw toward papers it found easy, and nobody can re-roll until an
+easy sample comes up. Size defaults to `max(3, 10%)` of the batch and is
+adjustable with `--size`. That default is a **convention, not a statistical
+guarantee**; say so if anyone treats it as one.
+
+Because both the draw and the batch are deterministic, the verdict call
+re-draws: **give it the same members and the same `--size`**. A different
+membership set or size is a different batch and marks a different set of papers
+as checked.
+
+Reading the sample report: `size` counts the papers *drawn*, `sampled[]` lists
+the ones whose cells could actually be shown, and `not_shown[]` names the
+difference. Do not diff two lists to find it, and do not report a draw as a
+check.
+
+**A failed sample is evidence about the batch, not about one paper.** A process
+that produced one confidently-wrong cell in a sample of three probably produced
+more in the other thirty-seven. So `--verdict failed` writes `batch-check:
+failed` on **every** member, sampled or not, and touches no cell. Do not
+silently repair the caught cell: that converts a signal about the population
+into a tidy-looking local fix. Nothing downstream may treat the batch as
+verified until it is re-extracted or checked in full.
+
+Two refusals, both from the same asymmetry — `failed` is a **finding** and must
+land whatever else went wrong, while `verified` is a **claim** and may only be
+written for what was actually established:
+
+- **`--verdict verified` is refused outright** (nothing written, exit 1) if any
+  drawn paper's cells could not be read. The human cannot have verified what
+  they were never shown. Repair and re-run, or record `failed`.
+- **`--all` aborts before drawing** if any artifact under the digests directory
+  cannot be read. Membership would be unknowable, and since the draw is a
+  function of membership, dropping an unreadable member *re-rolls the sample* —
+  sample-shopping dressed as a routine file problem. `--citekey` needs no such
+  guard and deliberately behaves differently: membership is explicit there, so
+  an unreadable member is reported against its own citekey and the run
+  continues.
+
+### 4. `render` — project the cells into the matrix
+
+```
+defendable-science digest extract render
+```
+
+A **merge, not a rewrite**, into the concept matrix. The author's taxonomy
+prose, PRISMA log, per-branch delta and section comments survive by
+construction — only the table's own lines are re-emitted. Rows are keyed by
+citekey in the matrix's first column, so re-rendering is idempotent.
+
+- **Render never deletes a row.** Insert or update only. A row this run has no
+  cells for is left exactly as it is; a paper leaving the survey is removed by
+  hand. Automatic deletion is the one operation here with no safe failure mode.
+- **`**This paper**` is never touched** — it is the author's own delta. Asking
+  to write it is refused, not silently skipped.
+- `not-addressed` renders as `*not addressed*`, never as an empty cell: an
+  empty cell reads as *not yet extracted*, which is a different claim.
+
+**Three costs to state plainly before the first render.** They are real, and
+the last two are irreversible-by-hand tidying:
+
+1. **A hand-edited row label is not overwritten — it is orphaned.** Row lookup
+   is exact label equality, so an edited label stops matching and the next
+   render adds a **second** row for that paper. Nothing you wrote is lost, but
+   the matrix now has a duplicate. The remedy is to **restore the label**, not
+   to re-edit it. (A citekey that ends up on two rows is a refusal on the run
+   after that: which row is *the* row cannot be guessed.)
+2. **The matrix is re-emitted canonically**, so hand-aligned column padding is
+   collapsed.
+3. **GFM alignment specifiers (`|:---:|`) are dropped** from the separator row.
+
+Refusals leave the file byte-identical rather than writing at a guess: two
+sections carrying the concept-matrix heading, more than one table inside that
+section, or a header with a duplicate column name (two columns of one name
+collapse into a single cell, which would destroy the row labels).
+
+A paper whose artifact cannot be read is reported in `errors[]` and its row
+left alone — the rest of the batch still lands, because skipping it changes
+nothing on disk while refusing the whole merge would strand every other
+paper's cells.
+
+### The extraction artifact
+
+Same file depth mode uses, one per paper (for illustration: `docs/research/literature/digests/<citekey>.md`),
+with a **second, separate** status key:
+
+```yaml
+---
+status:
+  understanding: {status: pending, unresolved: []}    # depth mode; untouched by extract
+  extraction:
+    cells: 8
+    locators: ok
+    in-sample: false
+    batch-check: pending
+  last-updated: 2026-08-28
+---
+```
+
+Do not put YAML comments *inside* the `extraction` block — an annotated child
+of a block mapping is refused by the frontmatter writer rather than silently
+destroyed.
+
+- `cells` — how many cells were recorded for this paper.
+- `locators` — `ok`; a cell without one cannot be recorded.
+- `in-sample` — **a human checked this paper's cells.** Not "was drawn": a draw
+  never followed by a verdict has established nothing, so only a `--verdict`
+  run sets it true. (It is monotone within a set of cells — nothing sets it
+  back to false, so it accumulates across re-samples. That is safe because
+  `record` rewrites the whole block with `in-sample: false` on every
+  re-extraction, so the flag can never outlive the cells it certified.)
+- `batch-check` — `pending` | `verified` | `failed`, the verdict on the *run*
+  this paper belongs to. Separate from `in-sample` because they answer
+  different questions: one field would have to read `failed` for a paper nobody
+  checked, which parses as a finding about that paper.
+
+The body carries the cells themselves in a delimited, generated block — that is
+the durable record. **The matrix row is a projection of it**, never authored
+independently, which is what lets `defend --target cited-work` check a cell
+later without parsing a table out of the author's prose.
+
+The file is the paper's reading record *at whatever depth it has been read*. A
+survey extracts forty papers; three later get digested properly and grow an
+`understanding` block and a written body. Nothing is migrated, and the two
+claims coexist visibly because they are genuinely different claims.
 
 ## Composition
 
@@ -151,7 +469,12 @@ consistent with current practice.
 - **`progress`** surfaces digested-vs-unresolved counts from
   digest artifacts (for illustration: `docs/research/literature/digests/*.md`) frontmatter as an independent
   "literature reading" view (`../progress/SKILL.md`), alongside — not folded
-  into — the hypothesis/paper/thesis roll-ups.
+  into — the hypothesis/paper/thesis roll-ups. It reports extraction as a
+  **second, separate row** (`extracted N / digested M`) — never summed with the
+  digested count, because the two mean different things.
+- **`literature position --level paper`** owns the concept matrix extraction
+  fills. Extraction reads its header as the question set and renders rows back
+  into it; it never invents an axis.
 
 ## Mentor persona
 
@@ -174,9 +497,22 @@ direction.
 - **Teach the paper freely, source-grounded.** Its content is established
   external knowledge (unlike a novel claim under `defend`) — explain and
   quote it directly, point at the exact section/equation.
-- **Verified, never self-attested.** `understanding.status: ok` only when the
-  reader has demonstrated each load-bearing point against the probe — no
-  "I've got it" shortcut (anti-Goodhart, same as `defend`).
+- **Verified, never self-attested — depth mode.** `understanding.status: ok`
+  only when the reader has demonstrated each load-bearing point against the
+  probe — no "I've got it" shortcut (anti-Goodhart, same as `defend`). This
+  guardrail is about *comprehension*, and it covers depth mode only, because
+  depth mode is the only mode that claims comprehension.
+- **Extraction claims less, and must say so in its own words.** Extraction
+  certifies that cells were recorded with locators and that a human checked a
+  deterministic sample of them against the sources. It does not certify that
+  the agent understood any paper, that the unsampled cells are right, or that a
+  locator points where it says. Never describe an extracted paper as read,
+  digested, or understood; never write `status.understanding` from extraction;
+  never let the two counts be summed.
+- **The human checks the sample, never the agent.** The agent did the
+  extracting, so an agent-checked sample certifies nothing. If the human is not
+  available to check, the batch stays `batch-check: pending` — which is honest
+  — rather than being marked verified.
 - **Propose/surface, never adjudicate novelty or inclusion.** Whether a paper
   is worth citing, novel, or in-scope stays with `literature position` and the
   human's sign-off. `digest` feeds that judgment; it doesn't make it.

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -212,11 +212,12 @@ defendable-science digest extract axes
 
 Prints `{"positioning": …, "axes": [...]}` — the matrix header minus its first
 column. Run it **first**. It refuses (exit 1) rather than letting a batch be
-read against a matrix that is not ready. The refusals, in full: no
-concept-matrix section; more than one section carrying that heading; no table
-in the section; **more than one table inside the section**; a missing `|---|`
-separator; ragged rows; unreplaced `<attr N>` placeholders; an unnamed column;
-no axes beyond the row label; two columns sharing a name. Every refusal names
+read against a matrix that is not ready. The refusals, in full: **no
+positioning document at that path**; no concept-matrix section; more than one
+section carrying that heading; no table in the section; **more than one table
+inside the section**; a missing `|---|` separator; ragged rows; unreplaced
+`<attr N>` placeholders; an unnamed column; no axes beyond the row label; two
+columns sharing a name. Every refusal names
 the file and the repair. Fix the matrix with the human; do not work around it.
 
 The `**This paper**` row is the author's own delta, never a paper to extract.
@@ -407,23 +408,21 @@ the last two are irreversible-by-hand tidying:
    collapsed.
 3. **GFM alignment specifiers (`|:---:|`) are dropped** from the separator row.
 
-Four refusals leave the file **byte-identical** rather than writing at a guess:
+Refusals leave the file **byte-identical** rather than writing at a guess.
+`render` reads the matrix the same way `axes` does, so it performs **every
+refusal in the `axes` list above** — including a missing document, unreplaced
+`<attr N>` placeholders, a duplicate column name, and both ambiguous-matrix
+cases — plus three of its own:
 
-- two sections carrying the concept-matrix heading;
-- more than one table inside that section;
-- a header with a duplicate column name — two columns of one name collapse into
-  a single cell, which would destroy the row labels;
 - **a recorded cell naming an axis the matrix no longer has.** This is the one
   you will actually hit: rename or delete a column between `record` and
   `render` and the whole merge refuses, because writing the cell would need a
   column that does not exist and dropping it would lose a recorded cell
   silently. The remedy is the human's call — restore the column name, or
-  re-extract against the new axes — so surface it rather than guessing.
-
-Two further refusals, on the same byte-identical terms: asking to render the
-`**This paper**` row (the author's own delta), and two rows in the file already
-carrying the **same** citekey — which row is *the* row cannot be guessed, so
-merge or delete the duplicates by hand first.
+  re-extract against the new axes — so surface it rather than guessing;
+- two rows in the file already carrying the **same** citekey — which row is
+  *the* row cannot be guessed, so merge or delete the duplicates by hand first;
+- asking to render the `**This paper**` row, which is the author's own delta.
 
 A paper whose artifact cannot be read is reported in `errors[]` and its row
 left alone — the rest of the batch still lands, because skipping it changes

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -204,8 +204,8 @@ defendable-science digest extract render [--citekey KEY ...] [--paper ID] [--pos
 when omitted (ADR-0039); pass them only when running from outside a paper
 directory or against a document the layout does not own.
 
-**One report shape across the four.** Every verb prints a JSON report on
-**every** outcome, refusals included, and every report carries:
+**One report shape across the four.** Once a verb starts, it prints a JSON
+report on **every** outcome, refusals included, and every report carries:
 
 - `ok` — `true` exactly when the command exited 0. Never read success off any
   other key.
@@ -214,9 +214,13 @@ directory or against a document the layout does not own.
   merge). Per-item failures live in each verb's own buckets (`rejected[]`,
   `errors[]`, `triage_not_updated[]`) and are **not** duplicated here.
 
-Exit 2 is Click's, and only Click's: a usage error (an unknown option, a
-missing required one, `--paper` unresolvable) prints a usage message, not a
-report. Anything else prints one.
+Some failures happen **before** a verb starts, and print only a diagnostic
+line — so parse defensively rather than assuming JSON on every non-zero exit.
+An unknown option or a missing required one is Click's usage error, exit 2.
+Running from outside any paper without `--paper` also exits 2, naming the
+option to pass. And a malformed `.defendable-science/config.yml` — an invalid
+`layout:` block, or a locator-pattern set that cannot be combined — fails the
+shared setup every command group uses, before this group's code runs at all.
 
 ### 1. `axes` — get the question set, before reading anything
 

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -212,12 +212,12 @@ defendable-science digest extract axes
 
 Prints `{"positioning": …, "axes": [...]}` — the matrix header minus its first
 column. Run it **first**. It refuses (exit 1) rather than letting a batch be
-read against a matrix that is not ready: no concept-matrix section, more than
-one section with that heading, no table in the section, a missing `|---|`
-separator, ragged rows, unreplaced `<attr N>` placeholders, an unnamed column,
-no axes beyond the row label, or two columns sharing a name. Every refusal
-names the file and the repair. Fix the matrix with the human; do not work
-around it.
+read against a matrix that is not ready. The refusals, in full: no
+concept-matrix section; more than one section carrying that heading; no table
+in the section; **more than one table inside the section**; a missing `|---|`
+separator; ragged rows; unreplaced `<attr N>` placeholders; an unnamed column;
+no axes beyond the row label; two columns sharing a name. Every refusal names
+the file and the repair. Fix the matrix with the human; do not work around it.
 
 The `**This paper**` row is the author's own delta, never a paper to extract.
 
@@ -265,11 +265,13 @@ the only writer. The rules:
 
 Default locator shapes: `§3` / `§3.2.1`, `Section 3` / `Sec. 3`, `p. 7` /
 `pp. 7-9`, `Eq. (4)` / `Equation 4`, `Table 2`, `Fig. 5`, `Alg. 1`, `Thm. 2` /
-`Lemma 3` / `Def. 1`, and comma-joined combinations. Extend or replace them
-under `literature.extraction.locator_patterns` in
-`.defendable-science/config.yml` — a set built around `§` and `Eq.` encodes one
-citation culture, and a survey of trials or case law locates claims
-differently.
+`Lemma 3` / `Def. 1`, and comma-joined combinations. **Extend** them under
+`literature.extraction.locator_patterns` in `.defendable-science/config.yml` —
+a set built around `§` and `Eq.` encodes one citation culture, and a survey of
+trials or case law locates claims differently. Configured patterns are
+**appended to the defaults, never replacing them**: there is no way to drop
+`§`/`Eq.`/`Thm.` from the accepted set. The cost of that is only extra accepted
+shapes, never a rejected locator the author meant.
 
 **`not-addressed` and the anti-gaming count.** "The paper does not address this
 axis" is a legitimate, common cell value, and demanding a locator for it is
@@ -397,17 +399,31 @@ the last two are irreversible-by-hand tidying:
 1. **A hand-edited row label is not overwritten — it is orphaned.** Row lookup
    is exact label equality, so an edited label stops matching and the next
    render adds a **second** row for that paper. Nothing you wrote is lost, but
-   the matrix now has a duplicate. The remedy is to **restore the label**, not
-   to re-edit it. (A citekey that ends up on two rows is a refusal on the run
-   after that: which row is *the* row cannot be guessed.)
+   the matrix now has two rows about one paper. The remedy is to **restore the
+   label**, not to re-edit it. **Nothing detects this for you**: the two rows
+   carry different labels, so no later run refuses, warns, or reconciles them.
+   The duplicate simply stays until a human notices it.
 2. **The matrix is re-emitted canonically**, so hand-aligned column padding is
    collapsed.
 3. **GFM alignment specifiers (`|:---:|`) are dropped** from the separator row.
 
-Refusals leave the file byte-identical rather than writing at a guess: two
-sections carrying the concept-matrix heading, more than one table inside that
-section, or a header with a duplicate column name (two columns of one name
-collapse into a single cell, which would destroy the row labels).
+Four refusals leave the file **byte-identical** rather than writing at a guess:
+
+- two sections carrying the concept-matrix heading;
+- more than one table inside that section;
+- a header with a duplicate column name — two columns of one name collapse into
+  a single cell, which would destroy the row labels;
+- **a recorded cell naming an axis the matrix no longer has.** This is the one
+  you will actually hit: rename or delete a column between `record` and
+  `render` and the whole merge refuses, because writing the cell would need a
+  column that does not exist and dropping it would lose a recorded cell
+  silently. The remedy is the human's call — restore the column name, or
+  re-extract against the new axes — so surface it rather than guessing.
+
+Two further refusals, on the same byte-identical terms: asking to render the
+`**This paper**` row (the author's own delta), and two rows in the file already
+carrying the **same** citekey — which row is *the* row cannot be guessed, so
+merge or delete the duplicates by hand first.
 
 A paper whose artifact cannot be read is reported in `errors[]` and its row
 left alone — the rest of the batch still lands, because skipping it changes

--- a/skills/literature/SKILL.md
+++ b/skills/literature/SKILL.md
@@ -110,6 +110,34 @@ Snowball steps use the same `defendable-science literature` commands (`resolve` 
    branch + current SOTA + the most-likely-cited-against + a simplest floor.
    Match splits / tuning budget / compute.
 
+**The matrix header is a machine-read question set.** At `--level paper`,
+`digest`'s extraction mode (`../digest/SKILL.md`) reads the `## Concept matrix`
+header as the literal list of questions to ask of every surveyed paper — the
+first column labels the row, every other column is an axis — and renders rows
+back into that table. So the header has hard shape rules, and `digest extract`
+**refuses rather than guessing** when they are broken. Get them right when you
+write the matrix, and preserve them when you edit it:
+
+- **One section named `Concept matrix`, holding exactly one table.** Two
+  sections with that heading, or a second table inside the section, and *which
+  table is the matrix* has no answer.
+- **No duplicate column names**, the row-label column included. Two columns of
+  one name collapse into a single cell, which would destroy the row labels.
+- **No unnamed columns, and no unreplaced `<attr N>` placeholders.** Extracting
+  forty papers against `<attr 1>` is worse than useless — choose the attributes
+  your delta turns on first.
+- **The header is the whole question set.** An axis absent from it cannot be
+  recorded, and every axis in it must be accounted for per paper (a paper that
+  says nothing on an axis gets an explicit `not-addressed` with a
+  justification, never an omission).
+- **`**This paper**` is your own delta** — extraction never reads or writes
+  that row.
+
+Rows are keyed by citekey in the first column and matched on exact equality, so
+rename a row label and the next render adds a *second* row for that paper
+rather than overwriting yours. Extraction never deletes a row: a paper that
+leaves the survey, you remove by hand.
+
 **Level tuning.** `hypothesis` → a fast **adversarial precedent rapid-review**:
 "would a reviewer say this is already known?" → verdict + the 1–3 papers that
 would reject it + the surviving delta; feeds `strategy.md`. `paper` → full

--- a/skills/progress/SKILL.md
+++ b/skills/progress/SKILL.md
@@ -33,8 +33,9 @@ lifecycle §5 (`../../docs/design/01-lifecycle.md`).
 
 Do **not** use progress to decide a verdict, rank artifacts by "productivity," or
 compute a completion percentage — those are firewall/anti-Goodhart violations
-(see Guardrails). Status frontmatter is *written* by the resolve skills and by
-`defend` (the `understanding` field); progress only *reads* it.
+(see Guardrails). Status frontmatter is *written* by the resolve skills, by
+`defend` (the `understanding` field) and by `digest` extraction mode (the
+`extraction` field); progress only *reads* it.
 
 ## Verbs
 
@@ -138,12 +139,30 @@ Output shape everywhere: `{covered / total by state}` + `{explicit blockers}` +
 
 A fourth roll-up, independent of the hypothesis/paper/thesis hierarchy above
 (`status literature`): scan digest artifacts (for illustration: `docs/research/literature/digests/*.md`)
-frontmatter directly — the `understanding` block the `digest` skill writes via
-`defend record --target paper-comprehension` (ADR-0033) — and report, per
-digested paper, `{digested & understood / gaps unresolved}`, joined against
-`triage.yml` by citekey for context (role, disposition). Same anti-Goodhart
-posture as everywhere else in this skill: coverage + named gaps, never a count
-of "papers read" as a productivity signal.
+frontmatter directly and report **two rows**, joined against `triage.yml` by
+citekey for context (role, disposition).
+
+| Row | Read from | Reports |
+|---|---|---|
+| digested | `status.understanding` — written by `digest` depth mode via `defend record --target paper-comprehension` (ADR-0033) | per paper, `{digested & understood / gaps unresolved}` |
+| extracted | `status.extraction` — written by `digest` extraction mode | per paper, `{cells N / in-sample yes\|no / batch-check pending\|verified\|failed}` |
+
+**The two rows are never summed, averaged, or merged**, and neither is the
+other's subset. They certify different things: `understanding` means a human
+demonstrated comprehension of the paper; `extraction` means cells were recorded
+with locators and a human checked a deterministic sample of them. A survey
+author must see `extracted 40 / digested 3`, not one blended number — folding
+them together is guarantee inflation, and it would report a paper nobody read
+as read. A paper may legitimately carry both blocks, one, or neither.
+
+Report a batch's `batch-check` honestly: `pending` is *unchecked*, not passing,
+and `failed` applies to every paper in that extraction run, sampled or not —
+it is a finding about the batch, not about the individual paper. A paper with
+no `status.extraction` block was never extracted; leave it out of the extracted
+row rather than counting it as zero cells.
+
+Same anti-Goodhart posture as everywhere else in this skill: coverage + named
+gaps, never a count of "papers read" as a productivity signal.
 
 ## Anti-Goodhart
 


### PR DESCRIPTION
## What

Adds **extraction mode** to `digest`: a survey-scale reader that fills a concept matrix from many papers, each cell carrying a source locator, instead of certifying deep comprehension of one paper. Four new verbs — `digest extract axes|record|sample|render` — plus the substrate they needed.

The point of the feature is an honesty distinction, not a throughput one. Extraction certifies something strictly **weaker** than depth mode: cells were extracted, each carries a locator, and a human verified a deterministic sample of them against the real sources. Depth mode's "verified, never self-attested" guardrail is now explicitly carved to depth mode, and `progress` reports the two as separate rows that are never summed. A paper with eight extracted cells is not a paper that was read.

## Details

- **The sample is deterministic and the human draws it, not the agent.** Seeded with `sha256` over the sorted membership set, so the same batch always draws the same papers — a fresh random draw would let anyone re-roll until an easy sample came up. Pinned by a test that spawns two interpreters under different `PYTHONHASHSEED` values; a same-process double-draw would not catch a `hash()`-seeded implementation.
- **A failed sample condemns the batch, not the paper.** Every artifact in the run gets `batch-check: failed`, including unsampled ones, and there is deliberately no route to repair the one caught cell — that would convert a signal about the population into a tidy-looking local fix.
- **Two refusals that fell out of the above.** A `verified` verdict is refused when a drawn paper's cells could not be read (a *finding* needs no evidence a *claim* does). `--all` aborts before drawing if membership cannot be determined — since the draw is a function of membership, an unreadable file would otherwise silently re-roll the sample.
- **`render` never deletes a row**, never touches `**This paper**`, and refuses rather than guesses: two sections with the same heading, more than one table in the matrix section, a duplicate column name, or a cell naming an axis the matrix no longer has. It is pure — it returns text and writes nothing — so every refusal leaves the author's file byte-identical by construction.
- **`core/mdtable.py` is now fence-aware.** It previously scanned every line containing `|`, so a fenced code block illustrating a table could be selected as the real one and spliced over. That also fixes `backlog.md`/`papers.md`, which had the same exposure (#94's failure class, reached through a different door).
- **The triage writeback never advances `disposition`.** It writes `extracted` and `extraction-cells` only. Advancing the human's decision state machine is the agency violation the plugin exists to prevent.
- **`patch_triage` gained a third refusal.** This PR is its first production caller, which made a latent defect reachable: two top-level rows sharing a YAML mapping anchor are one object, so patching one wrote extraction provenance onto the others — fabricated audit-trail entries at exit 0. Now refused, with an over-correction guard so two independently-written rows with identical content still patch normally.
- Two substrates promoted for reuse: `core/mdtable.py` (from `exploration/backlog.py`) and `core/frontmatter.py` (from `defend/record.py`). Both original callers verified against their pre-branch behaviour; every change is in the safe direction.
- Rationale recorded in **ADR-0040**; the design spec carries `*Amended during implementation*` blocks wherever the shipped behaviour diverged from the original design.

**Deliberately not changed:** the plugin's package pin stays `>=0.3.0,<0.4.0` and `plugin.json` is not bumped — the new verbs ship in the same unreleased `0.3.0`, so the floor does not move (ADR-0026).

**Follow-ups filed rather than fixed here:** #141, #142 (features the spec anticipated), #143, #144, #145, #146 (defects the reviews surfaced), #147 (`check` cannot yet validate the `status.extraction` contract `progress` now reads).

1302 tests passing at 100% statement+branch coverage.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
