### PR TITLE
fix(digest): name the extraction log entry from the citekey, not the artifact's stem

### DIFF
--- a/defendable-science/defendable_science/defend/record.py
+++ b/defendable-science/defendable_science/defend/record.py
@@ -305,7 +305,12 @@ def append_log_entry(log_dir: Path, date: str, stem: str, body: str) -> Path:
 
     :param log_dir: The accountability-log directory (created if absent).
     :param date: ISO date, used as the filename prefix.
-    :param stem: The artifact stem, used as the filename body.
+    :param stem: What a reader would search the log directory for, used as the
+        filename body — ``defend record`` passes the examined artifact's own
+        filename stem, while ``digest extract record`` passes the paper's
+        citekey (defendable-science#146) rather than the digest artifact's
+        stem, so the entry stays named after the paper even if the artifact's
+        naming scheme changes.
     :param body: The rendered YAML to write.
     :returns: The path written.
     """

--- a/defendable-science/defendable_science/digest/artifact.py
+++ b/defendable-science/defendable_science/digest/artifact.py
@@ -469,7 +469,10 @@ def write_extraction(
     :param log_dir: The accountability-log directory (`DEFAULT_LOG_DIR`).
     :param date: ISO date, for ``status.last-updated`` and the log entry.
     :returns: The accountability-log entry written — the one path the caller
-        does not already hold.
+        does not already hold. Named from the paper's citekey
+        (defendable-science#146), not from the artifact's filename — the log
+        entry stays joined to the paper it records even if `Layout.digest`'s
+        naming scheme ever changes.
     :raises ExtractionError: If the cells are empty, span more than one paper,
         or would not survive validation; if `batch_check` is not a known
         verdict; or if the existing artifact's frontmatter is malformed.
@@ -497,7 +500,7 @@ def write_extraction(
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(rebuild(fm_lines, body), encoding="utf-8")
     return append_log_entry(
-        Path(log_dir), date, path.stem, _log_body(path, citekey, cells, date)
+        Path(log_dir), date, citekey, _log_body(path, citekey, cells, date)
     )
 
 

--- a/defendable-science/tests/test_digest_artifact.py
+++ b/defendable-science/tests/test_digest_artifact.py
@@ -245,6 +245,26 @@ def test_the_log_entry_records_every_cell_including_the_absences(
     ]
 
 
+def test_the_log_entry_is_named_from_the_citekey_not_the_artifacts_stem(
+    tmp_path: Path,
+) -> None:
+    """Pins defendable-science#146: the join must survive `Layout.digest` changing.
+
+    Today ``Layout.digest`` happens to name the artifact ``<citekey>.md``, so a
+    log entry named from ``path.stem`` coincides with one named from the
+    citekey — for every path through the code. This writes the artifact at a
+    filename that deliberately does *not* match its citekey, so the two would
+    diverge if the log entry were still keyed off the file's stem.
+    """
+    log_dir = tmp_path / "defend-log"
+    artifact_path = tmp_path / "digest-2026-not-the-citekey.md"
+    entry_path = _write(artifact_path, log_dir)
+
+    assert entry_path == log_dir / f"{DATE}-{CITEKEY}.yml"
+    entry = yaml.safe_load(entry_path.read_text(encoding="utf-8"))[0]
+    assert entry["citekey"] == CITEKEY
+
+
 def test_a_second_extraction_the_same_day_never_overwrites_the_first(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What

`digest extract record`'s accountability-log entry is now named from the
paper's citekey (`write_extraction` already had `_one_citekey(cells)` in
scope), not from the digest artifact's filename stem — matching what
`append_check_log` already does for the batch-sample verdict log entry.

## Why

`Layout.digest` currently names every artifact `<citekey>.md`, so `path.stem`
and the citekey happen to coincide for every path through the code today —
this is latent, not a live bug. But nothing pinned the two together: change
the artifact naming scheme (a `digest-` prefix, a per-year subdirectory, a
slugged title) and the log entries would silently start filing under a
different name than the cells they record, with no error at any layer,
desynchronizing the join between an append-only evidence entry and the paper
it's about.

Updated the docstrings of `write_extraction` and the shared
`append_log_entry` (`:param stem:`) to say what the stem is now expected to
identify, since two different callers feed it different things: `defend
record` passes the examined artifact's own filename, extraction passes the
paper's citekey.

## Closes

Closes #146.

## Test plan

- [x] `uv run pytest -q` — 1445 passed, 100% coverage
- [x] `uv run mypy` / `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uvx pre-commit run --all-files` — clean
- [x] `codespell` on changed files — clean
- [x] New test constructs the digest artifact at a deliberately
      non-`<citekey>.md` path and asserts the log entry is still named from
      the citekey — fails if `Layout.digest`'s naming scheme ever changes
      and the log entry silently followed it
- [x] No change to the log entry's contents (`_log_body` already carries the
      citekey explicitly as the authoritative field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
