### PR TITLE
docs(decisions): record the cache_dir containment rule (closes #123)

### DIFF
--- a/decisions/0031-config-driven-cache-dir.md
+++ b/decisions/0031-config-driven-cache-dir.md
@@ -67,6 +67,20 @@ sub-caches. `research-init`'s scaffold and prose now reference
   invocation (previously these commands did not touch config at all); a
   malformed `config.yml` now surfaces as a clean exit 1 on those commands too,
   consistent with how `literature` commands already behaved.
+- **A relative `cache_dir` is anchored to the repo root and confined to it; an
+  absolute one is honoured without restriction** (#123). The two halves answer
+  different needs. A relative value is resolved against the repository rather
+  than the cwd, so the cache does not move when a command runs from a
+  subdirectory — before that, `dataset fetch` from `docs/research/<paper>/` wrote
+  into a directory `research-init` had never gitignored. And a *relative* value
+  that escapes the repository (`../../elsewhere`) is refused with a clean exit 1,
+  because it is almost certainly a typo and an integrity tool must not write
+  outside the work tree by accident. An **absolute** value stays unrestricted:
+  the off-repo cache this ADR exists to permit — a scratch volume, a CI mount —
+  is expressed exactly that way, so confining everything would have closed the
+  use case in order to fix the accident. This is the same containment rule
+  `resolve_layout` applies to `layout:` keys (ADR-0039), with absolute paths as
+  the deliberate difference.
 
 ## Rejected alternatives
 

--- a/decisions/0039-recorded-consumer-layout.md
+++ b/decisions/0039-recorded-consumer-layout.md
@@ -136,13 +136,14 @@ actionable message, matching the config-error convention ADR-0031 established
   failure this ADR exists to end, so it is tracked as
   [#124](https://github.com/davorrunje/defendable-science/issues/124) rather than
   left implied by the key's existence.
-- **A known asymmetry, stated rather than hidden:** `layout:` keys are confined
-  to the repository, but `cache_dir` is only *anchored*, not confined, so
-  `cache_dir: ../../elsewhere` still escapes. ADR-0031 deliberately allows an
-  off-repo cache (a scratch volume, a CI mount), so closing this needs a
-  decision rather than a patch. Tracked as
-  [#123](https://github.com/davorrunje/defendable-science/issues/123); not fixed
-  here.
+- **The asymmetry with `cache_dir` has since been resolved, not left standing.**
+  When this ADR was written, `layout:` keys were confined to the repository while
+  `cache_dir` was only *anchored* to it, so `cache_dir: ../../elsewhere` still
+  escaped. That is no longer true: a **relative** `cache_dir` is now confined by
+  the same rule, while an **absolute** one is still honoured, because ADR-0031
+  deliberately allows an off-repo cache (a scratch volume, a CI mount) and that is
+  how such a cache is expressed. See ADR-0031 § Consequences and
+  [#123](https://github.com/davorrunje/defendable-science/issues/123).
 - **The recordable surface is a commitment.** Four keys is now the contract
   `adopt` and `check` are written against; widening it later is cheap, narrowing
   it is a breaking change for any repo that recorded a key.

--- a/defendable-science/defendable_science/scaffold/render.py
+++ b/defendable-science/defendable_science/scaffold/render.py
@@ -118,7 +118,9 @@ def render_config(cache_dir: str = DEFAULT_CACHE_DIR) -> str:
 # parse as a real value and be read as a real binding.
 
 # The CLI's dataset + HTTP caches both live under exactly this path (ADR-0031);
-# the scaffolded .gitignore excludes it.
+# the scaffolded .gitignore excludes it. A relative value is resolved against the
+# repository root, not the working directory, and must stay inside the repo. For a
+# cache outside the repo — a scratch volume, a CI mount — give an absolute path.
 cache_dir: {cache_dir}
 
 # The repo-local harness implementing the experiment-backend contract


### PR DESCRIPTION
## What

Records the `cache_dir` containment rule where issue #123 asked for it — in the ADRs — and
corrects an ADR statement that #136 made false.

#136 implemented the rule but documented it only in `_repo_relative`'s docstring. The issue's
first acceptance criterion was explicit: *"One rule is chosen and **recorded (ADR or an
explicit note in the existing ADRs)**, stating why `cache_dir` and `layout:` keys are treated
the same or differently."* That is why this reopens #123 rather than filing a successor — the
acceptance was not met.

## Details

- **ADR-0031** (the `cache_dir` decision) now states both halves and why they differ. A
  relative value is anchored to the repo root and confined to it, because a value escaping the
  repository is almost certainly a typo and an integrity tool must not write outside the work
  tree by accident. An absolute value stays unrestricted, because the off-repo cache that ADR
  exists to permit — a scratch volume, a CI mount — is expressed exactly that way. Confining
  everything would have closed the use case in order to fix the accident.
- **ADR-0039** described the asymmetry as an open gap: *"`cache_dir` is only anchored, not
  confined, so `cache_dir: ../../elsewhere` still escapes … not fixed here."* #136 made that
  false. It now records the resolution and points at ADR-0031, so a reader of either ADR
  reaches the same rule.
- **The scaffolded `config.yml`** says it too, where an author actually meets the key:

```yaml
# The CLI's dataset + HTTP caches both live under exactly this path (ADR-0031);
# the scaffolded .gitignore excludes it. A relative value is resolved against the
# repository root, not the working directory, and must stay inside the repo. For a
# cache outside the repo — a scratch volume, a CI mount — give an absolute path.
cache_dir: .defendable-science/cache/
```

No behaviour change; #136 already shipped the enforcement and its tests. Full suite, mypy,
ruff, ruff format, pre-commit and validate-plugin all green.

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)
