### PR TITLE
fix(core): evaluate real gitignore semantics for cache_dir coverage

### DIFF
--- a/defendable-science/defendable_science/check/checks.py
+++ b/defendable-science/defendable_science/check/checks.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 
 from defendable_science.check.model import Finding, Report
 from defendable_science.core.config import load_config_text
+from defendable_science.core.gitignore import literal_covers
 from defendable_science.dataset import manifest as mf
 from defendable_science.digest import artifact as artifact_mod
 from defendable_science.digest import extraction as extraction_mod
@@ -1659,6 +1660,68 @@ def check_cross_artifact(layout: Layout, probe: Probe) -> list[Finding]:
 CONFIG_CHECK = "config"
 
 
+def _check_cache_dir_coverage(
+    layout: Layout,
+    probe: Probe,
+    cache_dir_config: str,
+    gitignore_text: str,
+    rel_config: str,
+) -> list[Finding]:
+    """Report whether `cache_dir_config` is covered by ``.gitignore``.
+
+    Prefers git's own answer (:meth:`Probe.is_gitignored`, #138); when git
+    cannot give one (absent, or the repo is not a git work tree — the
+    ordinary state right after ``init``, before ``git init``), falls back to
+    a literal, verbatim match (:func:`~.core.gitignore.literal_covers`)
+    before giving up. Confirmed coverage from either read is silence; only a
+    confirmed miss or a genuine "cannot tell at all" produces a finding.
+
+    :param layout: The resolved layout.
+    :param probe: The filesystem seam.
+    :param cache_dir_config: The configured cache directory.
+    :param gitignore_text: The ``.gitignore`` file's contents.
+    :param rel_config: The config file's repo-relative path, for a confirmed-miss finding.
+    :returns: At most one finding: ``invalid`` for a confirmed miss,
+        ``unreadable`` if coverage could not be determined at all.
+    """
+    covered = probe.is_gitignored(layout.repo_root, cache_dir_config)
+    if covered is None and literal_covers(cache_dir_config, gitignore_text):
+        covered = True
+    if covered is False:
+        return [
+            Finding(
+                severity="invalid",
+                check=CONFIG_CHECK,
+                file=rel_config,
+                message=(
+                    f"cache_dir is set to {cache_dir_config!r}, "
+                    f"but it is not in .gitignore"
+                ),
+                remedy=(f"add this line to .gitignore:\n{cache_dir_config}"),
+            )
+        ]
+    if covered is None:
+        rel_gitignore = str(layout.rel(layout.repo_root / ".gitignore"))
+        return [
+            Finding(
+                severity="unreadable",
+                check=CONFIG_CHECK,
+                file=rel_gitignore,
+                message=(
+                    "could not determine whether cache_dir "
+                    f"{cache_dir_config!r} is covered by .gitignore "
+                    "(git is unavailable, or the repository root is "
+                    "not a git work tree)"
+                ),
+                remedy=(
+                    "ensure git is installed and the repository root is a "
+                    "git work tree, then re-run `defendable-science check`"
+                ),
+            )
+        ]
+    return []
+
+
 def check_config(layout: Layout, probe: Probe) -> list[Finding]:
     """Report problems with the project configuration.
 
@@ -1668,10 +1731,14 @@ def check_config(layout: Layout, probe: Probe) -> list[Finding]:
     3. The ``layout:`` block (if present) contains only valid keys.
     4. The ``cache_dir`` is gitignored — evaluated with real gitignore
        semantics via ``git check-ignore`` (:meth:`Probe.is_gitignored`,
-       #138), not a literal-line matcher. When that question cannot be
-       answered (git absent, or the repo is not a git work tree), coverage is
-       reported as ``unreadable`` rather than silently passing or being told
-       apart as ``invalid`` — an uncertain condition is not a confirmed one.
+       #138), not a literal-line matcher. When git cannot answer (absent, or
+       the repo is not a git work tree — the ordinary state right after
+       ``init``, before ``git init``), a literal, verbatim match against
+       ``.gitignore`` is tried as a narrower fallback
+       (:func:`~.core.gitignore.literal_covers`); only when even that finds
+       nothing is coverage reported as ``unreadable`` — an uncertain
+       condition is never silently passed, but a demonstrable one is never
+       reported as uncertain either.
     5. The ``.gitignore`` file exists.
     6. The ``experiment_backend`` is bound (a null backend is a gap).
 
@@ -1727,45 +1794,19 @@ def check_config(layout: Layout, probe: Probe) -> list[Finding]:
     gitignore_path = layout.repo_root / ".gitignore"
     rel_gitignore = str(layout.rel(gitignore_path))
 
-    # Read .gitignore — just to confirm it is readable; coverage itself is
-    # answered by git, not by parsing this text (see `probe.is_gitignored`).
+    # Read .gitignore — to confirm it is readable, and as the literal-match
+    # fallback below; the primary answer comes from git, not from parsing
+    # this text (see `probe.is_gitignored`).
     if probe.exists(gitignore_path):
         gitignore_text = read_or_finding(gitignore_path, layout, probe, CONFIG_CHECK)
         if isinstance(gitignore_text, Finding):
             findings.append(gitignore_text)
         else:
-            covered = probe.is_gitignored(layout.repo_root, cache_dir_config)
-            if covered is False:
-                findings.append(
-                    Finding(
-                        severity="invalid",
-                        check=CONFIG_CHECK,
-                        file=rel_config,
-                        message=(
-                            f"cache_dir is set to {cache_dir_config!r}, "
-                            f"but it is not in .gitignore"
-                        ),
-                        remedy=(f"add this line to .gitignore:\n{cache_dir_config}"),
-                    )
+            findings.extend(
+                _check_cache_dir_coverage(
+                    layout, probe, cache_dir_config, gitignore_text, rel_config
                 )
-            elif covered is None:
-                findings.append(
-                    Finding(
-                        severity="unreadable",
-                        check=CONFIG_CHECK,
-                        file=rel_gitignore,
-                        message=(
-                            "could not determine whether cache_dir "
-                            f"{cache_dir_config!r} is covered by .gitignore "
-                            "(git is unavailable, or the repository root is "
-                            "not a git work tree)"
-                        ),
-                        remedy=(
-                            "ensure git is installed and the repository root is a "
-                            "git work tree, then re-run `defendable-science check`"
-                        ),
-                    )
-                )
+            )
     else:
         findings.append(
             Finding(

--- a/defendable-science/defendable_science/check/checks.py
+++ b/defendable-science/defendable_science/check/checks.py
@@ -1659,48 +1659,6 @@ def check_cross_artifact(layout: Layout, probe: Probe) -> list[Finding]:
 CONFIG_CHECK = "config"
 
 
-def _cache_dir_in_gitignore(cache_dir: str, gitignore_text: str) -> bool:
-    """Check if a cache_dir entry is covered by .gitignore rules.
-
-    Handles three covering cases:
-    1. Exact match after normalizing trailing slashes.
-    2. A parent directory (e.g., ``.defendable-science/`` covers
-       ``.defendable-science/cache/``).
-
-    Skips blank lines and comment lines (first non-space character is ``#``).
-    Does NOT evaluate gitignore glob or wildcard patterns — only literal
-    matches and parent-directory containment.
-
-    :param cache_dir: The configured cache directory (e.g.,
-        ``.defendable-science/cache/``).
-    :param gitignore_text: The ``.gitignore`` file contents.
-    :returns: ``True`` if the cache_dir is covered by an active rule, else
-        ``False``.
-    """
-    # Normalize cache_dir by removing trailing slash for comparison
-    normalized_cache = cache_dir.rstrip("/")
-
-    for line in gitignore_text.splitlines():
-        stripped = line.strip()
-        # Skip blank lines and comments
-        if not stripped or stripped[0] == "#":
-            continue
-
-        # Normalize the gitignore line by removing trailing slash
-        normalized_line = stripped.rstrip("/")
-
-        # Check exact match
-        if normalized_cache == normalized_line:
-            return True
-
-        # Check parent directory covering
-        # e.g., ".defendable-science/" covers ".defendable-science/cache/"
-        if normalized_cache.startswith(normalized_line + "/"):
-            return True
-
-    return False
-
-
 def check_config(layout: Layout, probe: Probe) -> list[Finding]:
     """Report problems with the project configuration.
 
@@ -1708,16 +1666,22 @@ def check_config(layout: Layout, probe: Probe) -> list[Finding]:
     1. The config file is readable.
     2. The file is valid YAML and contains a mapping.
     3. The ``layout:`` block (if present) contains only valid keys.
-    4. The ``cache_dir`` is gitignored.
+    4. The ``cache_dir`` is gitignored — evaluated with real gitignore
+       semantics via ``git check-ignore`` (:meth:`Probe.is_gitignored`,
+       #138), not a literal-line matcher. When that question cannot be
+       answered (git absent, or the repo is not a git work tree), coverage is
+       reported as ``unreadable`` rather than silently passing or being told
+       apart as ``invalid`` — an uncertain condition is not a confirmed one.
     5. The ``.gitignore`` file exists.
     6. The ``experiment_backend`` is bound (a null backend is a gap).
 
     :param layout: The resolved layout.
     :param probe: The filesystem seam.
     :returns: Findings for each issue: ``invalid`` for structural errors,
-        ``unreadable`` for read failures, and ``gap`` for an unbound backend.
-        None at all if the config file is absent or is a directory: there is
-        nothing to read, and :func:`check_layout` already reports it.
+        ``unreadable`` for read failures (including an undeterminable
+        cache_dir coverage), and ``gap`` for an unbound backend. None at all
+        if the config file is absent or is a directory: there is nothing to
+        read, and :func:`check_layout` already reports it.
     """
     findings: list[Finding] = []
 
@@ -1763,14 +1727,15 @@ def check_config(layout: Layout, probe: Probe) -> list[Finding]:
     gitignore_path = layout.repo_root / ".gitignore"
     rel_gitignore = str(layout.rel(gitignore_path))
 
-    # Read .gitignore
+    # Read .gitignore — just to confirm it is readable; coverage itself is
+    # answered by git, not by parsing this text (see `probe.is_gitignored`).
     if probe.exists(gitignore_path):
         gitignore_text = read_or_finding(gitignore_path, layout, probe, CONFIG_CHECK)
         if isinstance(gitignore_text, Finding):
             findings.append(gitignore_text)
         else:
-            # Check if cache_dir is covered by .gitignore
-            if not _cache_dir_in_gitignore(cache_dir_config, gitignore_text):
+            covered = probe.is_gitignored(layout.repo_root, cache_dir_config)
+            if covered is False:
                 findings.append(
                     Finding(
                         severity="invalid",
@@ -1781,6 +1746,24 @@ def check_config(layout: Layout, probe: Probe) -> list[Finding]:
                             f"but it is not in .gitignore"
                         ),
                         remedy=(f"add this line to .gitignore:\n{cache_dir_config}"),
+                    )
+                )
+            elif covered is None:
+                findings.append(
+                    Finding(
+                        severity="unreadable",
+                        check=CONFIG_CHECK,
+                        file=rel_gitignore,
+                        message=(
+                            "could not determine whether cache_dir "
+                            f"{cache_dir_config!r} is covered by .gitignore "
+                            "(git is unavailable, or the repository root is "
+                            "not a git work tree)"
+                        ),
+                        remedy=(
+                            "ensure git is installed and the repository root is a "
+                            "git work tree, then re-run `defendable-science check`"
+                        ),
                     )
                 )
     else:

--- a/defendable-science/defendable_science/check/probe.py
+++ b/defendable-science/defendable_science/check/probe.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol
 
+from defendable_science.core.gitignore import check_ignore
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -34,6 +36,15 @@ class Probe(Protocol):
 
     def glob(self, root: Path, pattern: str) -> list[Path]:
         """Return sorted matches of `pattern` under `root` (empty if absent)."""
+        ...
+
+    def is_gitignored(self, root: Path, path: str) -> bool | None:
+        """Return whether `path` (relative to `root`) is gitignored there.
+
+        :returns: ``True``/``False`` if the question could be answered, or
+            ``None`` if it could not (git absent, or `root` is not a git work
+            tree) — callers must treat that as its own outcome (#138, #139).
+        """
         ...
 
 
@@ -70,3 +81,7 @@ class FsProbe:
         if not root.is_dir():
             return []
         return sorted(root.glob(pattern))
+
+    def is_gitignored(self, root: Path, path: str) -> bool | None:
+        """Return whether `path` is gitignored in `root`, via ``git check-ignore``."""
+        return check_ignore(root, path)

--- a/defendable-science/defendable_science/core/gitignore.py
+++ b/defendable-science/defendable_science/core/gitignore.py
@@ -1,0 +1,81 @@
+"""Ask git, not a hand-rolled matcher, whether a path is gitignored (#138, #139).
+
+`check`'s cache_dir rule and `scaffold.render.merge_gitignore` each answered
+"is this path already gitignored?" with their own literal-line matcher —
+stripped-line equality plus a parent-directory prefix test. Neither understood
+real gitignore semantics: a `.gitignore` that legitimately covered a path
+through `**/`, a leading `/`, or a wildcard like `*.ext/` was told it did not.
+For `check` that produced a false ``invalid`` finding from the tool whose job
+is telling the truth about repo health; for `scaffold` it produced a redundant
+duplicate line on the first ``init`` into an already-correctly-configured repo.
+
+``git check-ignore`` is the actual authority on gitignore semantics: it also
+honours negations (``!pattern``), nested ``.gitignore`` files, ``.git/info/exclude``,
+and the global excludes file — none of which a hand-rolled matcher, or the
+``pathspec`` package (which only evaluates the text it is handed), would ever
+cover. Shelling out costs one subprocess per check and only works inside a
+git work tree; this repo already shells out to external tools elsewhere
+(``rclone`` in :mod:`defendable_science.core.mirror`, ``git`` itself in
+:mod:`defendable_science.core.keys`), and CLAUDE.md's light-wheel constraint is
+about not adding new *runtime dependencies* (that is why Pydantic was
+rejected), not about avoiding calls to a tool a git work tree already has.
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 - git is a trusted, fixed-arg subprocess
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _GitProc(Protocol):
+    """The minimal completed-process shape a git runner must return."""
+
+    @property
+    def returncode(self) -> int:
+        """The process exit code."""
+
+
+#: A ``git`` subprocess runner with the ``subprocess.run`` shape (injectable
+#: for tests, mirroring :data:`defendable_science.core.mirror.Runner`), so no
+#: test ever spawns a real ``git`` process or depends on the test process's
+#: own git state.
+GitRunner = Callable[..., _GitProc]
+
+
+def check_ignore(
+    root: Path, path: str, *, run: GitRunner = subprocess.run
+) -> bool | None:
+    """Ask git whether `path` (relative to `root`) is gitignored there.
+
+    Delegates to ``git check-ignore --quiet``, git's own answer, rather than
+    reimplementing gitignore-pattern matching.
+
+    :param root: The git work tree to check inside — ``git check-ignore`` runs
+        with this as its ``cwd``, regardless of the caller's own working
+        directory, so the check always uses *that* repository.
+    :param path: The path to check, relative to `root`.
+    :param run: The subprocess runner (defaults to :func:`subprocess.run`;
+        injectable so tests never spawn a real ``git`` process).
+    :returns: ``True`` if `path` is ignored, ``False`` if it is not, or
+        ``None`` if the question cannot be answered — git is absent, `root`
+        is not a git work tree, or git exits with any other code. Callers
+        must treat ``None`` as its own outcome and never collapse it into
+        either ``True`` or ``False`` (CLAUDE.md's failure-honesty rule): an
+        uncertain condition is not a definite negative.
+    """
+    try:
+        proc = run(  # nosec B603 - fixed git args, no shell
+            ["git", "check-ignore", "--quiet", "--", path],
+            capture_output=True,
+            check=False,
+            cwd=str(root),
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode in (0, 1):
+        return proc.returncode == 0
+    return None

--- a/defendable-science/defendable_science/core/gitignore.py
+++ b/defendable-science/defendable_science/core/gitignore.py
@@ -79,3 +79,37 @@ def check_ignore(
     if proc.returncode in (0, 1):
         return proc.returncode == 0
     return None
+
+
+def literal_covers(entry: str, gitignore_text: str) -> bool:
+    """Return whether `gitignore_text` literally names `entry` or a parent of it.
+
+    A narrower, git-free fallback for exactly one situation: :func:`check_ignore`
+    returned ``None`` because `entry`'s repository is not (yet) a git work
+    tree — the ordinary state of a repo between ``defendable-science init``
+    writing its ``.gitignore`` and the human running ``git init``
+    (`skills/research-init/SKILL.md`'s documented first-run order). In that
+    window a `.gitignore` can still trivially, literally cover a path — `init`
+    wrote the exact line itself — and reporting that as "cannot determine"
+    would regress a repo that demonstrably has no problem into looking
+    unusable. This never claims more than a literal reading can support: it
+    does not understand ``**/``, wildcards, or anchoring, so a caller must
+    still treat a ``False`` result from this function as "cannot rule out
+    git-only coverage", not as a confirmed negative.
+
+    :param entry: The path to look for (e.g. a configured ``cache_dir``).
+    :param gitignore_text: The ``.gitignore`` file's contents.
+    :returns: ``True`` if an active (non-comment, non-blank) line matches
+        `entry` exactly, or names a parent directory of it.
+    """
+    normalized_entry = entry.rstrip("/")
+    for line in gitignore_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped[0] == "#":
+            continue
+        normalized_line = stripped.rstrip("/")
+        if normalized_entry == normalized_line:
+            return True
+        if normalized_entry.startswith(normalized_line + "/"):
+            return True
+    return False

--- a/defendable-science/defendable_science/scaffold/init_repo.py
+++ b/defendable-science/defendable_science/scaffold/init_repo.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from defendable_science.core.gitignore import check_ignore
 from defendable_science.scaffold import render as r
 from defendable_science.scaffold import status
 from defendable_science.scaffold.layout import recorded_layout
@@ -94,10 +95,25 @@ def _mkdir(path: Path, actions: list[Action], *, dry_run: bool) -> None:
 def _merge_gitignore(
     layout: Layout, cache_dir: str, actions: list[Action], *, dry_run: bool
 ) -> None:
-    """Append any missing ignore entries to ``.gitignore``."""
+    """Append any missing ignore entries to ``.gitignore``.
+
+    An entry already covered by git — under any spelling, not just a literal
+    line — is not appended again (#139). ``check_ignore`` needs a real work
+    tree; when `layout.repo_root` is not one (``init`` may run before
+    ``git init``), it answers ``None`` for every entry, which degrades to
+    exactly the pre-#139 literal-membership behaviour: append if not
+    literally present. That must never error or silently skip the merge.
+    """
     path = layout.repo_root / ".gitignore"
     existing = path.read_text(encoding="utf-8") if path.is_file() else ""
-    merged = r.merge_gitignore(existing, r.gitignore_entries(cache_dir))
+    already_covered = [
+        entry
+        for entry in r.gitignore_entries(cache_dir)
+        if check_ignore(layout.repo_root, entry) is True
+    ]
+    merged = r.merge_gitignore(
+        existing, r.gitignore_entries(cache_dir), already_covered=already_covered
+    )
     if merged == existing:
         actions.append(Action(path=path, status="exists"))
         return

--- a/defendable-science/defendable_science/scaffold/render.py
+++ b/defendable-science/defendable_science/scaffold/render.py
@@ -277,18 +277,37 @@ def gitignore_entries(cache_dir: str) -> list[str]:
     ]
 
 
-def merge_gitignore(existing: str, entries: Sequence[str]) -> str:
+def merge_gitignore(
+    existing: str, entries: Sequence[str], *, already_covered: Sequence[str] = ()
+) -> str:
     """Append missing `entries` to an existing ``.gitignore``, verbatim otherwise.
 
     Append-only on purpose: a consumer's ``.gitignore`` is their file, and
     rewriting it to a template would discard rules the repo depends on.
 
+    This function stays pure (text in, text out, no filesystem or subprocess
+    access) so it is directly unit-testable. The literal stripped-line
+    membership test below is a fast, good-enough-on-its-own pure-text layer —
+    it is `already_covered` that carries the real gitignore-semantics answer
+    (``**/`` prefixes, leading ``/`` anchoring, wildcards, a covering parent
+    directory, ...), computed by the caller via
+    :func:`defendable_science.core.gitignore.check_ignore` against the real
+    ``.gitignore`` on disk (#138, #139), since that needs a real work tree
+    this function does not have.
+
     :param existing: The current file contents (``""`` when absent).
     :param entries: The entries that must be present.
+    :param already_covered: The subset of `entries` a caller has already
+        confirmed are gitignored by some other rule (equivalent-but
+        differently-spelled or a covering parent), so they must not be
+        appended again even though they are not a literal line here.
     :returns: The merged contents; `existing` unchanged when nothing is missing.
     """
     present = {line.strip() for line in existing.splitlines()}
-    missing = [entry for entry in entries if entry not in present]
+    covered = set(already_covered)
+    missing = [
+        entry for entry in entries if entry not in present and entry not in covered
+    ]
     if not missing:
         return existing
     prefix = existing

--- a/defendable-science/tests/test_check.py
+++ b/defendable-science/tests/test_check.py
@@ -98,6 +98,19 @@ def test_fs_probe_read_text_raises_oserror_for_a_missing_file(tmp_path: Path) ->
         FsProbe().read_text(tmp_path / "absent.md")
 
 
+def test_fs_probe_is_gitignored_delegates_to_git_check_ignore(tmp_path: Path) -> None:
+    """`FsProbe.is_gitignored` is a thin call to the real `git check-ignore` (#138)."""
+    import subprocess
+
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)  # nosec B603 B607
+    probe = FsProbe()
+
+    assert probe.is_gitignored(tmp_path, "cache/") is False
+
+    (tmp_path / ".gitignore").write_text("**/cache/\n", encoding="utf-8")
+    assert probe.is_gitignored(tmp_path, "cache/") is True
+
+
 def test_fs_probe_read_text_raises_oserror_for_a_binary_file(tmp_path: Path) -> None:
     # `UnicodeDecodeError` subclasses `ValueError`, not `OSError`, so it would
     # sail past every `except OSError:` in the checks and surface as a raw
@@ -149,10 +162,19 @@ class FakeProbe:
         files: dict[Path, str],
         unreadable: set[Path] | None = None,
         dirs: set[Path] | None = None,
+        gitignore: dict[str, bool | None] | None = None,
     ):
         self.files = files
         self.unreadable = unreadable or set()
         self.dirs = set(dirs or ())
+        #: Canned `is_gitignored` answers, keyed by the queried path. A path
+        #: not in here falls back to literal-line matching against whatever
+        #: ``.gitignore`` text lives in `files` — a best-effort stand-in for
+        #: real gitignore semantics, good enough for every test that does not
+        #: itself exercise glob/wildcard/anchoring patterns (#138). Real
+        #: coverage of those lives in `core/gitignore.py`'s own tests, which
+        #: exercise `git check-ignore` for real.
+        self.gitignore = gitignore or {}
 
     def _directories(self) -> set[Path]:
         """Every path that is a directory: the explicit ones and all ancestors."""
@@ -190,6 +212,38 @@ class FakeProbe:
             for p in {*self.files, *self._directories()}
             if root in p.parents and _matches(p.relative_to(root).parts, pat)
         )
+
+    def is_gitignored(self, root: Path, path: str) -> bool | None:
+        """Return the canned answer for `path`, or a literal-line fallback.
+
+        The fallback mirrors the pre-#138 production matcher exactly, so
+        every test that seeds a plain ``.gitignore`` and never configures
+        `gitignore` keeps its original outcome unmodified.
+        """
+        if path in self.gitignore:
+            return self.gitignore[path]
+        return _literal_gitignore_covers(path, self.files.get(root / ".gitignore", ""))
+
+
+def _literal_gitignore_covers(entry: str, gitignore_text: str) -> bool:
+    """Literal-line + parent-directory match — the matcher #138 removed.
+
+    Kept here, test-only, as `FakeProbe`'s default `is_gitignored` fallback:
+    good enough for tests that do not themselves exercise real gitignore
+    glob/wildcard/anchoring semantics, without duplicating a second
+    git-semantics evaluator in production code.
+    """
+    normalized_entry = entry.rstrip("/")
+    for line in gitignore_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped[0] == "#":
+            continue
+        normalized_line = stripped.rstrip("/")
+        if normalized_entry == normalized_line:
+            return True
+        if normalized_entry.startswith(normalized_line + "/"):
+            return True
+    return False
 
 
 ROOT = Path("/repo")
@@ -1821,6 +1875,75 @@ def test_config_check_ignores_commented_out_gitignore_entries() -> None:
         f for f in findings if "cache" in f.message and f.severity == "invalid"
     ]
     assert len(cache_missing) == 1
+
+
+# --- real gitignore semantics via `Probe.is_gitignored` (#138) ---------------
+#
+# These pin the acceptance criteria directly: a `.gitignore` that covers
+# cache_dir through a pattern a literal-line matcher cannot read (`**/`, a
+# leading `/`, a wildcard) must never produce the `invalid` finding. The fake
+# is configured with the canned answer a real `git check-ignore` would give;
+# `core/gitignore.py`'s own tests pin that git really does answer this way.
+
+
+@pytest.mark.parametrize(
+    "gitignore_line",
+    [
+        "**/.defendable-science/cache/",
+        "/.defendable-science/cache/",
+    ],
+)
+def test_config_check_accepts_a_pattern_a_literal_matcher_cannot_read(
+    gitignore_line: str,
+) -> None:
+    files = _scaffolded()
+    files[ROOT / ".gitignore"] = gitignore_line + "\n"
+    probe = FakeProbe(files, gitignore={r.DEFAULT_CACHE_DIR: True})
+
+    findings = c.check_config(LAYOUT, probe)
+
+    assert not any("cache" in f.message for f in findings)
+
+
+def test_config_check_accepts_a_wildcard_gitignore_pattern() -> None:
+    files = _scaffolded()
+    files[LAYOUT.config_file] = "cache_dir: .cache/\nexperiment_backend: bench\n"
+    files[ROOT / ".gitignore"] = "*.cache/\n"
+    probe = FakeProbe(files, gitignore={".cache/": True})
+
+    findings = c.check_config(LAYOUT, probe)
+
+    assert not any("cache" in f.message for f in findings)
+
+
+def test_config_check_still_flags_a_genuine_gitignore_miss_via_the_probe() -> None:
+    """The true-negative regression guard, now driven through `is_gitignored`."""
+    files = _scaffolded()
+    files[ROOT / ".gitignore"] = "__pycache__/\n"
+    probe = FakeProbe(files, gitignore={r.DEFAULT_CACHE_DIR: False})
+
+    findings = c.check_config(LAYOUT, probe)
+
+    cache_not_ignored = [
+        f
+        for f in findings
+        if ".defendable-science/cache" in f.message and f.severity == "invalid"
+    ]
+    assert len(cache_not_ignored) == 1
+    assert ".gitignore" in cache_not_ignored[0].remedy
+
+
+def test_config_check_reports_undeterminable_coverage_as_its_own_outcome() -> None:
+    """Git absent / not a work tree must never collapse into `invalid` (#138)."""
+    files = _scaffolded()
+    probe = FakeProbe(files, gitignore={r.DEFAULT_CACHE_DIR: None})
+
+    findings = c.check_config(LAYOUT, probe)
+
+    coverage_findings = [f for f in findings if "cache_dir" in f.message]
+    assert [f.severity for f in coverage_findings] == ["unreadable"]
+    assert "could not determine" in coverage_findings[0].message
+    assert "not in .gitignore" not in coverage_findings[0].message
 
 
 # --- cross-artifact checks -------------------------------------------------------

--- a/defendable-science/tests/test_check.py
+++ b/defendable-science/tests/test_check.py
@@ -10,6 +10,7 @@ import pytest
 from defendable_science.check import checks as c
 from defendable_science.check import model as m
 from defendable_science.check.probe import FsProbe
+from defendable_science.core.gitignore import literal_covers
 from defendable_science.digest import artifact as art
 from defendable_science.digest import extraction as ex
 from defendable_science.scaffold import render as r
@@ -222,28 +223,7 @@ class FakeProbe:
         """
         if path in self.gitignore:
             return self.gitignore[path]
-        return _literal_gitignore_covers(path, self.files.get(root / ".gitignore", ""))
-
-
-def _literal_gitignore_covers(entry: str, gitignore_text: str) -> bool:
-    """Literal-line + parent-directory match — the matcher #138 removed.
-
-    Kept here, test-only, as `FakeProbe`'s default `is_gitignored` fallback:
-    good enough for tests that do not themselves exercise real gitignore
-    glob/wildcard/anchoring semantics, without duplicating a second
-    git-semantics evaluator in production code.
-    """
-    normalized_entry = entry.rstrip("/")
-    for line in gitignore_text.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped[0] == "#":
-            continue
-        normalized_line = stripped.rstrip("/")
-        if normalized_entry == normalized_line:
-            return True
-        if normalized_entry.startswith(normalized_line + "/"):
-            return True
-    return False
+        return literal_covers(path, self.files.get(root / ".gitignore", ""))
 
 
 ROOT = Path("/repo")
@@ -1934,8 +1914,14 @@ def test_config_check_still_flags_a_genuine_gitignore_miss_via_the_probe() -> No
 
 
 def test_config_check_reports_undeterminable_coverage_as_its_own_outcome() -> None:
-    """Git absent / not a work tree must never collapse into `invalid` (#138)."""
+    """Git absent / not a work tree must never collapse into `invalid` (#138).
+
+    Uses a ``.gitignore`` that does not literally name ``cache_dir`` either,
+    so the literal-match fallback (below) cannot rescue this case — it is the
+    genuine "cannot tell at all" outcome.
+    """
     files = _scaffolded()
+    files[ROOT / ".gitignore"] = "__pycache__/\n"
     probe = FakeProbe(files, gitignore={r.DEFAULT_CACHE_DIR: None})
 
     findings = c.check_config(LAYOUT, probe)
@@ -1944,6 +1930,22 @@ def test_config_check_reports_undeterminable_coverage_as_its_own_outcome() -> No
     assert [f.severity for f in coverage_findings] == ["unreadable"]
     assert "could not determine" in coverage_findings[0].message
     assert "not in .gitignore" not in coverage_findings[0].message
+
+
+def test_config_check_falls_back_to_a_literal_match_when_git_cannot_tell() -> None:
+    """The regression #138's review caught: right after `init`, before `git init`.
+
+    A freshly-scaffolded repo's ``.gitignore`` literally names `cache_dir` —
+    ``init`` wrote it verbatim — but is not yet a git work tree, so
+    `Probe.is_gitignored` cannot answer. That must not be reported as
+    `unreadable`: the line is demonstrably there.
+    """
+    files = _scaffolded()
+    probe = FakeProbe(files, gitignore={r.DEFAULT_CACHE_DIR: None})
+
+    findings = c.check_config(LAYOUT, probe)
+
+    assert not any("cache_dir" in f.message for f in findings)
 
 
 # --- cross-artifact checks -------------------------------------------------------

--- a/defendable-science/tests/test_check_cli.py
+++ b/defendable-science/tests/test_check_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path  # noqa: TC003
 
 import pytest  # noqa: TC002
@@ -14,6 +15,9 @@ runner = CliRunner()
 
 
 def _init(root: Path) -> None:
+    # A real git work tree, so `check`'s cache_dir-coverage rule (#138) can
+    # give a definite answer via `git check-ignore` rather than "undeterminable".
+    subprocess.run(["git", "init", "-q", str(root)], check=True)  # nosec B603 B607
     assert runner.invoke(app, ["init", "--root", str(root)]).exit_code == 0
 
 

--- a/defendable-science/tests/test_gitignore.py
+++ b/defendable-science/tests/test_gitignore.py
@@ -1,0 +1,99 @@
+"""Tests for the shared ``git check-ignore`` seam (#138, #139)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path  # noqa: TC003
+from types import SimpleNamespace
+
+from defendable_science.core import gitignore as g
+
+
+def _fake_run(returncode: int) -> g.GitRunner:
+    """Build a fake ``git`` runner that always returns `returncode`."""
+
+    def _run(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(returncode=returncode)
+
+    return _run
+
+
+def _raising_run(*_args: object, **_kwargs: object) -> SimpleNamespace:
+    raise FileNotFoundError("git not found")
+
+
+def test_check_ignore_true_when_git_exits_zero(tmp_path: Path) -> None:
+    assert g.check_ignore(tmp_path, "x", run=_fake_run(0)) is True
+
+
+def test_check_ignore_false_when_git_exits_one(tmp_path: Path) -> None:
+    assert g.check_ignore(tmp_path, "x", run=_fake_run(1)) is False
+
+
+def test_check_ignore_none_on_any_other_exit_code(tmp_path: Path) -> None:
+    """128 (not a repo / usage error) — and every other code — is "undeterminable"."""
+    assert g.check_ignore(tmp_path, "x", run=_fake_run(128)) is None
+    assert g.check_ignore(tmp_path, "x", run=_fake_run(2)) is None
+
+
+def test_check_ignore_none_when_git_binary_is_absent(tmp_path: Path) -> None:
+    assert g.check_ignore(tmp_path, "x", run=_raising_run) is None
+
+
+def test_check_ignore_none_when_the_runner_raises_a_subprocess_error(
+    tmp_path: Path,
+) -> None:
+    def _run(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        raise subprocess.SubprocessError("boom")
+
+    assert g.check_ignore(tmp_path, "x", run=_run) is None
+
+
+def test_check_ignore_runs_git_in_the_given_root(tmp_path: Path) -> None:
+    seen: dict[str, object] = {}
+
+    def _run(*args: object, **kwargs: object) -> SimpleNamespace:
+        seen["cwd"] = kwargs.get("cwd")
+        seen["args"] = args[0]
+        return SimpleNamespace(returncode=1)
+
+    g.check_ignore(tmp_path, "some/path", run=_run)
+
+    assert seen["cwd"] == str(tmp_path)
+    assert seen["args"] == ["git", "check-ignore", "--quiet", "--", "some/path"]
+
+
+def test_check_ignore_against_a_real_git_repo(tmp_path: Path) -> None:
+    """End-to-end with the real ``git`` binary — the actual gitignore semantics."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)  # nosec B603 B607
+
+    # Not yet ignored.
+    assert g.check_ignore(tmp_path, ".defendable-science/cache/") is False
+
+    (tmp_path / ".gitignore").write_text(
+        "**/.defendable-science/cache/\n", encoding="utf-8"
+    )
+    assert g.check_ignore(tmp_path, ".defendable-science/cache/") is True
+
+
+def test_check_ignore_recognizes_a_leading_slash_anchored_pattern(
+    tmp_path: Path,
+) -> None:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)  # nosec B603 B607
+    (tmp_path / ".gitignore").write_text(
+        "/.defendable-science/cache/\n", encoding="utf-8"
+    )
+
+    assert g.check_ignore(tmp_path, ".defendable-science/cache/") is True
+
+
+def test_check_ignore_recognizes_a_wildcard_pattern(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)  # nosec B603 B607
+    (tmp_path / ".gitignore").write_text("*.cache/\n", encoding="utf-8")
+
+    assert g.check_ignore(tmp_path, ".cache/") is True
+
+
+def test_check_ignore_none_outside_a_git_work_tree(tmp_path: Path) -> None:
+    """A plain directory that was never ``git init``'d — the `init` fallback case."""
+    assert g.check_ignore(tmp_path, "x") is None

--- a/defendable-science/tests/test_init_repo.py
+++ b/defendable-science/tests/test_init_repo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -146,6 +147,91 @@ def test_init_reports_gitignore_as_exists_when_nothing_is_missing(repo: Path) ->
     statuses = _init(repo)
 
     assert "exists:.gitignore" in statuses
+
+
+# --- git-semantics coverage (#139): equivalent-but-differently-spelled -------
+#
+# `repo` (unlike these) is never a git work tree, so the tests above exercise
+# the literal-membership fast path and the git-absent fallback by construction
+# — `check_ignore` answers `None` for every entry there, which degrades to
+# exactly the pre-#139 behaviour. These pin the git-covered path itself.
+
+
+@pytest.mark.parametrize(
+    "gitignore_text",
+    [
+        "**/.defendable-science/cache/\n"
+        "**/.defendable-science/rclone.conf\n"
+        "**/.defendable-science/keys.json\n",
+        "/.defendable-science/cache/\n"
+        "/.defendable-science/rclone.conf\n"
+        "/.defendable-science/keys.json\n",
+        ".defendable-science/\n",  # a covering parent for all three entries
+    ],
+    ids=["double-star", "leading-slash", "covering-parent"],
+)
+def test_init_leaves_an_already_covered_gitignore_byte_identical(
+    repo: Path, gitignore_text: str
+) -> None:
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)  # nosec B603 B607
+    (repo / ".gitignore").write_text(gitignore_text, encoding="utf-8")
+
+    statuses = _init(repo)
+
+    assert "exists:.gitignore" in statuses
+    assert not any(s.startswith("merged:") for s in statuses)
+    assert (repo / ".gitignore").read_text(encoding="utf-8") == gitignore_text
+
+
+def test_init_still_appends_a_genuinely_uncovered_entry_in_a_git_repo(
+    repo: Path,
+) -> None:
+    """The true-negative regression guard, now inside a real git work tree."""
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)  # nosec B603 B607
+    (repo / ".gitignore").write_text("__pycache__/\n", encoding="utf-8")
+
+    statuses = _init(repo)
+
+    assert "merged:.gitignore" in statuses
+    text = (repo / ".gitignore").read_text(encoding="utf-8")
+    assert "__pycache__/" in text
+    assert r.DEFAULT_CACHE_DIR in text
+
+
+def test_init_falls_back_to_literal_matching_outside_a_git_work_tree(
+    repo: Path,
+) -> None:
+    """No ``git init`` here — `check_ignore` answers `None`, not `True` (#139).
+
+    A non-literal-but-equivalent spelling is therefore *not* recognised as
+    covering the entry, and `init` appends its own literal line. Not the
+    ideal outcome, but the required degradation: never error, never silently
+    skip the merge (a scaffold that quietly declines to ignore the key store
+    is worse than a duplicate line).
+    """
+    (repo / ".gitignore").write_text(
+        "**/.defendable-science/cache/\n", encoding="utf-8"
+    )
+
+    statuses = _init(repo)
+
+    assert "merged:.gitignore" in statuses
+    lines = (repo / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert "**/.defendable-science/cache/" in lines  # original, untouched
+    assert lines.count(r.DEFAULT_CACHE_DIR) == 1  # the appended literal line
+
+
+def test_init_dry_run_reports_exists_for_an_already_covered_gitignore(
+    repo: Path,
+) -> None:
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)  # nosec B603 B607
+    text = ".defendable-science/\n"  # covers all three entries
+    (repo / ".gitignore").write_text(text, encoding="utf-8")
+
+    statuses = _init(repo, dry_run=True)
+
+    assert "exists:.gitignore" in statuses
+    assert (repo / ".gitignore").read_text(encoding="utf-8") == text
 
 
 def test_dry_run_writes_nothing(repo: Path) -> None:

--- a/defendable-science/tests/test_progress_cli.py
+++ b/defendable-science/tests/test_progress_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 from datetime import date
 from pathlib import Path  # noqa: TC003
 
@@ -18,6 +19,9 @@ runner = CliRunner()
 
 
 def _init(root: Path, *, thesis: bool = False) -> None:
+    # A real git work tree, so `check`'s cache_dir-coverage rule (#138) can
+    # give a definite answer via `git check-ignore` rather than "undeterminable".
+    subprocess.run(["git", "init", "-q", str(root)], check=True)  # nosec B603 B607
     args = ["init", "--root", str(root)] + (["--thesis"] if thesis else [])
     assert runner.invoke(app, args).exit_code == 0
 

--- a/defendable-science/tests/test_render.py
+++ b/defendable-science/tests/test_render.py
@@ -223,6 +223,31 @@ def test_merge_gitignore_from_empty() -> None:
     assert merged == "# defendable-science\n.defendable-science/keys.json\n"
 
 
+def test_merge_gitignore_skips_entries_already_covered_by_git() -> None:
+    """`already_covered` (#139) — an entry not literally present is still skipped."""
+    existing = "**/.defendable-science/cache/\n"
+
+    merged = r.merge_gitignore(
+        existing,
+        r.gitignore_entries(".defendable-science/cache/"),
+        already_covered=[".defendable-science/cache/"],
+    )
+
+    # Only the two entries git-check-ignore did NOT already cover are appended.
+    assert merged.count(".defendable-science/cache/") == 1  # the original line only
+    assert ".defendable-science/rclone.conf" in merged
+    assert ".defendable-science/keys.json" in merged
+
+
+def test_merge_gitignore_is_a_noop_when_everything_is_already_covered() -> None:
+    existing = ".defendable-science/\n"
+    entries = r.gitignore_entries(".defendable-science/cache/")
+
+    merged = r.merge_gitignore(existing, entries, already_covered=entries)
+
+    assert merged == existing
+
+
 def test_rendered_config_records_a_divergent_layout(tmp_path: Path) -> None:
     """The block it writes must be the block `resolve_layout` reads back (#133)."""
     path = tmp_path / "config.yml"


### PR DESCRIPTION
## What

Replaces two hand-rolled "is this path already gitignored" matchers — one in
`check` (used by `check_config` to flag an uncovered `cache_dir`), one in
`scaffold.render.merge_gitignore` (used by `init` to decide which entries to
append) — with a single shared evaluator that asks `git check-ignore`
directly, so both agree with git about gitignore semantics (`**/`, leading
`/`, wildcards) instead of a literal-line-equality-plus-parent-prefix guess.

New module `core/gitignore.py`: `check_ignore(root, path) -> bool | None`
shells out to `git check-ignore --quiet`, returning `True`/`False`/`None`
(`None` = cannot determine — git absent, or `root` isn't a git work tree).
`check/probe.py`'s `Probe`/`FsProbe` gained `is_gitignored`, so `check`'s
tests stay hermetic against a `FakeProbe`. `scaffold.render.merge_gitignore`
gained an `already_covered` parameter (stays a pure function); `init_repo.py`
computes it via `check_ignore` before delegating.

**A literal-match fallback**, `core.gitignore.literal_covers`, is used only
when `check_ignore` returns `None`: a freshly-scaffolded repo that has not
yet been `git init`'d (the documented onboarding order in
`skills/research-init/SKILL.md`) still has a `.gitignore` that verbatim,
literally names `cache_dir` — `init` wrote it — and reporting that as
"cannot determine" would regress a repo with no actual problem into looking
unusable. Only when neither git nor a literal reading can confirm coverage
does `check` report `unreadable`. This was added after an independent review
pass caught the regression directly (see Test plan).

## Closes

Closes #138.
Closes #139.

## Test plan

- [x] `uv run pytest -q` — 1479 passed, 100% coverage
- [x] `uv run mypy` / `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uvx pre-commit run --all-files` — clean (including bandit; `# nosec`
      suppressions on the subprocess calls checked: fixed argv, no
      `shell=True`, `--` before the path argument, no injection vector)
- [x] `.gitignore` covering `cache_dir` via `**/`, leading `/`, and a
      wildcard pattern — no false `invalid`
- [x] The true-negative still fires with unchanged message/remedy
- [x] `init` into an already-correctly-configured repo (any equivalent
      spelling) leaves `.gitignore` byte-identical, reports `exists`
- [x] `init` in a non-git directory still appends entries via the literal
      fallback, never errors, never silently skips
- [x] `--dry-run` still writes nothing
- [x] **Regression caught by independent review and fixed in a second
      commit**: `check` run immediately after `init`, before `git init` —
      exactly the documented first-run sequence — was reporting the new
      `unreadable` finding where it previously passed cleanly, because
      `git check-ignore` can't answer outside a work tree at all. Fixed by
      the literal-match fallback described above; re-verified end-to-end
      against the real CLI both for the fixed case (clean) and the
      genuine-miss/genuinely-undeterminable cases (still correctly flagged)

## Scope note

`core/keys.py` already has its own independent `is_gitignored`/`GitRunner`
built the same way for an unrelated secret-store guardrail (#66) — a
different call shape and a deliberately different "uncertain = at risk"
posture (vs. `check`'s "uncertain = its own outcome"). Left unconsolidated;
reviewed and judged a reasonable scope boundary, not something this PR should
touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
