### PR TITLE
feat(check): validate the status.extraction contract that progress already reads

### DIFF
--- a/defendable-science/defendable_science/check/checks.py
+++ b/defendable-science/defendable_science/check/checks.py
@@ -27,11 +27,13 @@ are successful science, not findings.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from defendable_science.check.model import Finding, Report
 from defendable_science.core.config import load_config_text
 from defendable_science.dataset import manifest as mf
+from defendable_science.digest import artifact as artifact_mod
+from defendable_science.digest import extraction as extraction_mod
 from defendable_science.exploration.backlog import (
     REGISTRY_COLUMNS,
     Backlog,
@@ -51,6 +53,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from defendable_science.check.probe import Probe
+    from defendable_science.digest.extraction import Cell
     from defendable_science.exploration.backlog import Level, Row
     from defendable_science.scaffold.layout import Layout
 
@@ -786,6 +789,354 @@ def check_frontmatter(layout: Layout, probe: Probe) -> list[Finding]:
     return findings
 
 
+# --- extraction-status checks -------------------------------------------------
+
+EXTRACTION_CHECK = "extraction"
+
+
+def digest_artifacts(layout: Layout, probe: Probe) -> list[Path]:
+    """Return every digest artifact under ``layout.digests_dir``.
+
+    Digest artifacts are not staged documents in the hypothesis/paper/thesis
+    sense — they are not in `STAGED_DOCUMENTS` and :func:`check_frontmatter`
+    never scans them (defendable-science#147) — so this is a second, separate
+    listing, the same way `staged_documents` is the one `check_frontmatter`
+    walks.
+
+    :param layout: The resolved layout.
+    :param probe: The filesystem seam.
+    :returns: Sorted absolute paths to every ``*.md`` file directly under
+        ``layout.digests_dir`` (empty if the directory does not exist).
+    """
+    return probe.glob(layout.digests_dir, "*.md")
+
+
+def _extraction_locator_patterns(layout: Layout, probe: Probe) -> list[re.Pattern[str]]:
+    """Return the locator patterns cell locators are checked against.
+
+    Reads ``literature.extraction.locator_patterns`` from ``config.yml`` the
+    same way ``cli.py``'s own extraction command does
+    (``_lit_block``/``_locator_patterns``), but never raises or reports a
+    finding of its own: a missing, unreadable, or malformed config is already
+    :func:`check_config`'s finding to make, and duplicating it here would
+    report one defect twice. Falling back to the default pattern set on any
+    of those costs nothing but a slightly stricter locator-shape check — never
+    a false pass — because a configured pattern set only ever *widens* what a
+    locator may look like (see `~.extraction.DEFAULT_LOCATOR_PATTERNS`).
+
+    :param layout: The resolved layout.
+    :param probe: The filesystem seam.
+    :returns: Compiled locator patterns: the configured set if the config and
+        its ``literature.extraction.locator_patterns`` key are present and
+        well-formed, else the default set alone.
+    """
+    default = extraction_mod.compile_locator_patterns(None)
+    if not is_file(probe, layout.config_file):
+        return default
+    try:
+        config = load_config_text(probe.read_text(layout.config_file))
+    except (OSError, ValueError):
+        return default
+    lit = config.get("literature")
+    if not isinstance(lit, dict):
+        return default
+    extraction_block = lit.get("extraction")
+    if not isinstance(extraction_block, dict):
+        return default
+    configured = extraction_block.get("locator_patterns")
+    if not isinstance(configured, list) or not all(
+        isinstance(p, str) for p in configured
+    ):
+        return default
+    try:
+        return extraction_mod.compile_locator_patterns(configured)
+    except extraction_mod.ExtractionError:
+        return default
+
+
+def _check_extraction_fields(rel: str, extraction: dict[str, Any]) -> list[Finding]:
+    """Report bad values on ``status.extraction``'s scalar fields.
+
+    :param rel: The artifact's repo-relative path, for the findings.
+    :param extraction: The parsed ``status.extraction`` mapping.
+    :returns: One ``invalid`` finding per bad field.
+    """
+    findings: list[Finding] = []
+
+    batch_check = extraction.get("batch-check")
+    if batch_check not in artifact_mod.BATCH_CHECK_VERDICTS:
+        findings.append(
+            Finding(
+                severity="invalid",
+                check=EXTRACTION_CHECK,
+                file=rel,
+                message=(
+                    f"{rel} has `batch-check: {batch_check!r}`, which is not "
+                    f"one of {list(artifact_mod.BATCH_CHECK_VERDICTS)}"
+                ),
+                remedy=(
+                    f"set `batch-check` to one of "
+                    f"{list(artifact_mod.BATCH_CHECK_VERDICTS)}, matching the "
+                    "verdict `digest extract sample --verdict` recorded, or "
+                    "re-run extraction"
+                ),
+            )
+        )
+
+    locators = extraction.get("locators")
+    if locators not in artifact_mod.LOCATORS_WRITTEN_VALUES:
+        findings.append(
+            Finding(
+                severity="invalid",
+                check=EXTRACTION_CHECK,
+                file=rel,
+                message=(
+                    f"{rel} has `locators: {locators!r}`, which `digest "
+                    "extract record` never writes; the only value it writes "
+                    f"is {sorted(artifact_mod.LOCATORS_WRITTEN_VALUES)}"
+                ),
+                remedy=(
+                    "re-run `digest extract record` to regenerate the block "
+                    "rather than hand-editing `locators`"
+                ),
+            )
+        )
+
+    in_sample = extraction.get("in-sample")
+    if not isinstance(in_sample, bool):
+        findings.append(
+            Finding(
+                severity="invalid",
+                check=EXTRACTION_CHECK,
+                file=rel,
+                message=(
+                    f"{rel} has `in-sample: {in_sample!r}`, which is not a boolean"
+                ),
+                remedy=(
+                    "set `in-sample` to `true` or `false`, or re-run `digest "
+                    "extract sample` to set it from an actual check"
+                ),
+            )
+        )
+
+    return findings
+
+
+def _check_cell(rel: str, cell: Cell, patterns: list[re.Pattern[str]]) -> list[Finding]:
+    """Report why one recorded cell does not carry the evidence it claims to.
+
+    :param rel: The artifact's repo-relative path, for the finding.
+    :param cell: One cell read back by :func:`~.artifact.cells_from_text`.
+    :param patterns: Compiled locator patterns.
+    :returns: At most one ``invalid`` finding.
+    """
+    if cell.value == extraction_mod.NOT_ADDRESSED:
+        if not (cell.justification or "").strip():
+            return [
+                Finding(
+                    severity="invalid",
+                    check=EXTRACTION_CHECK,
+                    file=rel,
+                    message=(
+                        f"{rel}: the {cell.axis!r} cell is "
+                        f"{extraction_mod.NOT_ADDRESSED!r} with no "
+                        "justification"
+                    ),
+                    remedy=(
+                        f"add a `justification` to the {cell.axis!r} cell "
+                        "saying what puts it out of the paper's scope, or "
+                        "re-run `digest extract record`"
+                    ),
+                )
+            ]
+        return []
+    locator = cell.locator
+    if locator is None or not locator.strip():
+        return [
+            Finding(
+                severity="invalid",
+                check=EXTRACTION_CHECK,
+                file=rel,
+                message=f"{rel}: the {cell.axis!r} cell has no locator",
+                remedy=(
+                    f"add a locator to the {cell.axis!r} cell (e.g. '§3' or "
+                    f"'p. 7'), or record it as "
+                    f"{extraction_mod.NOT_ADDRESSED!r} with a justification"
+                ),
+            )
+        ]
+    if not extraction_mod.is_valid_locator(locator, patterns):
+        return [
+            Finding(
+                severity="invalid",
+                check=EXTRACTION_CHECK,
+                file=rel,
+                message=(
+                    f"{rel}: the {cell.axis!r} cell has locator "
+                    f"{locator!r}, which matches no known form"
+                ),
+                remedy=(
+                    f"fix the {cell.axis!r} cell's locator to a recognised "
+                    "form (e.g. '§3', 'p. 7', 'Eq. (4)', 'Thm. 2'), or extend "
+                    "`literature.extraction.locator_patterns` in config.yml"
+                ),
+            )
+        ]
+    return []
+
+
+def _check_extraction_cells(
+    rel: str,
+    path: Path,
+    text: str,
+    extraction: dict[str, Any],
+    patterns: list[re.Pattern[str]],
+) -> list[Finding]:
+    """Report a wrong ``cells`` count, and every cell missing its evidence.
+
+    Reuses :func:`~.artifact.cells_from_text` — the same parser
+    ``digest extract record`` reads back with — rather than re-parsing the
+    fenced YAML block, so a block this reports as sound can never be one the
+    writer itself would refuse.
+
+    :param rel: The artifact's repo-relative path, for the findings.
+    :param path: The artifact's absolute path, for the parser's own errors.
+    :param text: The artifact's full contents, already read through `probe`.
+    :param extraction: The parsed ``status.extraction`` mapping.
+    :param patterns: Compiled locator patterns.
+    :returns: ``invalid`` findings: a malformed or missing cells block despite
+        a ``status.extraction`` block claiming one, a wrong ``cells`` count,
+        or a per-cell locator/justification problem.
+    """
+    try:
+        cells = artifact_mod.cells_from_text(text, path)
+    except extraction_mod.ExtractionError as exc:
+        return [
+            Finding(
+                severity="invalid",
+                check=EXTRACTION_CHECK,
+                file=rel,
+                message=str(exc),
+                remedy=(
+                    f"{rel} declares a `status.extraction` block but its "
+                    "extracted-cells block is missing or malformed; "
+                    "repair it or re-run `digest extract record`"
+                ),
+            )
+        ]
+
+    findings: list[Finding] = []
+    claimed = extraction.get("cells")
+    if not isinstance(claimed, int) or isinstance(claimed, bool):
+        findings.append(
+            Finding(
+                severity="invalid",
+                check=EXTRACTION_CHECK,
+                file=rel,
+                message=f"{rel} has `cells: {claimed!r}`, which is not an integer",
+                remedy=(
+                    "set `cells` to the actual number of cells in the "
+                    "extracted-cells block, or re-run `digest extract record`"
+                ),
+            )
+        )
+    elif claimed != len(cells):
+        findings.append(
+            Finding(
+                severity="invalid",
+                check=EXTRACTION_CHECK,
+                file=rel,
+                message=(
+                    f"{rel} claims `cells: {claimed}`, but its "
+                    f"extracted-cells block holds {len(cells)} cell(s)"
+                ),
+                remedy=(
+                    "re-run `digest extract record` to regenerate the block "
+                    "rather than hand-editing `cells`"
+                ),
+            )
+        )
+
+    for cell in cells:
+        findings.extend(_check_cell(rel, cell, patterns))
+
+    return findings
+
+
+def check_extraction(layout: Layout, probe: Probe) -> list[Finding]:
+    """Report every digest artifact whose ``status.extraction`` block is unsound.
+
+    Extraction mode (#100) writes a second status contract into a paper's
+    digest artifact — ``status.extraction`` — that ``progress`` reads into its
+    own dashboard row (``skills/progress/SKILL.md``). Nothing validated it
+    before this check existed: a hand-edited ``cells`` count, a
+    ``batch-check`` typed by hand with no real check, or a cell missing its
+    locator produced a confidently *wrong* dashboard row rather than an error
+    (#147).
+
+    Reuses the writer's own parsers
+    (:func:`~.artifact.extraction_status_from_text`,
+    :func:`~.artifact.cells_from_text`) and the extraction library's own
+    rules (:func:`~.extraction.is_valid_locator`,
+    :data:`~.artifact.BATCH_CHECK_VERDICTS`) rather than reimplementing them,
+    so a block this reports as sound can never be one the writer, or
+    ``digest extract sample``, would refuse.
+
+    An artifact with no ``status.extraction`` block is not a finding at all —
+    it may be a depth-mode-only reading record, or a paper never digested,
+    and both are legitimately silent here. An artifact carrying both
+    ``understanding`` and ``extraction`` is validated only against
+    ``extraction``'s own rules; ``understanding`` is a different, stronger
+    claim this check does not touch.
+
+    :param layout: The resolved layout.
+    :param probe: The filesystem seam.
+    :returns: Findings for each unsound ``status.extraction`` block.
+        ``unreadable`` for a digest artifact that could not be read at all;
+        ``invalid`` for every other defect — a malformed frontmatter block, a
+        cells-block mismatch, a bad enum, a wrong type, or a cell missing its
+        locator or justification. Every one of these is a structurally wrong
+        value in a machine-read contract, never a legitimately-incomplete
+        state, so none is a ``gap``.
+    """
+    findings: list[Finding] = []
+    patterns: list[re.Pattern[str]] | None = None
+
+    for path in digest_artifacts(layout, probe):
+        rel = str(layout.rel(path))
+        text = read_or_finding(path, layout, probe, EXTRACTION_CHECK)
+        if isinstance(text, Finding):
+            findings.append(text)
+            continue
+
+        try:
+            extraction = artifact_mod.extraction_status_from_text(text, path)
+        except extraction_mod.ExtractionError as exc:
+            findings.append(
+                Finding(
+                    severity="invalid",
+                    check=EXTRACTION_CHECK,
+                    file=rel,
+                    message=str(exc),
+                    remedy=(
+                        f"fix the YAML frontmatter in {rel}, or remove the "
+                        "malformed status block"
+                    ),
+                )
+            )
+            continue
+        if extraction is None:
+            continue
+
+        if patterns is None:
+            patterns = _extraction_locator_patterns(layout, probe)
+
+        findings.extend(_check_extraction_fields(rel, extraction))
+        findings.extend(_check_extraction_cells(rel, path, text, extraction, patterns))
+
+    return findings
+
+
 # --- registries checks -------------------------------------------------------
 
 REGISTRIES_CHECK = "registries"
@@ -1469,16 +1820,16 @@ def check_config(layout: Layout, probe: Probe) -> list[Finding]:
     return findings
 
 
-# --- run_checks: compose all six families ------------------------------------
+# --- run_checks: compose all seven families -----------------------------------
 
 
 def run_checks(layout: Layout, probe: Probe) -> Report:
-    """Compose all six check families into a single report.
+    """Compose all seven check families into a single report.
 
-    Runs checks in order: layout, tables, frontmatter, registries, config,
-    cross-artifact. The order ensures that each family's findings are grouped
-    together, and any unreadable files are reported consistently across all
-    families.
+    Runs checks in order: layout, tables, frontmatter, extraction, registries,
+    config, cross-artifact. The order ensures that each family's findings are
+    grouped together, and any unreadable files are reported consistently
+    across all families.
 
     Deduplicates findings that share the same severity, file, and message
     (which may occur when multiple families read the same unreadable file).
@@ -1486,14 +1837,17 @@ def run_checks(layout: Layout, probe: Probe) -> Report:
 
     :param layout: The resolved layout.
     :param probe: The filesystem seam.
-    :returns: The composed report with deduplicated findings from all six families.
+    :returns: The composed report with deduplicated findings from all seven
+        families.
     """
     findings: list[Finding] = []
 
-    # Run in fixed order: layout, tables, frontmatter, registries, config, cross-artifact
+    # Run in fixed order: layout, tables, frontmatter, extraction, registries,
+    # config, cross-artifact
     findings.extend(check_layout(layout, probe))
     findings.extend(check_tables(layout, probe))
     findings.extend(check_frontmatter(layout, probe))
+    findings.extend(check_extraction(layout, probe))
     findings.extend(check_registries(layout, probe))
     findings.extend(check_config(layout, probe))
     findings.extend(check_cross_artifact(layout, probe))

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -501,9 +501,10 @@ def check(
 ) -> None:
     """Report the repo's validity state as JSON.
 
-    Runs six check families (layout, tables, frontmatter, registries, config,
-    cross-artifact) and emits findings grouped by severity. Exit code is keyed
-    to severity: ``invalid`` or ``unreadable`` → 1; ``gap`` or clean → 0.
+    Runs seven check families (layout, tables, frontmatter, extraction,
+    registries, config, cross-artifact) and emits findings grouped by
+    severity. Exit code is keyed to severity: ``invalid`` or ``unreadable`` →
+    1; ``gap`` or clean → 0.
 
     A missing or invalid layout block is fatal — the checker cannot know where
     anything is — so the check exits 1 with a message and no findings JSON. So

--- a/defendable-science/defendable_science/digest/artifact.py
+++ b/defendable-science/defendable_science/digest/artifact.py
@@ -54,6 +54,13 @@ if TYPE_CHECKING:
 #: population (spec §8).
 BATCH_CHECK_VERDICTS = ("pending", "verified", "failed")
 
+#: The only value ``status.extraction.locators`` is ever written with (see
+#: `ExtractionStatus.locators`). Not a claim about locator *shape* — that is
+#: `~.extraction.is_valid_locator` — but about the field itself: a value
+#: outside this set was never written by this module, so it is a hand-edit,
+#: not a leftover from a real run (defendable-science#147).
+LOCATORS_WRITTEN_VALUES = frozenset({"ok"})
+
 #: The frontmatter key extraction owns. Deliberately not ``understanding``.
 EXTRACTION_KEY = "extraction"
 
@@ -237,27 +244,27 @@ def _load_payload(payload: str, path: Path) -> tuple[str, list[Any]]:
     return citekey, items
 
 
-def read_cells(artifact: str | Path) -> list[Cell]:
-    """Read a paper's recorded cells back out of its artifact.
+def cells_from_text(text: str, path: Path) -> list[Cell]:
+    """Parse a paper's recorded cells out of already-read artifact `text`.
 
-    The inverse of :func:`write_extraction`'s body write, and the source the
-    ``positioning.md`` matrix is rendered from — the row is a projection of
-    these, never authored independently (spec §5).
+    The text-level counterpart of :func:`read_cells`, for a caller — namely
+    ``check`` — that reads the artifact through its own I/O seam rather than
+    the filesystem directly (defendable-science#147). :func:`read_cells`
+    delegates here after doing its own file read, so there is exactly one
+    parser, not two that could drift.
 
     Fails loudly rather than returning an empty list: a paper with no block has
     not been extracted, and reporting that as "extracted, zero cells" would be
     a finding about the paper rather than about the file.
 
-    :param artifact: The per-paper digest artifact.
+    :param text: The artifact's full contents, already read.
+    :param path: The artifact's path, named in any raised error.
     :returns: The recorded cells, in the order they were written.
-    :raises ExtractionError: If the artifact is missing, has no frontmatter, or
-        its cells block is absent or malformed.
+    :raises ExtractionError: If `text` has no frontmatter, or its cells block
+        is absent or malformed.
     """
-    path = Path(artifact)
-    if not path.is_file():
-        raise ExtractionError(f"{path}: digest artifact not found")
     try:
-        _, body = split_frontmatter(path.read_text(encoding="utf-8"))
+        _, body = split_frontmatter(text)
     except FrontmatterError as exc:
         raise ExtractionError(f"{path}: {exc}") from exc
     span = _locate_block(body, path)
@@ -269,6 +276,24 @@ def read_cells(artifact: str | Path) -> list[Cell]:
     begin, end = span
     citekey, items = _load_payload(_fenced_payload(body[begin + 1 : end], path), path)
     return [_cell_from_item(item, citekey, path) for item in items]
+
+
+def read_cells(artifact: str | Path) -> list[Cell]:
+    """Read a paper's recorded cells back out of its artifact.
+
+    The inverse of :func:`write_extraction`'s body write, and the source the
+    ``positioning.md`` matrix is rendered from — the row is a projection of
+    these, never authored independently (spec §5).
+
+    :param artifact: The per-paper digest artifact.
+    :returns: The recorded cells, in the order they were written.
+    :raises ExtractionError: If the artifact is missing, has no frontmatter, or
+        its cells block is absent or malformed.
+    """
+    path = Path(artifact)
+    if not path.is_file():
+        raise ExtractionError(f"{path}: digest artifact not found")
+    return cells_from_text(path.read_text(encoding="utf-8"), path)
 
 
 def _cell_from_item(item: Any, citekey: str, path: Path) -> Cell:
@@ -327,6 +352,31 @@ def _extraction_mapping(fm_lines: list[str], path: Path) -> dict[str, Any]:
     return block
 
 
+def extraction_status_from_text(text: str, path: Path) -> dict[str, Any] | None:
+    """Return the artifact's ``status.extraction`` mapping from already-read `text`.
+
+    The text-level counterpart of :func:`has_extraction` / :func:`_status_extraction`,
+    for a caller — namely ``check`` — that reads the artifact through its own
+    I/O seam rather than the filesystem directly (defendable-science#147).
+
+    ``None`` means *this paper was never extracted* — a fact. Frontmatter that
+    will not parse is a different thing entirely and raises, because an
+    unreadable artifact reported as an unextracted one is exactly the silent
+    substitution the failure-honesty rule forbids.
+
+    :param text: The artifact's full contents, already read.
+    :param path: The artifact's path, named in any raised error.
+    :returns: The ``status.extraction`` mapping, or ``None`` if absent.
+    :raises ExtractionError: If `text` has no frontmatter, an unterminated
+        frontmatter block, or frontmatter that is not valid YAML.
+    """
+    try:
+        fm_lines, _body = split_frontmatter(text)
+    except FrontmatterError as exc:
+        raise ExtractionError(f"{path}: {exc}") from exc
+    return _status_extraction(fm_lines, path)
+
+
 def has_extraction(artifact: str | Path) -> bool:
     """Whether `artifact` carries a ``status.extraction`` block.
 
@@ -344,11 +394,8 @@ def has_extraction(artifact: str | Path) -> bool:
     path = Path(artifact)
     if not path.is_file():
         raise ExtractionError(f"{path}: digest artifact not found")
-    try:
-        fm_lines, _body = split_frontmatter(path.read_text(encoding="utf-8"))
-    except FrontmatterError as exc:
-        raise ExtractionError(f"{path}: {exc}") from exc
-    return _status_extraction(fm_lines, path) is not None
+    text = path.read_text(encoding="utf-8")
+    return extraction_status_from_text(text, path) is not None
 
 
 def _dump_block(block: dict[str, Any], path: Path) -> str:

--- a/defendable-science/tests/test_check.py
+++ b/defendable-science/tests/test_check.py
@@ -10,6 +10,8 @@ import pytest
 from defendable_science.check import checks as c
 from defendable_science.check import model as m
 from defendable_science.check.probe import FsProbe
+from defendable_science.digest import artifact as art
+from defendable_science.digest import extraction as ex
 from defendable_science.scaffold import render as r
 from defendable_science.scaffold import status as st
 from defendable_science.scaffold.layout import Layout
@@ -909,6 +911,457 @@ def test_staged_documents_handles_external_thesis_dir() -> None:
     assert LAYOUT.paper_docs_dir("dc") / "pitch.md" in docs
     assert external_thesis / "kappa" / "kappa.md" in docs
     assert external_thesis / "kappa" / "aims.md" in docs
+
+
+# --- extraction-status checks (#147) ------------------------------------------
+
+EXTRACT_CITEKEY = "smith2024widget"
+DIGEST_PATH = LAYOUT.digest(EXTRACT_CITEKEY)
+
+
+def _extraction_cells(citekey: str = EXTRACT_CITEKEY) -> list[ex.Cell]:
+    """One value cell with a locator, one justified `not-addressed` cell."""
+    return [
+        ex.Cell(citekey, "guarantee type", "architectural", locator="§2, Eq. (3)"),
+        ex.Cell(
+            citekey,
+            "scope",
+            ex.NOT_ADDRESSED,
+            justification="scoped to fully-monotone inputs in §1",
+        ),
+    ]
+
+
+def _extraction_artifact(
+    tmp_path: Path,
+    citekey: str = EXTRACT_CITEKEY,
+    cells: list[ex.Cell] | None = None,
+    *,
+    in_sample: bool = False,
+    batch_check: str = "pending",
+) -> str:
+    """Build a real extraction artifact through the actual writer.
+
+    Written to `tmp_path` (a real, throwaway directory) and read back as text,
+    so every fixture is exactly what `digest extract record` produces rather
+    than a hand-rolled approximation of it. Callers that need a corrupted
+    artifact take this text and mutate it, the same way a hand-edit would.
+    """
+    path = tmp_path / f"{citekey}.md"
+    art.write_extraction(
+        path,
+        _extraction_cells(citekey) if cells is None else cells,
+        in_sample=in_sample,
+        batch_check=batch_check,
+        log_dir=tmp_path / "log",
+        date="2026-08-28",
+    )
+    return path.read_text(encoding="utf-8")
+
+
+def _strip_cells_block(text: str) -> str:
+    """Delete the extracted-cells block, leaving the status block intact."""
+    lines = text.splitlines()
+    begin = lines.index(art.CELLS_BEGIN)
+    end = lines.index(art.CELLS_END)
+    return "\n".join(lines[:begin] + lines[end + 1 :]) + "\n"
+
+
+def test_extraction_check_is_silent_on_a_scaffolded_repo() -> None:
+    assert c.check_extraction(LAYOUT, FakeProbe(_scaffolded())) == []
+
+
+def test_extraction_check_is_silent_on_an_artifact_with_no_extraction_block() -> None:
+    """A depth-mode-only digest is legitimately extraction-free (#147)."""
+    files = _scaffolded()
+    files[DIGEST_PATH] = (
+        "---\n"
+        "status:\n"
+        "  understanding: {status: gaps, unresolved: [why convexity matters]}\n"
+        "  last-updated: 2026-08-28\n"
+        "---\n\n"
+        f"# {EXTRACT_CITEKEY}\n"
+    )
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_accepts_a_freshly_written_artifact(tmp_path: Path) -> None:
+    files = _scaffolded()
+    files[DIGEST_PATH] = _extraction_artifact(tmp_path)
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_validates_extraction_rules_only_when_both_blocks_are_present(
+    tmp_path: Path,
+) -> None:
+    """`understanding` and `extraction` coexist; neither is judged by the other's rules."""
+    text = _extraction_artifact(tmp_path).replace(
+        "status:\n",
+        "status:\n  understanding: {status: gaps, unresolved: []}\n",
+        1,
+    )
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_flags_a_cell_count_mismatch(tmp_path: Path) -> None:
+    text = _extraction_artifact(tmp_path).replace('"cells": 2', '"cells": 5')
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "claims `cells: 5`" in findings[0].message
+    assert "holds 2 cell(s)" in findings[0].message
+    assert findings[0].file == str(LAYOUT.rel(DIGEST_PATH))
+
+
+def test_extraction_check_flags_a_non_integer_cells_value(tmp_path: Path) -> None:
+    text = _extraction_artifact(tmp_path).replace('"cells": 2', '"cells": "two"')
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "not an integer" in findings[0].message
+
+
+def test_extraction_check_flags_a_boolean_cells_value(tmp_path: Path) -> None:
+    """A `bool` is a subclass of `int`; `cells: true` must not slip through."""
+    text = _extraction_artifact(tmp_path).replace('"cells": 2', '"cells": true')
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "not an integer" in findings[0].message
+
+
+def test_extraction_check_flags_an_unknown_batch_check_verdict(tmp_path: Path) -> None:
+    text = _extraction_artifact(tmp_path).replace(
+        '"batch-check": "pending"', '"batch-check": "yolo"'
+    )
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "batch-check: 'yolo'" in findings[0].message
+
+
+def test_extraction_check_flags_a_hand_written_locators_value(tmp_path: Path) -> None:
+    text = _extraction_artifact(tmp_path).replace(
+        '"locators": "ok"', '"locators": "verified"'
+    )
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "locators: 'verified'" in findings[0].message
+
+
+def test_extraction_check_flags_a_non_boolean_in_sample(tmp_path: Path) -> None:
+    text = _extraction_artifact(tmp_path).replace(
+        '"in-sample": false', '"in-sample": "no"'
+    )
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "in-sample: 'no'" in findings[0].message
+
+
+def test_extraction_check_flags_a_cell_with_no_locator(tmp_path: Path) -> None:
+    text = _extraction_artifact(tmp_path).replace("  locator: §2, Eq. (3)\n", "")
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "'guarantee type' cell has no locator" in findings[0].message
+
+
+def test_extraction_check_flags_a_cell_locator_with_an_unrecognised_shape(
+    tmp_path: Path,
+) -> None:
+    text = _extraction_artifact(tmp_path).replace(
+        "locator: §2, Eq. (3)", "locator: somewhere in the middle"
+    )
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "matches no known form" in findings[0].message
+
+
+def test_extraction_check_flags_a_not_addressed_cell_with_no_justification(
+    tmp_path: Path,
+) -> None:
+    text = _extraction_artifact(tmp_path).replace(
+        "  justification: scoped to fully-monotone inputs in §1\n", ""
+    )
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert (
+        "'scope' cell is 'not-addressed' with no justification" in findings[0].message
+    )
+
+
+def test_extraction_check_reports_an_unreadable_digest_artifact(
+    tmp_path: Path,
+) -> None:
+    files = _scaffolded()
+    files[DIGEST_PATH] = _extraction_artifact(tmp_path)
+    probe = FakeProbe(files, unreadable={DIGEST_PATH})
+
+    findings = c.check_extraction(LAYOUT, probe)
+
+    assert [f.severity for f in findings] == ["unreadable"]
+
+
+def test_extraction_check_flags_unterminated_frontmatter() -> None:
+    files = _scaffolded()
+    files[DIGEST_PATH] = "---\nstatus:\n  extraction: {}\n"
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert findings[0].file == str(LAYOUT.rel(DIGEST_PATH))
+
+
+def test_extraction_check_flags_a_missing_cells_block(tmp_path: Path) -> None:
+    """Claiming a cell count with no cells block at all is a defect, not a read failure."""
+    text = _strip_cells_block(_extraction_artifact(tmp_path))
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "no extracted-cells block" in findings[0].message
+
+
+def test_extraction_check_flags_a_broken_cells_fence(tmp_path: Path) -> None:
+    text = _extraction_artifact(tmp_path).replace("```yaml", "```", 1)
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "no ```yaml fence" in findings[0].message
+
+
+def test_extraction_check_handles_multiple_digest_artifacts(tmp_path: Path) -> None:
+    """The locator patterns are only computed once, and reused for later artifacts."""
+    other_citekey = "jones2023gadget"
+    files = _scaffolded()
+    files[DIGEST_PATH] = _extraction_artifact(tmp_path)
+    files[LAYOUT.digest(other_citekey)] = _extraction_artifact(
+        tmp_path, citekey=other_citekey
+    )
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_uses_configured_locator_patterns(tmp_path: Path) -> None:
+    text = _extraction_artifact(
+        tmp_path,
+        cells=[
+            ex.Cell(
+                EXTRACT_CITEKEY, "guarantee type", "architectural", locator="Widget-7"
+            ),
+            ex.Cell(
+                EXTRACT_CITEKEY,
+                "scope",
+                ex.NOT_ADDRESSED,
+                justification="scoped to fully-monotone inputs in §1",
+            ),
+        ],
+    )
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+    files[LAYOUT.config_file] = (
+        "literature:\n  extraction:\n    locator_patterns:\n      - 'Widget-\\d+'\n"
+    )
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_rejects_an_unconfigured_locator_shape_without_config(
+    tmp_path: Path,
+) -> None:
+    """The same locator, with no config extending the pattern set, is rejected."""
+    text = _extraction_artifact(
+        tmp_path,
+        cells=[
+            ex.Cell(
+                EXTRACT_CITEKEY, "guarantee type", "architectural", locator="Widget-7"
+            ),
+            ex.Cell(
+                EXTRACT_CITEKEY,
+                "scope",
+                ex.NOT_ADDRESSED,
+                justification="scoped to fully-monotone inputs in §1",
+            ),
+        ],
+    )
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "matches no known form" in findings[0].message
+
+
+def test_extraction_check_falls_back_to_defaults_when_config_is_missing(
+    tmp_path: Path,
+) -> None:
+    files = _scaffolded()
+    files[DIGEST_PATH] = _extraction_artifact(tmp_path)
+    del files[LAYOUT.config_file]
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_falls_back_to_defaults_when_config_is_unreadable(
+    tmp_path: Path,
+) -> None:
+    files = _scaffolded()
+    files[DIGEST_PATH] = _extraction_artifact(tmp_path)
+    probe = FakeProbe(files, unreadable={LAYOUT.config_file})
+
+    assert c.check_extraction(LAYOUT, probe) == []
+
+
+def test_extraction_check_falls_back_to_defaults_when_config_yaml_is_malformed(
+    tmp_path: Path,
+) -> None:
+    files = _scaffolded()
+    files[DIGEST_PATH] = _extraction_artifact(tmp_path)
+    files[LAYOUT.config_file] = "cache_dir: [unclosed\n"
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert findings == []
+
+
+def test_extraction_check_falls_back_to_defaults_when_literature_is_not_a_mapping(
+    tmp_path: Path,
+) -> None:
+    files = _scaffolded()
+    files[DIGEST_PATH] = _extraction_artifact(tmp_path)
+    files[LAYOUT.config_file] = "literature: nope\n"
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_falls_back_to_defaults_when_extraction_block_is_not_a_mapping(
+    tmp_path: Path,
+) -> None:
+    files = _scaffolded()
+    files[DIGEST_PATH] = _extraction_artifact(tmp_path)
+    files[LAYOUT.config_file] = "literature:\n  extraction: nope\n"
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_falls_back_to_defaults_when_locator_patterns_is_not_a_list(
+    tmp_path: Path,
+) -> None:
+    files = _scaffolded()
+    files[DIGEST_PATH] = _extraction_artifact(tmp_path)
+    files[LAYOUT.config_file] = (
+        "literature:\n  extraction:\n    locator_patterns: 'not-a-list'\n"
+    )
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_falls_back_to_defaults_when_a_locator_pattern_is_not_a_string(
+    tmp_path: Path,
+) -> None:
+    files = _scaffolded()
+    files[DIGEST_PATH] = _extraction_artifact(tmp_path)
+    files[LAYOUT.config_file] = (
+        "literature:\n  extraction:\n    locator_patterns:\n      - 7\n"
+    )
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_falls_back_to_defaults_when_a_configured_pattern_is_invalid_regex(
+    tmp_path: Path,
+) -> None:
+    files = _scaffolded()
+    files[DIGEST_PATH] = _extraction_artifact(tmp_path)
+    files[LAYOUT.config_file] = (
+        "literature:\n  extraction:\n    locator_patterns:\n      - '(unclosed'\n"
+    )
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_falls_back_silently_without_duplicating_configs_own_finding(
+    tmp_path: Path,
+) -> None:
+    """A malformed config is `check_config`'s finding to make, not this check's."""
+    files = _scaffolded()
+    files[DIGEST_PATH] = _extraction_artifact(tmp_path)
+    files[LAYOUT.config_file] = "cache_dir: [unclosed\n"
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert not any("config.yml" in f.file for f in findings)
+
+
+def test_digest_artifacts_lists_files_directly_under_the_digests_dir(
+    tmp_path: Path,
+) -> None:
+    files = _scaffolded()
+    files[DIGEST_PATH] = _extraction_artifact(tmp_path)
+    files[LAYOUT.digests_dir / "notes" / "nested.md"] = "not a digest"
+
+    found = c.digest_artifacts(LAYOUT, FakeProbe(files))
+
+    assert found == [DIGEST_PATH]
+
+
+def test_run_checks_includes_extraction_findings() -> None:
+    files = _scaffolded()
+    files[DIGEST_PATH] = (
+        "---\n"
+        "status:\n"
+        '  extraction: {"cells": 1, "locators": "ok", "in-sample": false, '
+        '"batch-check": "pending"}\n'
+        "---\n"
+    )
+
+    report = c.run_checks(LAYOUT, FakeProbe(files))
+
+    extraction_findings = [f for f in report.findings if f.check == "extraction"]
+    assert extraction_findings
+    assert report.exit_code == 1
 
 
 # --- registries checks -------------------------------------------------------


### PR DESCRIPTION
## What

Adds a seventh `check` family, `check_extraction`, validating the
`status.extraction` block that `digest extract record` writes into per-paper
digest artifacts — a machine-read contract `progress` already reads into a
dashboard row, but that nothing previously validated.

Reports (all `invalid`, one `unreadable` for a read failure):
- `cells` disagreeing with the actual parsed cell count
- `batch-check` outside `pending`/`verified`/`failed`
- `locators` outside the values the writer ever emits
- `in-sample` not a boolean
- a cell with no locator (unless `not-addressed` with a justification), or a
  locator matching no known form

An artifact with no `status.extraction` block is silently skipped (a
depth-mode-only or never-digested paper is not this check's business); an
artifact carrying both `understanding` and `extraction` is validated only
against `extraction`'s own rules.

## Reuse, not reimplementation

Added text-based counterparts to the writer's own parsers —
`extraction_status_from_text`/`cells_from_text` in `digest/artifact.py` —
with the existing path-based `has_extraction`/`read_cells` now delegating to
them, so `check` reads through its `Probe` seam using the exact same parser
the writer reads back with. A block this check calls sound can never be one
`digest extract record` itself would refuse.

## Closes

Closes #147.

## Test plan

- [x] `uv run pytest -q` — 1485 passed, 100% coverage
- [x] `uv run mypy` / `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uvx pre-commit run --all-files` — clean
- [x] Negative test: no `status.extraction` block → no finding
- [x] Cross-contamination test: both `understanding` and `extraction`
      present, one broken — findings only ever reference the broken one
- [x] Independent adversarial review pass: traced the locator-pattern
      config-loading fallback (falls back to defaults on any config
      problem — verified `check_config` doesn't duplicate the finding, and
      that a custom-pattern-only locator is still caught, just misattributed
      to "no known form" rather than "your config is malformed" — flagging
      this as a follow-up, not a blocker, see below); confirmed
      `batch-check: pending` (the default) is never wrongly flagged; fed
      corrupted YAML into the cells block and confirmed a clean finding, no
      crash; confirmed a `not-addressed` cell may carry both a locator and a
      justification

## Follow-up filed separately

The review surfaced a real but non-blocking gap: a malformed
`literature.extraction.locator_patterns` config entry (wrong shape, or a bad
regex) silently falls back to default patterns with no diagnostic anywhere
naming the config as the problem — a valid custom-only locator then gets
misattributed as "matches no known form" rather than "your config entry is
broken." Will file as its own issue rather than scope-creep this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
