### PR TITLE
fix(core): close the fence-handling gaps in mdtable and extraction's heading probe

### DIFF
--- a/defendable-science/defendable_science/core/mdtable.py
+++ b/defendable-science/defendable_science/core/mdtable.py
@@ -17,9 +17,33 @@ Row = dict[str, str]
 #: A markdown heading of any level, with its title text.
 _HEADING = re.compile(r"^#{1,6}\s+(?P<title>.+?)\s*$")
 
-#: A CommonMark fenced-code-block marker: up to three spaces of indent, then at
-#: least three backticks or tildes, then the info string.
-_FENCE = re.compile(r"^ {0,3}(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
+#: A backtick fence: any amount of leading-space indent (see the indent note on
+#: :func:`_fenced`), then three or more backticks, then an info string. Per
+#: CommonMark, a *backtick* fence's info string may not itself contain a
+#: backtick — otherwise a paragraph that merely starts with three backticks
+#: and goes on to mention another one would wrongly open a fence that is never
+#: closed. ``[^`]*`` enforces that; it may still be empty.
+_BACKTICK_FENCE = re.compile(r"^(?P<indent> *)(?P<fence>`{3,})(?P<info>[^`]*)$")
+
+#: A tilde fence: same shape, but CommonMark does not restrict its info
+#: string — a tilde fence is exactly what a backtick-restricted info string
+#: would need to escape into, so the exemption is deliberate, not an
+#: oversight.
+_TILDE_FENCE = re.compile(r"^(?P<indent> *)(?P<fence>~{3,})(?P<info>.*)$")
+
+
+def _fence_match(line: str) -> re.Match[str] | None:
+    """Return the fence-opener/closer match for `line`, backtick or tilde.
+
+    Tried as two separate patterns (rather than one with an alternation)
+    because Python's `re` cannot give the backtick and tilde branches of one
+    alternation the same group names, and the caller wants one shape
+    (``indent``/``fence``/``info``) regardless of which delimiter matched.
+
+    :param line: One document line, newline already stripped.
+    :returns: The match, or ``None`` if `line` opens or closes neither kind.
+    """
+    return _BACKTICK_FENCE.match(line) or _TILDE_FENCE.match(line)
 
 
 def _fenced(lines: list[str]) -> list[bool]:
@@ -35,16 +59,34 @@ def _fenced(lines: list[str]) -> list[bool]:
     Closing follows CommonMark: the same character as the opening fence, at
     least as long, and no info string. An unclosed fence runs to the end.
 
+    Indent, a deliberate approximation: CommonMark caps a fence at three
+    spaces of indent **at the document's top level** — four or more there is
+    an indented code block instead, not a fence. But block content inside a
+    list item is indented relative to the item's own marker, so a fence
+    legitimately sits at four or more columns there, and this module does not
+    track list-item nesting to know which regime a given line is in. Rather
+    than re-deriving that (a real chunk of CommonMark's container-block
+    algorithm), an opener is accepted at *any* indent, and a closer must be
+    indented at least as far as its opener (CommonMark itself allows a closer
+    up to three spaces regardless of the opener's indent; this module trades
+    that precision for not having to track containers). Both directions of
+    error this can introduce only make `_fenced` claim *more* of the document
+    as fenced, never less — consistent with the module's "conservative on
+    purpose" contract of hiding a possible illustration rather than risking
+    it read as real content.
+
     :param lines: The document's lines.
     :returns: One flag per line, ``True`` when the line is fenced.
     """
     mask = [False] * len(lines)
     marker: str | None = None
+    marker_indent = 0
     for i, line in enumerate(lines):
-        match = _FENCE.match(line.rstrip("\n"))
+        match = _fence_match(line.rstrip("\n"))
         if marker is None:
             if match is not None:
                 marker = match.group("fence")
+                marker_indent = len(match.group("indent"))
                 mask[i] = True
             continue
         mask[i] = True
@@ -53,6 +95,7 @@ def _fenced(lines: list[str]) -> list[bool]:
             and match.group("fence")[0] == marker[0]
             and len(match.group("fence")) >= len(marker)
             and not match.group("info").strip()
+            and len(match.group("indent")) >= marker_indent
         ):
             marker = None
     return mask
@@ -186,6 +229,48 @@ def _collect_rows(
     return rows, end
 
 
+def _headings(lines: list[str], fenced: list[bool]) -> list[tuple[int, str]]:
+    """Return every heading's ``(index, casefolded title)``, fence-aware.
+
+    Shared by :func:`_section_bounds` and :func:`find_headings` so "scan the
+    document for headings by title" has exactly one implementation — a
+    ``#``-prefixed line inside a code block is a comment or a shell prompt,
+    not a heading, and neither caller should re-derive that rule.
+
+    :param lines: The document's lines.
+    :param fenced: Per-line fence flags from :func:`_fenced`.
+    :returns: Every heading, in document order.
+    """
+    headings: list[tuple[int, str]] = []
+    for i, line in enumerate(lines):
+        if fenced[i]:
+            continue
+        match = _HEADING.match(line)
+        if match is not None:
+            headings.append((i, match.group("title").strip().casefold()))
+    return headings
+
+
+def find_headings(text: str, title: str) -> list[int]:
+    """Return the 0-based line indices of headings matching `title`.
+
+    Fence-aware: a heading merely *shown* inside a code block (documentation,
+    an example) is not a match — the same rule :func:`parse_document` and
+    :func:`_section_bounds` apply when they decide whether a section exists.
+    Exported so a caller that only wants to know "does this section exist at
+    all" (as opposed to locating and reading it) does not have to fall back to
+    a fence-blind regex to ask that question.
+
+    :param text: The host markdown document.
+    :param title: The heading text to find, compared case-insensitively.
+    :returns: The matching headings' line indices, in document order.
+    """
+    lines = text.splitlines(keepends=True)
+    fenced = _fenced(lines)
+    want = title.strip().casefold()
+    return [i for i, heading_title in _headings(lines, fenced) if heading_title == want]
+
+
 def _section_bounds(
     lines: list[str], title: str, fenced: list[bool]
 ) -> tuple[int, int] | None:
@@ -206,13 +291,7 @@ def _section_bounds(
         silently, since the document parses perfectly well either way.
     """
     want = title.strip().casefold()
-    headings: list[tuple[int, str]] = []
-    for i, line in enumerate(lines):
-        if fenced[i]:
-            continue
-        match = _HEADING.match(line)
-        if match is not None:
-            headings.append((i, match.group("title").strip().casefold()))
+    headings = _headings(lines, fenced)
     matches = [i for i, heading in enumerate(headings) if heading[1] == want]
     if len(matches) > 1:
         raise AmbiguousSectionError(

--- a/defendable-science/defendable_science/digest/extraction.py
+++ b/defendable-science/defendable_science/digest/extraction.py
@@ -20,6 +20,7 @@ from defendable_science.core.mdtable import (
     AmbiguousSectionError,
     Row,
     TableError,
+    find_headings,
     parse_document,
 )
 
@@ -34,14 +35,6 @@ SELF_ROW = "**This paper**"
 
 #: An unreplaced template placeholder, e.g. ``<attr 1>`` or ``<prior work>``.
 PLACEHOLDER_RE = re.compile(r"^<[^>]*>$")
-
-#: The concept-matrix heading as a line, matched the way the parser matches it:
-#: any level, case-insensitively (see ``core.mdtable._section_bounds``). Used
-#: only to tell "no such section" apart from "section, but no table".
-_MATRIX_HEADING_LINE = re.compile(
-    rf"^#{{1,6}}\s+{re.escape(CONCEPT_MATRIX_HEADING)}\s*$",
-    re.IGNORECASE | re.MULTILINE,
-)
 
 
 class ExtractionError(ValueError):
@@ -112,7 +105,7 @@ def read_matrix(path: str | Path) -> Matrix:
             f"{target}: {exc} — give every row one cell per header column"
         ) from exc
     if doc.header is None:
-        if _MATRIX_HEADING_LINE.search(text) is None:
+        if not find_headings(text, CONCEPT_MATRIX_HEADING):
             raise ExtractionError(
                 f"{target}: no '{CONCEPT_MATRIX_HEADING}' section — ask the "
                 "`literature` skill for `position --level paper` to write one"

--- a/defendable-science/tests/test_extraction.py
+++ b/defendable-science/tests/test_extraction.py
@@ -86,6 +86,23 @@ def test_the_missing_section_remedy_is_a_skill_request_not_a_shell_command(
     assert "`literature position" not in message
 
 
+def test_a_heading_only_inside_a_fence_reports_no_section(tmp_path: Path) -> None:
+    """Issue #145 case A: a fence-blind probe would offer the wrong remedy.
+
+    The document's only ``## Concept matrix`` heading sits inside a code
+    fence, so the fence-aware parser correctly finds no section. The
+    discriminator between "no section" and "section, but no table" must agree
+    — reporting "holds no table" here would send the author to add a matrix
+    to a section that does not exist.
+    """
+    text = "# P\n\n```\n## Concept matrix\n```\n"
+    with pytest.raises(ex.ExtractionError, match="no 'Concept matrix'") as caught:
+        ex.axes_from_positioning(_write(tmp_path, text))
+    message = str(caught.value)
+    assert "ask the `literature` skill" in message
+    assert "holds no table" not in message
+
+
 def test_a_differently_cased_heading_still_reports_the_missing_table(
     tmp_path: Path,
 ) -> None:

--- a/defendable-science/tests/test_mdtable.py
+++ b/defendable-science/tests/test_mdtable.py
@@ -342,3 +342,88 @@ def test_an_unwindowed_ragged_table_after_the_first_is_still_ignored() -> None:
     """`backlog.py`'s guarantee: a later sloppy table is not this caller's problem."""
     text = "| a | b |\n|---|---|\n| 1 | 2 |\n\nprose\n\n| x |\n|---|\n| 1 | 2 |\n"
     assert md.parse_document(text).header == ["a", "b"]
+
+
+# --- find_headings (issue #145, case A) -----------------------------------------
+
+
+def test_find_headings_locates_a_matching_heading() -> None:
+    text = "# Doc\n\n## Concept matrix\n\nprose\n"
+    assert md.find_headings(text, "Concept matrix") == [2]
+
+
+def test_find_headings_is_case_insensitive_and_strips_the_title() -> None:
+    text = "### concept MATRIX\n\nprose\n"
+    assert md.find_headings(text, "  Concept Matrix  ") == [0]
+
+
+def test_find_headings_returns_empty_for_no_match() -> None:
+    assert md.find_headings("# Doc\n\nprose\n", "Concept matrix") == []
+
+
+def test_find_headings_ignores_a_heading_shown_inside_a_fence() -> None:
+    text = "# Doc\n\n```\n## Concept matrix\n```\n\nprose\n"
+    assert md.find_headings(text, "Concept matrix") == []
+
+
+def test_find_headings_reports_every_match_for_ambiguity_callers() -> None:
+    text = "## Concept matrix\n\nprose\n\n### concept matrix\n\nmore\n"
+    assert md.find_headings(text, "Concept matrix") == [0, 4]
+
+
+# --- fence-indent inside a list item (issue #145, case B) -----------------------
+
+
+def test_a_fence_indented_inside_a_list_item_is_detected() -> None:
+    lines = ["- item", "", "    ```", "    | a |", "    |---|", "    ```"]
+    assert md._fenced(lines) == [False, False, True, True, True, True]
+
+
+def test_a_fenced_list_item_table_is_not_selected_as_the_document_s_table() -> None:
+    text = "- item\n\n    ```\n    | a |\n    |---|\n    | fake |\n    ```\n\nprose\n"
+    doc = md.parse_document(text)
+    assert doc.header is None
+    assert doc.preamble == text
+
+
+def test_splice_does_not_overwrite_a_fenced_table_inside_a_list_item() -> None:
+    text = (
+        "- item\n\n    ```\n    | a |\n    |---|\n    | fake |\n    ```\n\n"
+        "| Method | axis |\n|---|---|\n| real | value |\n"
+    )
+    doc = md.parse_document(text)
+    assert doc.header == ["Method", "axis"]
+    out = md.splice(doc.preamble, doc.postamble, doc.header, doc.rows)
+    assert out == text
+    assert "| fake |" in out
+
+
+def test_a_closer_indented_less_than_its_opener_does_not_close() -> None:
+    """The case-B approximation: a closer must be at least as indented."""
+    lines = ["    ```", "  ```", "content"]
+    assert md._fenced(lines) == [True, True, True]
+
+
+# --- backtick info-string restriction (issue #145, case C) ----------------------
+
+
+def test_a_backtick_paragraph_with_a_further_backtick_does_not_open_a_fence() -> None:
+    lines = ["```js `x`", "| a |", "|---|", "| 1 |"]
+    assert md._fenced(lines) == [False, False, False, False]
+
+
+def test_the_table_after_a_backtick_paragraph_is_still_found() -> None:
+    text = "```js `x`\n\n| a |\n|---|\n| 1 |\n"
+    doc = md.parse_document(text)
+    assert doc.header == ["a"]
+    assert doc.rows == [{"a": "1"}]
+
+
+def test_a_tilde_fence_s_info_string_may_contain_a_backtick() -> None:
+    lines = ["~~~info with a backtick ` in it", "content", "~~~"]
+    assert md._fenced(lines) == [True, True, True]
+
+
+def test_a_backtick_fence_with_a_clean_info_string_still_opens() -> None:
+    lines = ["```python", "code", "```"]
+    assert md._fenced(lines) == [True, True, True]


### PR DESCRIPTION
## What

Closes three related CommonMark fence-detection gaps in `core/mdtable.py` (the
host-preserving markdown-table reader/writer shared across front-ends) and
the one consumer bug they enabled in `digest/extraction.py`:

- **Case A**: `extraction.py`'s `_MATRIX_HEADING_LINE` was a fence-blind
  regex used only to distinguish "no `## Concept matrix` section" from
  "section exists but holds no table." When the document's only such heading
  sat inside a code fence, the fence-aware parser correctly found no
  section, but the regex incorrectly did — sending the author the wrong
  remedy. Fixed by adding a fence-aware `find_headings(text, title)` to
  `core/mdtable.py`, backed by a helper now shared with the pre-existing
  `_section_bounds` (one heading-scan implementation, not two). The regex is
  deleted.
- **Case B**: the fence-opener regex only accepted ≤3 spaces of indent
  (correct at a document's top level) — so a fence legitimately indented 4+
  columns inside a list item was invisible, and its illustration content
  could be read as the document's real table. Fixed with a documented,
  deliberate approximation: an opener is accepted at any indent, and a
  closer must be indented at least as far as its opener. Both directions of
  imprecision this trades away only make the module claim *more* of the
  document as fenced, never less — consistent with its "conservative on
  purpose" contract.
- **Case C**: the fence regex let a backtick fence's info string contain
  more backticks, so an ordinary paragraph starting with three backticks and
  mentioning another one would open a fence that's never closed, silently
  swallowing the rest of the document (including a real table) as "fenced."
  Fixed by splitting into a backtick pattern (info string may not contain a
  backtick, per CommonMark) and a tilde pattern (unrestricted — CommonMark's
  tilde exemption is real and preserved).

## Closes

Closes #145.

## Test plan

- [x] `uv run pytest -q` — 1468 passed, 100% coverage
- [x] `uv run mypy` / `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uvx pre-commit run --all-files` — clean
- [x] One test per acceptance criterion in the issue, plus the tilde exemption
- [x] All three issue reproductions re-run against the fix, output included
      in the implementation notes
- [x] Independent adversarial review pass: traced `_section_bounds`'s reuse
      of the new shared heading helper line-by-line against the pre-refactor
      code: byte-identical behavior; verified Case B against sequential
      fences (no state leak), a list-item fence with an accidental
      wrong-indent closer (documented trade-off, not a bug), and a plain
      unindented table (regression-safe); verified Case C's "never opens at
      all" semantics against actual CommonMark rules, not assumed; tried
      nested list fences, empty info strings, and an unclosed fence running
      to EOF — all behaved correctly
- [x] Confirmed no existing test in `test_mdtable.py`/`test_extraction.py`
      was weakened or changed — diff is pure additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
