### PR TITLE
fix(literature): clean up patch_triage's orphan .tmp on a failed write

### DIFF
--- a/defendable-science/defendable_science/literature/registry.py
+++ b/defendable-science/defendable_science/literature/registry.py
@@ -737,13 +737,25 @@ def patch_triage(
       only the anchor label, but "loses a label silently" is still a silent
       change this writer should not make on the human's behalf.
 
+    The write itself is **atomic**: the new content lands in a sibling
+    ``<name>.tmp`` first, which then replaces the target in one filesystem
+    operation, so a crash mid-write can never leave a half-written sidecar. If
+    either the write or the replace raises, the ``.tmp`` file is removed before
+    the exception propagates (defendable-science#144) — a failed patch leaves
+    the directory exactly as it found it, not a stray ``triage.yml.tmp`` next
+    to an untouched ``triage.yml`` for the human to puzzle over while doing the
+    by-hand edit the refusal already sent them to do.
+
     :param path: The sidecar path (created if absent).
     :param citekey: The row to patch (created if absent).
     :param updates: Scalar keys to set; a ``None`` value deletes the key.
-    :raises RegistryError: If the file carries comments, holds a row that is not
-        a mapping, holds a YAML anchor aliased more than once anywhere in the
-        document (whole rows, nested values, merge keys, or scalars), is
-        unreadable, or any update value is not a scalar.
+    :raises RegistryError: If the file carries invalid YAML, comments, holds a
+        row that is not a mapping, holds a YAML anchor aliased more than once
+        anywhere in the document (whole rows, nested values, merge keys, or
+        scalars), or any update value is not a scalar.
+    :raises OSError: If the file cannot be read, or the atomic write/replace
+        itself fails (e.g. a full disk or a permission error); no orphan
+        ``.tmp`` file is left behind either way.
     """
     for key, value in updates.items():
         if value is not None and not isinstance(value, (str, int, bool)):
@@ -799,8 +811,24 @@ def patch_triage(
             row.pop(key, None)
         else:
             row[key] = value
+    _write_triage_atomically(target, data)
+
+
+def _write_triage_atomically(target: Path, data: dict[str, Any]) -> None:
+    """Write `data` to `target` via a sibling ``.tmp``, cleaned up on failure.
+
+    :param target: The sidecar path to write.
+    :param data: The full top-level mapping to serialize.
+    :raises OSError: If the write or the replace fails; no orphan ``.tmp`` file
+        is left behind either way (defendable-science#144).
+    """
     tmp = target.with_name(target.name + ".tmp")
-    tmp.write_text(
-        yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encoding="utf-8"
-    )
-    tmp.replace(target)
+    try:
+        tmp.write_text(
+            yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+        tmp.replace(target)
+    except OSError:
+        tmp.unlink(missing_ok=True)
+        raise

--- a/defendable-science/tests/test_lit_registry.py
+++ b/defendable-science/tests/test_lit_registry.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 
 import pytest
 
 from defendable_science.literature import registry as reg
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _write(path: Path, items: list[dict[str, Any]]) -> Path:
@@ -477,6 +475,47 @@ def test_patch_triage_creates_a_missing_file(tmp_path: Path) -> None:
     path = tmp_path / "t.yml"
     reg.patch_triage(path, "k", {"disposition": "screened"})
     assert reg.load_triage(path)["k"].disposition == "screened"
+
+
+# --- #144: a failed atomic replace must not leave an orphan .tmp ---------------
+
+
+def test_patch_triage_removes_the_tmp_file_when_replace_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`tmp.replace(target)` raising leaves no `.tmp` beside the untouched file."""
+    path = tmp_path / "t.yml"
+    original = "k:\n  disposition: inbox\n"
+    path.write_text(original, encoding="utf-8")
+
+    def _boom(self: Path, _target: Path) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "replace", _boom)
+    with pytest.raises(OSError, match="disk full"):
+        reg.patch_triage(path, "k", {"disposition": "screened"})
+
+    assert path.read_text(encoding="utf-8") == original
+    assert not (tmp_path / "t.yml.tmp").exists()
+
+
+def test_patch_triage_removes_the_tmp_file_when_write_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`tmp.write_text` raising is also cleaned up, even though nothing landed."""
+    path = tmp_path / "t.yml"
+    original = "k:\n  disposition: inbox\n"
+    path.write_text(original, encoding="utf-8")
+
+    def _boom(self: Path, *_args: object, **_kwargs: object) -> None:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "write_text", _boom)
+    with pytest.raises(OSError, match="permission denied"):
+        reg.patch_triage(path, "k", {"disposition": "screened"})
+
+    assert path.read_text(encoding="utf-8") == original
+    assert not (tmp_path / "t.yml.tmp").exists()
 
 
 # --- the write must not lose a row a reader cannot see -------------------------


### PR DESCRIPTION
## What

`patch_triage`'s atomic write (write to a sibling `<name>.tmp`, then
`replace()` it onto the target) now cleans up the `.tmp` file before
re-raising whenever either step fails, instead of leaving it behind.

## Why

Nothing is lost on a failed write today — the sidecar is untouched, which is
the point of the atomic write. But the orphan `.tmp` file sits right where
the caller's failure message already sends the human to edit the sidecar by
hand, leaving two files where the tool named one, with no way to tell which
is authoritative. `digest extract record` calls `patch_triage` once per paper
across a survey batch, so a persistent failure (read-only directory, full
disk) leaves one orphan per attempt rather than one ever.

The fix matches the same `except: path.unlink(missing_ok=True); raise`
pattern already used for this exact reason elsewhere in the codebase
(`literature/acquire.py`, `core/download.py`).

## Closes

Closes #144.

## Test plan

- [x] `uv run pytest -q` — 1446 passed, 100% coverage
- [x] `uv run mypy` / `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `codespell` on changed files — clean
- [x] New tests simulate both a failed `write_text` and a failed `replace`
      (via `monkeypatch`), asserting the original exception propagates
      unchanged, the sidecar is byte-identical, and no `.tmp` file remains
- [x] Manual repro: patched `Path.replace` to raise `OSError`, confirmed only
      `t.yml` remains in the directory afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)
