### PR TITLE
fix(literature): refuse patch_triage writes that leak or lose YAML aliasing

### DIFF
--- a/defendable-science/defendable_science/literature/registry.py
+++ b/defendable-science/defendable_science/literature/registry.py
@@ -555,22 +555,39 @@ def _has_comments(text: str) -> bool:
     return any(line.lstrip().startswith("#") for line in text.splitlines())
 
 
-def _walk_node(node: yaml.Node, owner: str, visits: dict[int, list[str]]) -> None:
+def _walk_node(
+    node: yaml.Node, owner: str, visits: dict[int, list[str]], stack: set[int]
+) -> None:
     """Record that ``node`` (and everything reachable from it) belongs to ``owner``.
+
+    A self-referential anchor (``a: &s {self: *s}``) makes the composed node
+    graph cyclic — a legitimate YAML shape, not malformed input — so this
+    tracks the node ids currently on the recursion path (``stack``) and stops
+    descending once it returns to one of them, rather than recursing forever.
+    The owner is still recorded for that revisit: reaching a node a second
+    time, even via its own cycle, is exactly what "aliased" means here.
 
     :param node: The composed node to visit.
     :param owner: The top-level citekey whose subtree this node was reached from.
     :param visits: Accumulator, mutated in place: node id → the owners that
         reached it, one entry per visit (so a node reached twice from the same
         owner still shows a duplicate, meaning "aliased").
+    :param stack: Node ids currently being descended into, on this call path;
+        mutated in place and restored before returning.
     """
     visits.setdefault(id(node), []).append(owner)
+    if id(node) in stack:
+        return
     if isinstance(node, yaml.MappingNode):
+        stack.add(id(node))
         for _, value_node in node.value:
-            _walk_node(value_node, owner, visits)
+            _walk_node(value_node, owner, visits, stack)
+        stack.discard(id(node))
     elif isinstance(node, yaml.SequenceNode):
+        stack.add(id(node))
         for item_node in node.value:
-            _walk_node(item_node, owner, visits)
+            _walk_node(item_node, owner, visits, stack)
+        stack.discard(id(node))
 
 
 def _compose_row_visits(
@@ -586,10 +603,11 @@ def _compose_row_visits(
     """
     row_nodes: dict[str, yaml.Node] = {}
     visits: dict[int, list[str]] = {}
+    stack: set[int] = set()
     for key_node, value_node in root.value:
         citekey = str(key_node.value)
         row_nodes[citekey] = value_node
-        _walk_node(value_node, citekey, visits)
+        _walk_node(value_node, citekey, visits, stack)
     return row_nodes, visits
 
 

--- a/defendable-science/defendable_science/literature/registry.py
+++ b/defendable-science/defendable_science/literature/registry.py
@@ -555,22 +555,123 @@ def _has_comments(text: str) -> bool:
     return any(line.lstrip().startswith("#") for line in text.splitlines())
 
 
-def _aliased_rows(raw: dict[Any, Any]) -> list[list[str]]:
-    """Return the groups of citekeys whose rows are the *same* Python object.
+def _walk_node(node: yaml.Node, owner: str, visits: dict[int, list[str]]) -> None:
+    """Record that ``node`` (and everything reachable from it) belongs to ``owner``.
 
-    ``yaml.safe_load`` gives every alias of one anchor the same object, so
-    ``b2021: *shared`` is not a copy of ``a2020`` — it *is* ``a2020``. Identity
-    is the exact test for that and cannot false-positive: two rows written out
-    separately are distinct objects however identical they read.
-
-    :param raw: The top-level mapping, as :func:`triage_mapping` returned it.
-    :returns: One sorted citekey list per shared object, groups sorted; empty
-        when no two rows are the same object.
+    :param node: The composed node to visit.
+    :param owner: The top-level citekey whose subtree this node was reached from.
+    :param visits: Accumulator, mutated in place: node id → the owners that
+        reached it, one entry per visit (so a node reached twice from the same
+        owner still shows a duplicate, meaning "aliased").
     """
-    by_object: dict[int, list[str]] = {}
-    for key, row in raw.items():
-        by_object.setdefault(id(row), []).append(str(key))
-    return sorted(sorted(keys) for keys in by_object.values() if len(keys) > 1)
+    visits.setdefault(id(node), []).append(owner)
+    if isinstance(node, yaml.MappingNode):
+        for _, value_node in node.value:
+            _walk_node(value_node, owner, visits)
+    elif isinstance(node, yaml.SequenceNode):
+        for item_node in node.value:
+            _walk_node(item_node, owner, visits)
+
+
+def _compose_row_visits(
+    root: yaml.MappingNode,
+) -> tuple[dict[str, yaml.Node], dict[int, list[str]]]:
+    """Walk every row's subtree, tracking which citekey(s) reach each node.
+
+    :param root: The composed top-level mapping node.
+    :returns: ``(row_nodes, visits)`` — each top-level citekey's own value
+        node, and, for every node anywhere in the document, the list of
+        citekeys whose subtree reached it (with duplicates, so length alone
+        says whether it was reached more than once).
+    """
+    row_nodes: dict[str, yaml.Node] = {}
+    visits: dict[int, list[str]] = {}
+    for key_node, value_node in root.value:
+        citekey = str(key_node.value)
+        row_nodes[citekey] = value_node
+        _walk_node(value_node, citekey, visits)
+    return row_nodes, visits
+
+
+def _classify_alias_groups(
+    row_nodes: dict[str, yaml.Node], visits: dict[int, list[str]]
+) -> tuple[list[list[str]], list[list[str]]]:
+    """Split nodes reached more than once into whole-row and nested-alias groups.
+
+    A node reached only once is not aliased at all — ordinary content. A node
+    reached more than once is a genuine ``&anchor``/``*alias`` (see
+    :func:`_alias_groups` for why that identity test cannot false-positive).
+    It is a **whole-row** group when every citekey that reached it did so via
+    its *own* top-level row value — the original "two citekeys, one anchored
+    mapping" case. Otherwise it is a **nested-alias** group: at least one
+    citekey reached the shared node only through something nested inside its
+    row (a nested row, a merge key, or a scalar), or the same citekey reached
+    it more than once from within its own row.
+
+    :param row_nodes: Each top-level citekey's own value node.
+    :param visits: Node id → the citekeys whose subtree reached it, as built
+        by :func:`_compose_row_visits`.
+    :returns: ``(whole_row_groups, nested_alias_groups)``, each a sorted list
+        of sorted citekey lists; empty when nothing is aliased.
+    """
+    whole: dict[int, tuple[str, ...]] = {}
+    nested: dict[int, tuple[str, ...]] = {}
+    for node_id, owners in visits.items():
+        if len(owners) <= 1:
+            continue
+        distinct = tuple(sorted(set(owners)))
+        if all(id(row_nodes.get(c)) == node_id for c in distinct):
+            whole[node_id] = distinct
+        else:
+            nested[node_id] = distinct
+    return (
+        [list(group) for group in sorted(set(whole.values()))],
+        [list(group) for group in sorted(set(nested.values()))],
+    )
+
+
+def _alias_groups(text: str) -> tuple[list[list[str]], list[list[str]]]:
+    """Return the citekey groups implicated by a YAML anchor/alias in ``text``.
+
+    This walks the **composed node graph** (``yaml.compose``), not the
+    ``yaml.safe_load``-constructed objects. That distinction is what makes the
+    check safe for scalars: CPython interns small integers and singletons like
+    ``True``/``False``, so two independently-written rows that both happen to
+    hold ``extracted: true`` would share ``id(True)`` with no YAML anchor
+    involved at all — a false positive if identity were tested on the
+    constructed values. A composed :class:`yaml.nodes.Node` carries no such
+    caching: every node is a fresh wrapper object regardless of the scalar it
+    holds, so two nodes are ever the same object only when the source text
+    actually used ``&anchor``/``*alias`` to make them so.
+
+    Two kinds of sharing are distinguished, because one of them is exactly the
+    pre-existing "two citekeys, one anchored mapping" case and keeps its
+    established message; see :func:`_classify_alias_groups` for exactly how:
+
+    - **whole-row** groups: every implicated citekey's *entire* top-level row
+      is the shared node (``a2020: &shared`` / ``b2021: *shared``) — the
+      original ``_aliased_rows`` case from ``bd60859``, now folded in here.
+    - **nested-alias** groups: the shared node is reachable from more than one
+      place but is not every implicated row's whole value — a row anchored at
+      the top level and aliased *inside* another row's nested value, a merge
+      key (``<<: *base``), or a scalar anchor (``rationale: *reason``) reused
+      anywhere, including within a single row.
+
+    :param text: The sidecar's YAML text. Assumed already validated by
+        :func:`triage_mapping` as either blank or a top-level mapping — the
+        only two shapes ``patch_triage`` calls this with.
+    :returns: ``(whole_row_groups, nested_alias_groups)``, each a sorted list
+        of sorted citekey lists; empty when nothing is aliased.
+    """
+    root = yaml.compose(text, Loader=yaml.SafeLoader)
+    if root is None:
+        return [], []
+    if not isinstance(root, yaml.MappingNode):  # pragma: no cover
+        # Unreachable in practice: triage_mapping already required text to be
+        # either blank or a top-level mapping before this is ever called.
+        return [], []
+    row_nodes, visits = _compose_row_visits(root)
+    return _classify_alias_groups(row_nodes, visits)
 
 
 def patch_triage(
@@ -600,20 +701,30 @@ def patch_triage(
     hand-authored while carrying, say, an extraction record for a paper nothing
     ever extracted. Inventing an audit-trail entry is worse than losing one, so
     this is refused as well, naming the rows that share an object.
-    :func:`_aliased_rows` tests object *identity*, which cannot false-positive:
-    two rows written out separately are distinct objects however alike they read.
 
-    .. warning::
-       One class of loss remains **unguarded** (defendable-science#143): an
-       anchored *scalar or nested value inside* a row (``rationale: *reason``)
-       is written back fully expanded. The data survives; the sharing does not.
-       A file using anchors that way should be hand-edited rather than patched.
+    It also covers every other shape a YAML anchor can take
+    (defendable-science#143), via :func:`_alias_groups`, which walks the
+    *composed node graph* rather than the constructed objects — the only way
+    to test true identity without false-positiving on interned scalars like
+    small ints or ``True``/``False``:
+
+    - A row anchored at the top level and aliased **inside another row's
+      nested value** (``a2020: &shared`` / ``b2021: {parent: *shared}``) is
+      refused the same as the whole-row case — patching ``a2020`` must not
+      silently write into ``b2021.parent`` too.
+    - A **merge key** (``<<: *base``) or a **scalar anchor**
+      (``rationale: *reason``), reused anywhere in the file — across rows or
+      within one row — is refused rather than silently expanded. Anchor names
+      cannot survive ``safe_dump`` either way; the previous behaviour lost
+      only the anchor label, but "loses a label silently" is still a silent
+      change this writer should not make on the human's behalf.
 
     :param path: The sidecar path (created if absent).
     :param citekey: The row to patch (created if absent).
     :param updates: Scalar keys to set; a ``None`` value deletes the key.
     :raises RegistryError: If the file carries comments, holds a row that is not
-        a mapping, holds two rows that are the same anchored mapping, is
+        a mapping, holds a YAML anchor aliased more than once anywhere in the
+        document (whole rows, nested values, merge keys, or scalars), is
         unreadable, or any update value is not a scalar.
     """
     for key, value in updates.items():
@@ -641,13 +752,24 @@ def patch_triage(
                 "writer cannot rewrite the file without dropping them, so it is "
                 f"refusing — set {sorted(updates)} on {citekey!r} by hand"
             )
-        shared = _aliased_rows(raw)
-        if shared:
+        whole, nested = _alias_groups(text)
+        if whole:
             raise RegistryError(
-                f"{target}: rows {shared} are the same mapping — citekeys joined "
+                f"{target}: rows {whole} are the same mapping — citekeys joined "
                 "by a YAML anchor. Setting a field on any one of them would set "
                 "it on all of them, recording work that was never done on the "
                 "others. So it is refusing — give each row its own keys, or set "
+                f"{sorted(updates)} on {citekey!r} by hand"
+            )
+        if nested:
+            raise RegistryError(
+                f"{target}: rows {nested} share a YAML anchor somewhere inside "
+                "them — a row anchored at the top level and aliased inside "
+                "another row's nested value, a merge key ('<<: *base'), or a "
+                "scalar anchor ('rationale: *reason'). Writing this back would "
+                "either silently propagate a change across rows that share the "
+                "anchor, or silently drop the anchor/alias structure entirely. "
+                "So it is refusing — remove the anchor, or set "
                 f"{sorted(updates)} on {citekey!r} by hand"
             )
         data: dict[str, Any] = {str(key): row for key, row in raw.items()}

--- a/defendable-science/tests/test_lit_registry.py
+++ b/defendable-science/tests/test_lit_registry.py
@@ -696,6 +696,30 @@ def test_patch_triage_refuses_a_row_aliased_inside_a_list(tmp_path: Path) -> Non
     assert path.read_bytes() == before
 
 
+def test_patch_triage_refuses_a_self_referential_anchor_without_crashing(
+    tmp_path: Path,
+) -> None:
+    """A row aliased into its own nested value makes the node graph cyclic.
+
+    ``&anchor`` inside the row it names, aliased back into itself
+    (``a2020: &shared {..., self: *shared}``), is a legitimate composed shape
+    — a plausible typo, not malformed YAML — and must be refused like any
+    other anchor reuse, not crash with a ``RecursionError``.
+    """
+    path = tmp_path / "t.yml"
+    path.write_text(
+        "a2020: &shared\n  disposition: screened\n  self: *shared\n",
+        encoding="utf-8",
+    )
+    before = path.read_bytes()
+
+    with pytest.raises(reg.RegistryError) as caught:
+        reg.patch_triage(path, "a2020", {"extracted": "2026-08-28"})
+
+    assert "a2020" in str(caught.value)
+    assert path.read_bytes() == before
+
+
 def test_patch_triage_refuses_a_merge_key_reuse(tmp_path: Path) -> None:
     """A merge key (`<<: *base`) is refused by name, not silently expanded."""
     path = tmp_path / "t.yml"

--- a/defendable-science/tests/test_lit_registry.py
+++ b/defendable-science/tests/test_lit_registry.py
@@ -624,6 +624,173 @@ def test_patch_triage_does_not_refuse_rows_that_merely_look_alike(
     assert "extracted" not in rows["b2021"].raw
 
 
+def test_patch_triage_refuses_blank_file_without_choking_on_composing_it(
+    tmp_path: Path,
+) -> None:
+    """A blank *existing* file composes to ``None`` — not a mapping to walk."""
+    path = tmp_path / "t.yml"
+    path.write_text("", encoding="utf-8")
+    reg.patch_triage(path, "k", {"disposition": "screened"})
+    assert reg.load_triage(path)["k"].disposition == "screened"
+
+
+# --- #143: a row anchored at the top level, aliased *inside* another row's ----
+# nested value. The bd60859 guard only buckets top-level rows by id() and does
+# not walk into a row's nested values, so this shape slipped through: patching
+# `a2020` silently wrote `extracted`/`extraction-cells` into `b2021.parent` too,
+# and `patch_triage` returned exit 0 as a clean success.
+
+NESTED_ALIAS_TRIAGE = (
+    "a2020: &shared\n"
+    "  disposition: screened\n"
+    "  rationale: superseded by the 2023 revision\n"
+    "b2021:\n"
+    "  disposition: screened\n"
+    "  parent: *shared\n"
+)
+
+
+def test_patch_triage_refuses_a_row_aliased_inside_another_rows_nested_value(
+    tmp_path: Path,
+) -> None:
+    """The issue's exact repro: `a2020` reachable both at top level and nested."""
+    path = tmp_path / "t.yml"
+    path.write_text(NESTED_ALIAS_TRIAGE, encoding="utf-8")
+    before = path.read_bytes()
+
+    with pytest.raises(reg.RegistryError) as caught:
+        reg.patch_triage(
+            path, "a2020", {"extracted": "2026-08-28", "extraction-cells": 8}
+        )
+
+    message = str(caught.value)
+    assert "a2020" in message
+    assert "b2021" in message
+    assert "'extracted'" in message
+    assert "'extraction-cells'" in message
+    # No write happened at all — b2021.parent must not have gained the fields.
+    assert path.read_bytes() == before
+    assert not (tmp_path / "t.yml.tmp").exists()
+
+
+def test_patch_triage_refuses_a_row_aliased_inside_a_list(tmp_path: Path) -> None:
+    """The same nested-alias hazard, one level deeper: inside a sequence."""
+    path = tmp_path / "t.yml"
+    path.write_text(
+        "a2020: &shared\n"
+        "  disposition: screened\n"
+        "b2021:\n"
+        "  disposition: screened\n"
+        "  related:\n"
+        "    - *shared\n",
+        encoding="utf-8",
+    )
+    before = path.read_bytes()
+
+    with pytest.raises(reg.RegistryError) as caught:
+        reg.patch_triage(path, "a2020", {"extracted": "2026-08-28"})
+
+    message = str(caught.value)
+    assert "a2020" in message
+    assert "b2021" in message
+    assert path.read_bytes() == before
+
+
+def test_patch_triage_refuses_a_merge_key_reuse(tmp_path: Path) -> None:
+    """A merge key (`<<: *base`) is refused by name, not silently expanded."""
+    path = tmp_path / "t.yml"
+    path.write_text(
+        "base: &base\n"
+        "  disposition: screened\n"
+        "a2020:\n"
+        "  <<: *base\n"
+        "  rationale: templated\n",
+        encoding="utf-8",
+    )
+    before = path.read_bytes()
+
+    with pytest.raises(reg.RegistryError) as caught:
+        reg.patch_triage(path, "a2020", {"extracted": "2026-08-28"})
+
+    message = str(caught.value)
+    assert "a2020" in message
+    assert "base" in message
+    assert "anchor" in message
+    assert path.read_bytes() == before
+
+
+def test_patch_triage_refuses_a_scalar_anchor_reuse(tmp_path: Path) -> None:
+    """A scalar anchor (`rationale: *reason`) reused across rows is refused."""
+    path = tmp_path / "t.yml"
+    path.write_text(
+        "a2020:\n"
+        "  disposition: screened\n"
+        "  rationale: &reason superseded by the 2023 revision\n"
+        "b2021:\n"
+        "  disposition: screened\n"
+        "  rationale: *reason\n",
+        encoding="utf-8",
+    )
+    before = path.read_bytes()
+
+    with pytest.raises(reg.RegistryError) as caught:
+        reg.patch_triage(path, "a2020", {"extracted": "2026-08-28"})
+
+    message = str(caught.value)
+    assert "a2020" in message
+    assert "b2021" in message
+    assert "anchor" in message
+    assert path.read_bytes() == before
+
+
+def test_patch_triage_refuses_a_scalar_anchor_reused_within_one_row(
+    tmp_path: Path,
+) -> None:
+    """The same posture applies with no cross-row leak at all: still refused.
+
+    Per #143's acceptance criteria, a merge key or scalar anchor is "either
+    survives or is refused — not silently expanded" unconditionally, even when
+    every alias of the anchor sits inside the single row being patched.
+    """
+    path = tmp_path / "t.yml"
+    path.write_text(
+        "a2020:\n"
+        "  disposition: screened\n"
+        "  rationale: &reason same story\n"
+        "  note: *reason\n",
+        encoding="utf-8",
+    )
+    before = path.read_bytes()
+
+    with pytest.raises(reg.RegistryError) as caught:
+        reg.patch_triage(path, "a2020", {"extracted": "2026-08-28"})
+
+    message = str(caught.value)
+    assert "a2020" in message
+    assert "anchor" in message
+    assert path.read_bytes() == before
+
+
+def test_patch_triage_on_an_accepted_sidecar_changes_only_the_named_row(
+    tmp_path: Path,
+) -> None:
+    """A negative test on a plain, alias-free sidecar with several rows."""
+    path = tmp_path / "t.yml"
+    path.write_text(
+        "a2020:\n  disposition: screened\n"
+        "b2021:\n  disposition: exclude\n"
+        "c2022:\n  disposition: inbox\n",
+        encoding="utf-8",
+    )
+    reg.patch_triage(path, "b2021", {"extracted": "2026-08-28", "extraction-cells": 8})
+    rows = reg.load_triage(path)
+    assert rows["b2021"].raw["extracted"] == "2026-08-28"
+    assert rows["b2021"].raw["extraction-cells"] == 8
+    for citekey in ("a2020", "c2022"):
+        assert "extracted" not in rows[citekey].raw
+        assert "extraction-cells" not in rows[citekey].raw
+
+
 def test_patch_triage_keeps_a_non_string_citekey_addressable(tmp_path: Path) -> None:
     """A YAML key that is not a string (``2020:``) is still a row, not a casualty."""
     path = tmp_path / "t.yml"


### PR DESCRIPTION
## What

`literature.registry.patch_triage` now refuses (instead of silently
corrupting or expanding) every remaining shape of YAML anchor/alias reuse in
a triage sidecar:

- A row anchored at the top level and aliased *inside* another row's nested
  value (the issue's exact repro: `a2020: &shared` / `b2021: {parent:
  *shared}`) — previously patched `a2020` and silently wrote into
  `b2021.parent` too, at exit 0.
- Merge keys (`<<: *base`) and scalar anchors (`rationale: *reason`), reused
  anywhere in the file (across rows or within one row) — previously silently
  expanded, losing the anchor structure with no signal.
- A self-referential anchor (`a: &s {self: *s}`) — a legitimate composed-node
  shape that the first version of this fix crashed on with a
  `RecursionError`; now refused cleanly like any other alias reuse.

The whole-row alias case from `bd60859` is preserved unchanged (same
message), as is the comment refusal, the non-mapping-row refusal, and the
`test_patch_triage_does_not_refuse_rows_that_merely_look_alike`
over-correction guard.

## Why

`yaml.safe_load` gives every alias of an anchor the *same* Python object, so
identity is normally the safe way to detect true sharing — that's how the
existing whole-row guard works. But extending that same technique to scalars
is unsafe: CPython interns small ints and singletons like `True`/`False`, so
two independently-written rows that happen to both hold `extracted: true`
would share `id(True)` with no anchor involved at all. This fix instead
walks the **composed node graph** (`yaml.compose`), where identity reflects
genuine YAML-level aliasing regardless of the scalar a node holds.

## Closes

Closes #143.

## Test plan

- [x] `uv run pytest -q` — 1452 passed, 100% coverage
- [x] `uv run mypy` — clean
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `codespell` on changed files — clean
- [x] Manual repro of the issue's exact YAML before/after the fix
- [x] Adversarial review pass (self-reference, unused anchor, cross-row
      third-party alias) — the self-referential case surfaced a
      `RecursionError` regression, fixed in the second commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
