### PR TITLE
fix(defend): anchor defend record --log-dir's default to the layout

### DIFF
--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -1734,9 +1734,12 @@ def record(
     transcript: Annotated[
         str, typer.Option("--transcript", help="Transcript file, or '-' for stdin.")
     ] = "",
-    log_dir: Annotated[str, typer.Option("--log-dir")] = str(
-        record_mod.DEFAULT_LOG_DIR
-    ),
+    log_dir: Annotated[
+        str | None,
+        typer.Option(
+            "--log-dir", help="Accountability log; from the layout if omitted."
+        ),
+    ] = None,
 ) -> None:
     """Record a ``defend``/``digest`` examination: patch understanding + log.
 
@@ -1753,9 +1756,19 @@ def record(
     :param override: A blanket logged override of the surfaced gaps.
     :param acks: Per-gap acknowledgements, ``gap::name``, ``||``-separated.
     :param transcript: Transcript file path, or ``-`` for stdin.
-    :param log_dir: Directory for the accountability log.
+    :param log_dir: Directory for the accountability log; the layout's
+        ``defend-log`` when omitted. The default comes from the layout rather
+        than the cwd because this command is meant to be run from inside a
+        paper directory, and a cwd-relative default would bury the run's
+        evidence there, where no reviewer would look for it.
     :raises typer.Exit: Code 1 on a guard violation or malformed artifact/input.
     """
+    _config, layout = _layout_or_exit()
+    log_root = (
+        Path(log_dir)
+        if log_dir is not None
+        else layout.research_root / record_mod.DEFAULT_LOG_DIR.name
+    )
     try:
         transcript_text: str | None = None
         if transcript == "-":
@@ -1778,7 +1791,7 @@ def record(
             override=override,
             acknowledgements=_parse_acks(acks),
             transcript=transcript_text,
-            log_dir=log_dir,
+            log_dir=log_root,
         )
     except (record_mod.RecordError, OSError) as exc:
         typer.echo(f"defend record failed: {exc}", err=True)

--- a/defendable-science/tests/test_record.py
+++ b/defendable-science/tests/test_record.py
@@ -352,6 +352,36 @@ def test_cli_record(tmp_path: Path) -> None:
     assert json.loads(result.stdout)["outcome"] == "resolved"
 
 
+def test_cli_record_logs_under_the_layout_not_the_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Run from inside a paper, the log must not land in that paper's tree.
+
+    Reproduces defendable-science#140: a relative ``DEFAULT_LOG_DIR`` resolves
+    against the cwd, and ``defend``/``digest`` are meant to be run from inside
+    a paper directory, so the un-anchored default silently buries the log in
+    a second, nested ``docs/research/defend-log`` under the paper it examined.
+    """
+    (tmp_path / ".defendable-science").mkdir()
+    (tmp_path / ".defendable-science" / "config.yml").write_text("", encoding="utf-8")
+    paper_dir = tmp_path / "docs" / "research" / "p1" / "paper"
+    paper_dir.mkdir(parents=True)
+    artifact = paper_dir / "findings.md"
+    artifact.write_text(_ARTIFACT, encoding="utf-8")
+
+    monkeypatch.chdir(paper_dir)
+    result = runner.invoke(
+        app,
+        ["defend", "record", "--artifact", "findings.md", "--target", "methodology"],
+    )
+
+    assert result.exit_code == 0, result.stderr
+    assert not (paper_dir / "docs").exists()
+    entries = sorted((tmp_path / "docs" / "research" / "defend-log").iterdir())
+    assert len(entries) == 1
+    assert json.loads(result.stdout)["log_entry"] == str(entries[0])
+
+
 def test_cli_record_transcript_from_stdin(tmp_path: Path) -> None:
     artifact = _artifact(tmp_path)
     result = runner.invoke(


### PR DESCRIPTION
## What

`defend record --log-dir`'s default now anchors to the resolved layout
(`layout.research_root / "defend-log"`) instead of resolving the relative
default `docs/research/defend-log` against the current working directory. An
explicit `--log-dir` still wins.

## Why

`defend`/`digest` are meant to be run from inside a paper directory, so the
natural cwd is a paper directory — and there the un-anchored relative default
silently created a second, nested log tree under the paper it examined:

```
$ cd docs/research/p1/paper
$ defendable-science defend record --artifact positioning.md --target claim
{"outcome": "resolved", ...}
$ find . -path "*defend-log*"
./docs/research/p1/paper/docs/research/defend-log/2026-08-28-positioning.yml
```

Exit code 0, no error, and the evidentiary trail lands where no reviewer
would ever look. This is the same class of bug already found and fixed for
`digest extract record` (#100) — `defend record` predates the layout module
(#122, ADR-0039) and was deliberately left alone at the time, out of that
change's scope. This issue is that fix.

## Closes

Closes #140.

## Test plan

- [x] `uv run pytest -q` — 1445 passed, 100% coverage
- [x] `uv run mypy` / `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `codespell` on changed files — clean
- [x] New test reproduces the issue exactly: chdir into a nested paper
      directory, omit `--log-dir`, assert the log lands under the
      repo-root layout's `defend-log`, and that no nested `docs/` tree is
      created under the paper directory
- [x] Manual repro of the issue's exact `cd docs/research/p1/paper` scenario
      against the built CLI — log now lands at
      `<root>/docs/research/defend-log/`, not nested under the paper

🤖 Generated with [Claude Code](https://claude.com/claude-code)
