### PR TITLE
feat(init): record a divergent layout in one command (closes #133)

### DIFF
--- a/decisions/0039-recorded-consumer-layout.md
+++ b/decisions/0039-recorded-consumer-layout.md
@@ -144,6 +144,21 @@ actionable message, matching the config-error convention ADR-0031 established
   deliberately allows an off-repo cache (a scratch volume, a CI mount) and that is
   how such a cache is expressed. See ADR-0031 § Consequences and
   [#123](https://github.com/davorrunje/defendable-science/issues/123).
+- **`init` records the layout it scaffolds into
+  ([#133](https://github.com/davorrunje/defendable-science/issues/133)).** The
+  four keys are also `init` options — `--research-root`, `--literature-dir`,
+  `--datasets-manifest`, `--thesis-dir` — which override the resolved layout for
+  that run *and* are written into the `layout:` block of the `config.yml` it
+  renders. `adopt` therefore records a divergence in one run instead of four
+  steps (init, hand-add the block, re-init, delete the registries the first run
+  left at the defaults). The options reuse `resolve_layout()` rather than a
+  second validation path, so an option is validated exactly like a block key,
+  and the defaults-omitted rule holds in the writing direction too: a value
+  equal to the default is not written. Because `init` still never rewrites an
+  existing `config.yml`, an option passed at a repo that already has one must
+  *agree* with what it records; a contradiction exits 1 naming the key and both
+  values, since silently ignoring it would leave the author believing they had
+  recorded a layout they had not.
 - **The recordable surface is a commitment.** Four keys is now the contract
   `adopt` and `check` are written against; widening it later is cheap, narrowing
   it is a breaking change for any repo that recorded a key.
@@ -170,6 +185,15 @@ actionable message, matching the config-error convention ADR-0031 established
   semantics, and because it would make thesis-ness a claim in config that can
   disagree with the tree on disk — exactly the kind of unverifiable assertion
   `check` exists to eliminate.
+- **Merging the `layout:` block into an existing `config.yml`** (#133's option
+  B) instead of taking it as `init` options. It would spare the author the
+  option names, but the scaffolded `config.yml` is 21 comment lines out of 35 —
+  the comments *are* the documentation of each binding — and `pyyaml` cannot
+  round-trip comments. `literature/registry.py::patch_triage` already refuses to
+  rewrite a commented YAML file for exactly this reason. Merging would either
+  destroy those comments or require a comment-preserving YAML library, and this
+  package adds no runtime dependency for a convenience. `init`'s
+  never-overwrite guarantee also stops being a single rule the reader can hold.
 - **Leaving the layout as prose and hard-coding the defaults** — the status quo.
   It is the smallest diff, but it leaves nothing for `check` to check against,
   no way for `adopt` to record a divergence, and nine copies to keep in step by

--- a/decisions/0039-recorded-consumer-layout.md
+++ b/decisions/0039-recorded-consumer-layout.md
@@ -128,14 +128,17 @@ actionable message, matching the config-error convention ADR-0031 established
   resolved from the layout (an explicit value still wins), and the literature
   registry/triage defaults now come from the layout rather than from module-level
   path literals.
-- **`datasets_manifest` is recordable but not yet routed.** The `dataset`
-  commands still take the manifest as an argument defaulting to the literal
-  `datasets.yml`, so a repo that records `datasets_manifest: data/datasets.yml`
-  is validated and resolved correctly and then ignored by the only commands that
-  read a manifest. Recording a key the tooling does not honour is precisely the
-  failure this ADR exists to end, so it is tracked as
-  [#124](https://github.com/davorrunje/defendable-science/issues/124) rather than
-  left implied by the key's existence.
+- **`datasets_manifest` is routed into the `dataset` commands.** When this ADR
+  was written it was recordable but ignored: the commands took the manifest as
+  an argument defaulting to the literal `datasets.yml`, so a repo recording
+  `datasets_manifest: data/datasets.yml` had it validated, resolved, and then
+  ignored by the only commands that read a manifest — precisely the failure this
+  ADR exists to end. That gap was tracked as
+  [#124](https://github.com/davorrunje/defendable-science/issues/124) and closed
+  by [#126](https://github.com/davorrunje/defendable-science/pull/126):
+  `cli.py`'s `_manifest_path()` now falls back to `layout.datasets_manifest`, so
+  an omitted `--manifest` resolves to the recorded path from any directory,
+  while an explicit value still wins and is honoured exactly as typed.
 - **The asymmetry with `cache_dir` has since been resolved, not left standing.**
   When this ADR was written, `layout:` keys were confined to the repository while
   `cache_dir` was only *anchored* to it, so `cache_dir: ../../elsewhere` still

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -335,8 +335,9 @@ def _layout_with_options_or_exit(
             "init never rewrites an existing .defendable-science/config.yml, so "
             "this option cannot take effect:\n"
             f"{detail}\n"
-            "Edit the layout: block in .defendable-science/config.yml to record "
-            "the new path, or drop the option, then re-run.",
+            "Add or edit the layout: block in .defendable-science/config.yml to "
+            "record the new path (a config with no block records the default), "
+            "or drop the option, then re-run.",
             err=True,
         )
         raise typer.Exit(code=1)

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -39,7 +39,13 @@ from defendable_science.literature import acquire as acquire_mod
 from defendable_science.literature import graph as graph_mod
 from defendable_science.literature import registry as registry_mod
 from defendable_science.scaffold.init_repo import init_repo
-from defendable_science.scaffold.layout import Layout, LayoutError, resolve_layout
+from defendable_science.scaffold.layout import (
+    Layout,
+    LayoutError,
+    layout_conflicts,
+    layout_from_overrides,
+    resolve_layout,
+)
 
 if TYPE_CHECKING:
     import re
@@ -287,6 +293,56 @@ def _cache_root(config: dict[str, Any] | None = None, root: Path | None = None) 
 # --- init (defendable-science#123) ----------------------------------------------------
 
 
+def _layout_with_options_or_exit(
+    recorded: Layout, options: dict[str, str | None]
+) -> Layout:
+    """Fold ``init``'s layout options into the layout ``config.yml`` resolved to.
+
+    ``init`` never rewrites an existing ``config.yml``, so an option passed at a
+    repo that already has one can only agree with it or be a lie. Agreement
+    proceeds; disagreement exits, because silently ignoring the option would
+    leave the author believing they had recorded a layout they had not
+    (defendable-science#133).
+
+    :param recorded: The layout ``config.yml`` resolves to (the default when
+        there is no config).
+    :param options: Layout key → the value passed on the command line, or
+        ``None`` when the option was not given.
+    :returns: The layout to scaffold into: `recorded` when no option was given
+        or when every option agrees with it, otherwise the requested one.
+    :raises typer.Exit: Code 1 on an invalid option value, or when an option
+        contradicts an existing ``config.yml``.
+    """
+    given = {key: value for key, value in options.items() if value is not None}
+    if not given:
+        return recorded
+    try:
+        requested = layout_from_overrides(given, recorded.repo_root)
+    except LayoutError as exc:
+        typer.echo(f"invalid layout option: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    if not recorded.config_file.is_file():
+        return requested
+    conflicts = layout_conflicts(recorded, requested, given)
+    if conflicts:
+        detail = "\n".join(
+            f"  --{c.key.replace('_', '-')} asks for "
+            f"{recorded.rel(c.requested).as_posix()!r}, but config.yml records "
+            f"{recorded.rel(c.recorded).as_posix()!r} for layout.{c.key}"
+            for c in conflicts
+        )
+        typer.echo(
+            "init never rewrites an existing .defendable-science/config.yml, so "
+            "this option cannot take effect:\n"
+            f"{detail}\n"
+            "Edit the layout: block in .defendable-science/config.yml to record "
+            "the new path, or drop the option, then re-run.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    return recorded
+
+
 @app.command()
 def init(
     root: Annotated[
@@ -306,6 +362,37 @@ def init(
         bool,
         typer.Option("--dry-run", help="Report what would be written; write nothing."),
     ] = False,
+    research_root: Annotated[
+        str | None,
+        typer.Option(
+            "--research-root",
+            help=(
+                "Record a divergent research root (repo-relative). "
+                "Carries the literature and thesis directories with it."
+            ),
+        ),
+    ] = None,
+    literature_dir: Annotated[
+        str | None,
+        typer.Option(
+            "--literature-dir",
+            help="Record a divergent literature directory (repo-relative).",
+        ),
+    ] = None,
+    datasets_manifest: Annotated[
+        str | None,
+        typer.Option(
+            "--datasets-manifest",
+            help="Record a divergent dataset registry path (repo-relative).",
+        ),
+    ] = None,
+    thesis_dir: Annotated[
+        str | None,
+        typer.Option(
+            "--thesis-dir",
+            help="Record a divergent thesis directory (repo-relative).",
+        ),
+    ] = None,
 ) -> None:
     """Scaffold the consumer layout, and report every path considered as JSON.
 
@@ -331,13 +418,32 @@ def init(
     :param thesis: Also scaffold the optional thesis tree (aims, milestones,
         the kappa directory).
     :param dry_run: Report exactly what a real run would do, touching nothing.
+    :param research_root: Scaffold into, and record, a divergent research root —
+        so ``adopt`` lands the tree where the repo already keeps it in one run,
+        with nothing to delete at the default locations afterwards. Each layout
+        option must be repo-relative and stay inside the repository, and a value
+        equal to the default is *not* recorded (ADR-0039).
+    :param literature_dir: As `research_root`, for the literature directory.
+    :param datasets_manifest: As `research_root`, for the dataset registry.
+    :param thesis_dir: As `research_root`, for the thesis directory.
     :raises typer.Exit: Code 1 if ``--root`` names something that is not an
-        existing directory, on an invalid ``.defendable-science/config.yml``, or
-        if a path cannot be written (an unwritable tree, a parent that is a
-        file). A failed run prints no report: a partial scaffold must never read
-        as a completed one.
+        existing directory, on an invalid ``.defendable-science/config.yml`` or
+        an invalid layout option, if a layout option contradicts a layout an
+        existing ``config.yml`` already records (this command does not rewrite
+        it, so the option could not take effect), or if a path cannot be written
+        (an unwritable tree, a parent that is a file). A failed run prints no
+        report: a partial scaffold must never read as a completed one.
     """
     config, layout = _layout_or_exit(_explicit_root_or_exit(root))
+    layout = _layout_with_options_or_exit(
+        layout,
+        {
+            "research_root": research_root,
+            "literature_dir": literature_dir,
+            "datasets_manifest": datasets_manifest,
+            "thesis_dir": thesis_dir,
+        },
+    )
     # Repo-relative and directory-shaped, matching `render.DEFAULT_CACHE_DIR`:
     # this string is written into both config.yml and .gitignore, and an
     # absolute path in either would be wrong (.gitignore) or unportable (config).

--- a/defendable-science/defendable_science/scaffold/init_repo.py
+++ b/defendable-science/defendable_science/scaffold/init_repo.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 from defendable_science.scaffold import render as r
 from defendable_science.scaffold import status
+from defendable_science.scaffold.layout import recorded_layout
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -131,7 +132,15 @@ def init_repo(
     _write(
         layout.datasets_manifest, r.render_datasets_manifest(), actions, dry_run=dry_run
     )
-    _write(layout.config_file, r.render_config(cache_dir), actions, dry_run=dry_run)
+    # The config records the layout it was scaffolded into, so a divergent tree
+    # is written *and* recorded by one run — never a tree the next command
+    # cannot find (defendable-science#133).
+    _write(
+        layout.config_file,
+        r.render_config(cache_dir, recorded_layout(layout)),
+        actions,
+        dry_run=dry_run,
+    )
     _write(
         layout.config_dir / "rclone.conf.example",
         r.render_rclone_example(),

--- a/defendable-science/defendable_science/scaffold/layout.py
+++ b/defendable-science/defendable_science/scaffold/layout.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping
 
 #: The four keys ``config.yml``'s ``layout:`` block accepts.
 LAYOUT_KEYS: tuple[str, ...] = (
@@ -273,3 +273,92 @@ def resolve_layout(config: Mapping[str, Any], repo_root: Path) -> Layout:
             "thesis_dir", raw.get("thesis_dir"), research / "thesis", repo_root
         ),
     )
+
+
+@dataclass(frozen=True)
+class LayoutConflict:
+    """One key whose requested value contradicts the recorded one.
+
+    :param key: The layout key, as it is written in ``config.yml``.
+    :param recorded: The absolute path ``config.yml`` records for it.
+    :param requested: The absolute path the caller asked for.
+    """
+
+    key: str
+    recorded: Path
+    requested: Path
+
+
+def layout_from_overrides(
+    overrides: Mapping[str, str | None], repo_root: Path
+) -> Layout:
+    """Resolve a layout from caller-supplied overrides (``init``'s options).
+
+    A thin front door onto :func:`resolve_layout`, so an option gets **exactly**
+    the validation a ``layout:`` block gets — relative, inside the repository, no
+    ``..`` escape — rather than a second copy of the rule that could drift from
+    it.
+
+    :param overrides: Layout key → value; a ``None`` value means "not given" and
+        falls back to the default, matching an omitted block key.
+    :param repo_root: The repository root.
+    :returns: The resolved layout.
+    :raises LayoutError: On an unknown key or an invalid value, identically to a
+        ``layout:`` block carrying the same value.
+    """
+    block = {key: value for key, value in overrides.items() if value is not None}
+    return resolve_layout({"layout": block}, repo_root)
+
+
+def recorded_layout(layout: Layout) -> dict[str, str]:
+    """Return the ``layout:`` block that records `layout`, defaults omitted.
+
+    ADR-0039's defaults-omitted rule, applied in the writing direction: a repo
+    matching the default records nothing, and a key whose value is what the
+    resolver would have derived anyway is left out. Derived defaults follow the
+    **resolved** ``research_root``, so recording ``research_root: writing`` does
+    not also write the ``writing/literature`` and ``writing/thesis`` it carries.
+
+    :param layout: A resolved layout.
+    :returns: Repo-relative POSIX paths, keyed in :data:`LAYOUT_KEYS` order —
+        the inverse of :func:`resolve_layout`, so the block it returns resolves
+        back to `layout`.
+    """
+    default = Layout.default(layout.repo_root)
+    derived = {
+        "research_root": default.research_root,
+        "literature_dir": layout.research_root / "literature",
+        "datasets_manifest": default.datasets_manifest,
+        "thesis_dir": layout.research_root / "thesis",
+    }
+    return {
+        key: layout.rel(getattr(layout, key)).as_posix()
+        for key in LAYOUT_KEYS
+        if getattr(layout, key) != derived[key]
+    }
+
+
+def layout_conflicts(
+    recorded: Layout, requested: Layout, keys: Iterable[str]
+) -> list[LayoutConflict]:
+    """Report the `keys` on which `requested` contradicts `recorded`.
+
+    Only the keys the caller actually asked for are compared: an option nobody
+    passed cannot contradict anything.
+
+    :param recorded: The layout ``config.yml`` resolves to.
+    :param requested: The layout the caller's options resolve to.
+    :param keys: The layout keys the caller supplied.
+    :returns: One conflict per disagreeing key, in :data:`LAYOUT_KEYS` order;
+        empty when every supplied key agrees.
+    """
+    asked = set(keys)
+    return [
+        LayoutConflict(
+            key=key,
+            recorded=getattr(recorded, key),
+            requested=getattr(requested, key),
+        )
+        for key in LAYOUT_KEYS
+        if key in asked and getattr(recorded, key) != getattr(requested, key)
+    ]

--- a/defendable-science/defendable_science/scaffold/render.py
+++ b/defendable-science/defendable_science/scaffold/render.py
@@ -61,10 +61,13 @@ _LAYOUT_STUB = """\
 """
 
 #: Precedes a recorded block, so the author reading the file knows why it is
-#: there and what an omitted key means.
+#: there and what an omitted key means. Carries the stub's key list too: the
+#: author whose repo already diverges is the one most likely to add a second
+#: key, and this is the only place in the file that says which keys exist.
 _RECORDED_LAYOUT_PREAMBLE = """\
 # This repo diverges from the default tree, so the divergent roots are recorded
-# here. Omitted keys fall back to the default; an unknown key is an error.
+# here. Keys: research_root, literature_dir, datasets_manifest, thesis_dir.
+# Omitted keys fall back to the default; an unknown key is an error.
 """
 
 

--- a/defendable-science/defendable_science/scaffold/render.py
+++ b/defendable-science/defendable_science/scaffold/render.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import yaml
+
 from defendable_science.exploration.backlog import (
     HYPOTHESIS_PREAMBLE,
     Backlog,
@@ -22,7 +24,7 @@ from defendable_science.exploration.backlog import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
 #: Mirrors ``core.config``'s cache default (ADR-0031); written explicitly so the
 #: scaffolded ``.gitignore`` and the runtime cache path cannot drift.
@@ -48,6 +50,22 @@ _MILESTONE_ENTRY = """\
 """
 
 _GITIGNORE_MARKER = "# defendable-science"
+
+#: What a default repo's ``config.yml`` says about ``layout:`` — a comment, not
+#: a key, because a repo matching the default records nothing.
+_LAYOUT_STUB = """\
+# layout:
+#   Only needed if this repo diverges from the default tree. Keys:
+#   research_root, literature_dir, datasets_manifest, thesis_dir.
+#   Omitted keys fall back to the default; an unknown key is an error.
+"""
+
+#: Precedes a recorded block, so the author reading the file knows why it is
+#: there and what an omitted key means.
+_RECORDED_LAYOUT_PREAMBLE = """\
+# This repo diverges from the default tree, so the divergent roots are recorded
+# here. Omitted keys fall back to the default; an unknown key is an error.
+"""
 
 
 def render_papers_registry() -> str:
@@ -101,16 +119,30 @@ def render_datasets_manifest() -> str:
     )
 
 
-def render_config(cache_dir: str = DEFAULT_CACHE_DIR) -> str:
+def render_config(
+    cache_dir: str = DEFAULT_CACHE_DIR,
+    layout_block: Mapping[str, str] | None = None,
+) -> str:
     """Render ``.defendable-science/config.yml`` with the five consumer bindings.
 
     Every binding is ``null`` until the author sets it. ``layout:`` is written as
-    a comment, not a key: a repo matching the default tree records nothing, so
-    there is nothing to keep in step.
+    a comment, not a key, when the repo matches the default tree: it records
+    nothing, so there is nothing to keep in step. A repo that diverges gets a
+    real block instead, written here at scaffold time — ``init`` never rewrites
+    an existing ``config.yml`` (ADR-0039, defendable-science#133).
 
     :param cache_dir: The cache root to record (ADR-0031).
+    :param layout_block: The divergent layout keys to record, defaults already
+        omitted (:func:`defendable_science.scaffold.layout.recorded_layout`).
+        Empty or ``None`` renders the commented stub.
     :returns: The config file text.
     """
+    layout = (
+        _LAYOUT_STUB
+        if not layout_block
+        else _RECORDED_LAYOUT_PREAMBLE
+        + yaml.safe_dump({"layout": dict(layout_block)}, sort_keys=False)
+    )
     return f"""\
 # defendable-science project configuration.
 #
@@ -143,11 +175,7 @@ literature:
     remote: null
     base_path: null
 
-# layout:
-#   Only needed if this repo diverges from the default tree. Keys:
-#   research_root, literature_dir, datasets_manifest, thesis_dir.
-#   Omitted keys fall back to the default; an unknown key is an error.
-"""
+{layout}"""
 
 
 def render_rclone_example() -> str:

--- a/defendable-science/tests/test_cli_commands.py
+++ b/defendable-science/tests/test_cli_commands.py
@@ -846,6 +846,9 @@ def test_init_refuses_an_absolute_layout_option(
     assert result.exit_code == 1
     assert "is absolute" in result.output
     assert "Traceback" not in result.output
+    assert result.stdout.strip() == ""
+    assert not (repo / "docs").exists()
+    assert not (tmp_path / "writing").exists()
 
 
 def test_init_accepts_layout_options_that_agree_with_the_recorded_layout(

--- a/defendable-science/tests/test_cli_commands.py
+++ b/defendable-science/tests/test_cli_commands.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 
 import pytest
+import yaml
 from typer.testing import CliRunner
 
 from defendable_science.cli import app
@@ -723,6 +725,201 @@ def test_init_exits_1_on_an_invalid_layout_block(
     assert "Traceback" not in result.output
     assert result.stdout.strip() == ""
     assert not (repo / "docs").exists()
+
+
+# --- init layout options (#133) ------------------------------------------------------
+
+
+def _unstyled(text: str) -> str:
+    """Strip ANSI styling: CI sets FORCE_COLOR, so Rich styles option names."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def test_init_layout_options_scaffold_and_record_in_one_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The whole point of #133: no default-location registries to delete after."""
+    repo = _fresh_repo(tmp_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--thesis",
+            "--research-root",
+            "writing",
+            "--literature-dir",
+            "bib",
+            "--datasets-manifest",
+            "data/datasets.yml",
+            "--thesis-dir",
+            "phd",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (repo / "writing" / "papers.md").is_file()
+    assert (repo / "bib" / "references.json").is_file()
+    assert (repo / "data" / "datasets.yml").is_file()
+    assert (repo / "phd" / "aims.md").is_file()
+    assert not (repo / "docs").exists()
+    config = yaml.safe_load(
+        (repo / ".defendable-science" / "config.yml").read_text(encoding="utf-8")
+    )
+    assert config["layout"] == {
+        "research_root": "writing",
+        "literature_dir": "bib",
+        "datasets_manifest": "data/datasets.yml",
+        "thesis_dir": "phd",
+    }
+
+
+def test_init_layout_options_are_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second run with the same options changes nothing, byte for byte."""
+    repo = _fresh_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    options = ["init", "--research-root", "writing"]
+    runner.invoke(app, options)
+    before = {p: p.read_bytes() for p in sorted(repo.rglob("*")) if p.is_file()}
+
+    result = runner.invoke(app, options)
+
+    assert result.exit_code == 0, result.output
+    assert {p: p.read_bytes() for p in sorted(repo.rglob("*")) if p.is_file()} == before
+    assert json.loads(result.stdout)["counts"]["created"] == 0
+
+
+def test_init_records_only_the_divergent_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ADR-0039: a key equal to the default is not written into the block."""
+    repo = _fresh_repo(tmp_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(
+        app,
+        [
+            "init",
+            "--research-root",
+            "writing",
+            "--literature-dir",
+            "writing/literature",
+            "--datasets-manifest",
+            "datasets.yml",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    config = yaml.safe_load(
+        (repo / ".defendable-science" / "config.yml").read_text(encoding="utf-8")
+    )
+    assert config["layout"] == {"research_root": "writing"}
+
+
+def test_init_refuses_a_layout_option_that_escapes_the_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _fresh_repo(tmp_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["init", "--literature-dir", "../bib"])
+
+    assert result.exit_code == 1
+    assert "layout.literature_dir" in result.output
+    assert "stay inside the repository" in result.output
+    assert "Traceback" not in result.output
+    assert result.stdout.strip() == ""
+    assert not (repo / "docs").exists()
+
+
+def test_init_refuses_an_absolute_layout_option(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _fresh_repo(tmp_path)
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["init", "--research-root", str(tmp_path / "writing")])
+
+    assert result.exit_code == 1
+    assert "is absolute" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_init_accepts_layout_options_that_agree_with_the_recorded_layout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Agreement is not a conflict: the scaffold lands at the recorded paths."""
+    repo = _fresh_repo(tmp_path)
+    (repo / ".defendable-science").mkdir()
+    (repo / ".defendable-science" / "config.yml").write_text(
+        "layout:\n  research_root: writing/\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["init", "--research-root", "writing"])
+
+    assert result.exit_code == 0, result.output
+    assert (repo / "writing" / "papers.md").is_file()
+
+
+def test_init_refuses_a_layout_option_that_contradicts_the_recorded_layout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Never silently ignored: `init` cannot rewrite an existing config.yml."""
+    repo = _fresh_repo(tmp_path)
+    (repo / ".defendable-science").mkdir()
+    config = repo / ".defendable-science" / "config.yml"
+    config.write_text("layout:\n  research_root: writing/\n", encoding="utf-8")
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["init", "--research-root", "papers"])
+
+    assert result.exit_code == 1
+    output = _unstyled(result.output)
+    assert "--research-root" in output
+    assert "writing" in output  # what config.yml records
+    assert "papers" in output  # what the option asked for
+    assert "config.yml" in output  # how to resolve it
+    assert "Traceback" not in output
+    assert result.stdout.strip() == ""
+    assert not (repo / "papers").exists()
+    assert not (repo / "writing").exists()
+    assert config.read_text(encoding="utf-8") == "layout:\n  research_root: writing/\n"
+
+
+def test_init_refuses_a_layout_option_when_the_config_records_the_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An existing config with no `layout:` block still records the default."""
+    repo = _fresh_repo(tmp_path)
+    (repo / ".defendable-science").mkdir()
+    (repo / ".defendable-science" / "config.yml").write_text(
+        "cache_dir: .defendable-science/cache/\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(repo)
+
+    result = runner.invoke(app, ["init", "--research-root", "writing"])
+
+    assert result.exit_code == 1
+    assert "--research-root" in _unstyled(result.output)
+    assert not (repo / "writing").exists()
+
+
+def test_init_help_lists_every_layout_option() -> None:
+    result = runner.invoke(app, ["init", "--help"])
+
+    assert result.exit_code == 0
+    helptext = _unstyled(result.stdout)
+    for option in (
+        "--research-root",
+        "--literature-dir",
+        "--datasets-manifest",
+        "--thesis-dir",
+    ):
+        assert option in helptext
 
 
 def test_init_reports_a_write_failure_without_a_traceback(

--- a/defendable-science/tests/test_init_repo.py
+++ b/defendable-science/tests/test_init_repo.py
@@ -280,3 +280,35 @@ def test_a_fresh_scaffold_survives_the_whole_backlog_flow(
     validated = runner.invoke(app, ["dataset", "validate"])
     assert validated.exit_code == 0, validated.output
     assert json.loads(validated.stdout)["ok"] is True
+
+
+def test_the_scaffolded_config_records_a_divergent_layout(repo: Path) -> None:
+    """One `init` run lands the tree *and* records where it landed (#133)."""
+    layout = Layout(
+        repo_root=repo,
+        research_root=repo / "writing",
+        literature_dir=repo / "bib",
+        datasets_manifest=repo / "data" / "datasets.yml",
+        thesis_dir=repo / "phd",
+    )
+
+    init_repo(layout)
+
+    config = yaml.safe_load(
+        (repo / ".defendable-science" / "config.yml").read_text(encoding="utf-8")
+    )
+    assert config["layout"] == {
+        "research_root": "writing",
+        "literature_dir": "bib",
+        "datasets_manifest": "data/datasets.yml",
+        "thesis_dir": "phd",
+    }
+
+
+def test_the_scaffolded_config_of_a_default_repo_records_no_layout(repo: Path) -> None:
+    _init(repo)
+
+    config = yaml.safe_load(
+        (repo / ".defendable-science" / "config.yml").read_text(encoding="utf-8")
+    )
+    assert "layout" not in config

--- a/defendable-science/tests/test_layout.py
+++ b/defendable-science/tests/test_layout.py
@@ -215,3 +215,92 @@ def test_repo_root_with_dotdot_is_canonicalized() -> None:
     assert out.rel(out.literature_dir) == Path("writing/literature")
     assert out.rel(out.datasets_manifest) == Path("datasets.yml")
     assert out.rel(out.thesis_dir) == Path("writing/thesis")
+
+
+# --- recording a layout back into config.yml (#133) ------------------------
+
+
+def test_a_default_layout_records_nothing() -> None:
+    """ADR-0039's defaults-omitted rule: a matching repo records no key."""
+    assert lay.recorded_layout(lay.Layout.default(Path("/repo"))) == {}
+
+
+def test_recording_omits_the_keys_that_derive_from_the_research_root() -> None:
+    """`literature_dir` and `thesis_dir` follow a moved research root."""
+    out = lay.layout_from_overrides({"research_root": "writing"}, Path("/repo"))
+
+    assert lay.recorded_layout(out) == {"research_root": "writing"}
+
+
+def test_recording_keeps_every_divergent_key() -> None:
+    out = lay.layout_from_overrides(
+        {
+            "research_root": "writing/",
+            "literature_dir": "bib/",
+            "datasets_manifest": "data/datasets.yml",
+            "thesis_dir": "phd/",
+        },
+        Path("/repo"),
+    )
+
+    assert lay.recorded_layout(out) == {
+        "research_root": "writing",
+        "literature_dir": "bib",
+        "datasets_manifest": "data/datasets.yml",
+        "thesis_dir": "phd",
+    }
+
+
+def test_overrides_reuse_the_containment_rule() -> None:
+    with pytest.raises(lay.LayoutError) as excinfo:
+        lay.layout_from_overrides({"literature_dir": "../bib"}, Path("/repo"))
+
+    assert "layout.literature_dir" in str(excinfo.value)
+    assert "stay inside the repository" in str(excinfo.value)
+
+
+def test_overrides_of_nothing_are_the_default_layout() -> None:
+    assert lay.layout_from_overrides({}, Path("/repo")) == lay.Layout.default(
+        Path("/repo")
+    )
+
+
+def test_no_conflict_when_the_requested_keys_agree_with_the_recorded_ones() -> None:
+    recorded = lay.resolve_layout(
+        {"layout": {"research_root": "writing"}}, Path("/repo")
+    )
+    requested = lay.layout_from_overrides({"research_root": "writing/"}, Path("/repo"))
+
+    assert lay.layout_conflicts(recorded, requested, ["research_root"]) == []
+
+
+def test_a_conflict_names_the_key_and_both_values() -> None:
+    recorded = lay.Layout.default(Path("/repo"))
+    requested = lay.layout_from_overrides(
+        {"research_root": "writing", "literature_dir": "bib"}, Path("/repo")
+    )
+
+    conflicts = lay.layout_conflicts(
+        recorded, requested, ["research_root", "literature_dir"]
+    )
+
+    assert conflicts == [
+        lay.LayoutConflict(
+            key="research_root",
+            recorded=Path("/repo/docs/research"),
+            requested=Path("/repo/writing"),
+        ),
+        lay.LayoutConflict(
+            key="literature_dir",
+            recorded=Path("/repo/docs/research/literature"),
+            requested=Path("/repo/bib"),
+        ),
+    ]
+
+
+def test_only_the_named_keys_are_compared() -> None:
+    """An option the author did not pass cannot conflict with anything."""
+    recorded = lay.Layout.default(Path("/repo"))
+    requested = lay.layout_from_overrides({"thesis_dir": "phd"}, Path("/repo"))
+
+    assert lay.layout_conflicts(recorded, requested, ["research_root"]) == []

--- a/defendable-science/tests/test_render.py
+++ b/defendable-science/tests/test_render.py
@@ -211,3 +211,40 @@ def test_merge_gitignore_from_empty() -> None:
     merged = r.merge_gitignore("", [".defendable-science/keys.json"])
 
     assert merged == "# defendable-science\n.defendable-science/keys.json\n"
+
+
+def test_rendered_config_records_a_divergent_layout(tmp_path: Path) -> None:
+    """The block it writes must be the block `resolve_layout` reads back (#133)."""
+    path = tmp_path / "config.yml"
+    path.write_text(
+        r.render_config(
+            layout_block={"research_root": "writing", "literature_dir": "my bib: 1"}
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config(path)
+
+    assert config["layout"] == {
+        "research_root": "writing",
+        "literature_dir": "my bib: 1",
+    }
+    assert config["cache_dir"] == r.DEFAULT_CACHE_DIR
+
+
+def test_a_recorded_layout_round_trips_through_the_resolver(tmp_path: Path) -> None:
+    from defendable_science.scaffold import layout as lay
+
+    resolved = lay.layout_from_overrides(
+        {"research_root": "writing", "literature_dir": "bib"}, tmp_path
+    )
+    path = tmp_path / "config.yml"
+    path.write_text(
+        r.render_config(layout_block=lay.recorded_layout(resolved)), encoding="utf-8"
+    )
+
+    assert lay.resolve_layout(load_config(path), tmp_path) == resolved
+
+
+def test_an_empty_layout_block_renders_the_default_config() -> None:
+    assert r.render_config(layout_block={}) == r.render_config()

--- a/defendable-science/tests/test_render.py
+++ b/defendable-science/tests/test_render.py
@@ -12,6 +12,7 @@ from defendable_science.core.config import load_config
 from defendable_science.dataset import manifest as manifest_mod
 from defendable_science.exploration import backlog as b
 from defendable_science.literature import registry as reg
+from defendable_science.scaffold import layout as lay
 from defendable_science.scaffold import render as r
 from defendable_science.scaffold.layout import Layout
 
@@ -233,8 +234,6 @@ def test_rendered_config_records_a_divergent_layout(tmp_path: Path) -> None:
 
 
 def test_a_recorded_layout_round_trips_through_the_resolver(tmp_path: Path) -> None:
-    from defendable_science.scaffold import layout as lay
-
     resolved = lay.layout_from_overrides(
         {"research_root": "writing", "literature_dir": "bib"}, tmp_path
     )

--- a/skills/research-init/SKILL.md
+++ b/skills/research-init/SKILL.md
@@ -55,9 +55,13 @@ then:
 ```bash
 defendable-science init              # add --thesis for a thesis-by-publication repo
 defendable-science init --dry-run    # report what a real run would do, write nothing
-defendable-science init --research-root writing   # scaffold into, and record, a
-                                                  # divergent root (see Adopt, step 2)
 ```
+
+**In `adopt`, settle the layout before the first real `init` run.** `init`
+renders `config.yml` and never rewrites it, so a bare run records the default
+layout — after which a divergence costs an edit plus a cleanup (Adopt, step 2),
+where deciding first costs one command. Inventory, confirm the divergences, then
+run `init` once with them as options.
 
 `init` is **idempotent and non-destructive**: a file already present is reported
 `exists` and left exactly as the author wrote it. There is deliberately no
@@ -202,8 +206,19 @@ consumer):
    rewrite it. Options that agree with the layout it records are fine and the
    scaffold lands at the recorded paths; an option that contradicts it exits 1
    naming the key and both values, rather than being silently ignored. Resolve
-   that by editing the `layout:` block in `config.yml` (the author's file to
-   change), then re-run.
+   that by adding or editing the `layout:` block in `config.yml` (the author's
+   file to change), then re-run.
+
+   On that path — and only that path — there is cleanup, because the config only
+   exists if an earlier `init` already scaffolded at the previous locations. The
+   re-run lands a second set of registries at the newly recorded paths and leaves
+   the first set orphaned; an empty registry at a stale location is a perfectly
+   valid file, so `check` will not flag it. **Delete the empty registries the
+   earlier run left behind, for the keys the block moved** — a key the block
+   leaves at its default has its live file exactly where the earlier run put it,
+   and must not be touched. Confirm each deletion with the author, and delete
+   only files that are still empty: a registry with content is the author's work,
+   and the move is then theirs to make.
 
 3. **Literature.** Reference PDFs + digests + any existing bibliography →
    `literature/references.json` (CSL-JSON) + `triage.yml`, with **roles tagged**

--- a/skills/research-init/SKILL.md
+++ b/skills/research-init/SKILL.md
@@ -55,6 +55,8 @@ then:
 ```bash
 defendable-science init              # add --thesis for a thesis-by-publication repo
 defendable-science init --dry-run    # report what a real run would do, write nothing
+defendable-science init --research-root writing   # scaffold into, and record, a
+                                                  # divergent root (see Adopt, step 2)
 ```
 
 `init` is **idempotent and non-destructive**: a file already present is reported
@@ -178,16 +180,30 @@ consumer):
    ignore. *The author confirms the block* — recording where material already
    lives is the proposal, and **relocating files to the default tree stays
    available as the author's choice**, no longer the only option.
-   Sequencing, given that `init` renders `config.yml` itself and never rewrites
-   an existing one: run `defendable-science init --dry-run` first — it writes
-   nothing and reports every path it *would* touch. With no `layout:` block
-   recorded yet, those are the **default** paths, so read them back as the
-   proposal the block is about to override, not as a preview of where files will
-   end up. Then run `init`, add the confirmed block to the `config.yml` it
-   rendered, and run `init` once more so anything still missing lands in the
-   recorded locations. Finally delete the empty registries the first run left
-   behind **for the keys the block moved** — a key the block leaves at its
-   default has its live file exactly where the first run put it.
+
+   Once the author has confirmed the divergences, pass them straight to `init` —
+   one run scaffolds into those paths *and* records them in the `config.yml` it
+   renders, so nothing is left at the default locations to clean up afterwards:
+
+   ```bash
+   defendable-science init --dry-run --research-root writing --literature-dir bib
+   defendable-science init --research-root writing --literature-dir bib
+   ```
+
+   One option per recordable key: `--research-root`, `--literature-dir`,
+   `--datasets-manifest`, `--thesis-dir`. Only the confirmed divergences are
+   passed; a value equal to the default is not recorded. Each must be a
+   repo-relative path inside the work tree — an absolute path or one escaping
+   the repo is refused with a message, never a partial scaffold. Run the same
+   command with `--dry-run` first to show the author exactly where files will
+   land; unlike a bare `--dry-run`, this previews the *proposed* tree.
+
+   If `.defendable-science/config.yml` **already exists**, `init` will not
+   rewrite it. Options that agree with the layout it records are fine and the
+   scaffold lands at the recorded paths; an option that contradicts it exits 1
+   naming the key and both values, rather than being silently ignored. Resolve
+   that by editing the `layout:` block in `config.yml` (the author's file to
+   change), then re-run.
 
 3. **Literature.** Reference PDFs + digests + any existing bibliography →
    `literature/references.json` (CSL-JSON) + `triage.yml`, with **roles tagged**


### PR DESCRIPTION
## What

Lets `init` record a divergent layout in one command, so onboarding an existing repo is a
single call instead of a four-step dance.

Before: run `init`, hand-add a `layout:` block to `config.yml`, re-run `init`, then delete the
empty registries the first run left at the default locations for the keys the block moved.

Now:

```console
$ defendable-science init --root X --research-root writing/ --literature-dir bib/
```

Everything lands at the recorded paths on the first run, there is no `docs/research/` to clean
up, and the block records exactly the two divergent keys — `datasets_manifest` and `thesis_dir`
stay out of it because they still equal their defaults (ADR-0039's defaults-omitted rule).

## Why options rather than merging `config.yml`

The issue offered both. Merging is ruled out by a position this codebase already holds:
`literature/registry.py::patch_triage` **refuses** to rewrite comment-carrying YAML because
*"pyyaml cannot round-trip comments … rather than silently destroying them."* The scaffolded
`config.yml` is **21 comment lines out of 35**, and those comments are the documentation an
author reads to understand each binding. Merging would destroy them or require a
comment-preserving YAML library, and this project adds no new runtime dependencies. Recorded in
ADR-0039 as a rejected alternative.

## An option that cannot take effect is refused, not ignored

`init` never rewrites an existing `config.yml`. So a layout option passed at a repo that already
has one cannot be honoured — and silently dropping it would leave the author believing they had
recorded a layout they had not.

- agrees with what the config records → proceeds, scaffold lands at the recorded paths
- contradicts it → **exit 1**, naming the key, the recorded value and the passed value, and
  pointing at the file to change
- a config that is silent on `layout:` counts as recording the default, so an option against it
  is refused too — the only reading consistent with never-rewrite

Comparison is on resolved `Path`s, not strings, so `writing`, `writing/` and `./writing` are the
same value rather than a spurious conflict.

Validation goes through `resolve_layout` itself rather than a second copy of the containment
rule, so `--literature-dir ../bib` produces that key's own message and unknown-key handling
comes free. A test asserts on the shared message, so a future divergence fails rather than
passing quietly.

## The escape hatch cleans up after itself

Review caught that the conflict path reintroduces the mess this issue removes: a repo only
reaches it because an earlier `init` already scaffolded at the old locations, so editing the
block and re-running lands a second set of registries and orphans the first — and **`check`
stays silent**, because an empty registry at a stale location is a perfectly valid file.

`skills/research-init/SKILL.md § Adopt` now carries the cleanup on that path and only that
path, with two guardrails the skill needs: confirm each deletion with the author, and delete
only files that are still empty — a registry with content is the author's work, and moving it
is their call. `§ What it scaffolds` also warns that running bare `init` before the layout is
settled forecloses the one-run path permanently.

## Also

ADR-0039's consequences list still claimed `datasets_manifest` was "recordable but not yet
routed". It has been routed since #126 closed #124 — corrected here, since this PR edits the
same list. That stale bullet had already propagated into an implementation report as a false
claim, which is a fair argument for fixing ADRs the moment they go out of date.

1348 tests, 100% statement + branch coverage. pytest, mypy, ruff, ruff format, all pre-commit
hooks and validate-plugin exit 0.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
