### PR TITLE
fix(cli): keep MyST field lists out of --help output

### DIFF
--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import dataclasses
 import getpass
+import inspect
 import json
 import platform
+import re
 import shutil
 import subprocess  # nosec B404 - used only to read `--version` of trusted tools
 import sys
@@ -48,8 +50,7 @@ from defendable_science.scaffold.layout import (
 )
 
 if TYPE_CHECKING:
-    import re
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
     from defendable_science.core.http import HttpClient
 
@@ -58,7 +59,120 @@ class CacheDirError(ValueError):
     """Raised on an invalid ``cache_dir:`` configuration."""
 
 
-app = typer.Typer(
+_FIELD_LIST_RE = re.compile(r"^:\w[\w-]*")
+_INLINE_ROLE_RE = re.compile(r":[A-Za-z][\w-]*:`([^`]*)`")
+
+
+def _role_target(raw: str) -> str:
+    """Render a Sphinx inline-role target the way Sphinx itself would.
+
+    :param raw: The role's backtick-quoted target, e.g. ``resolve_root`` or
+        ``~pkg.mod.func`` (a leading ``~`` means "show only the last
+        component").
+    :returns: `raw` with a leading ``~`` resolved to its last dotted
+        component; `raw` unchanged otherwise.
+    """
+    if raw.startswith("~"):
+        return raw[1:].rsplit(".", 1)[-1]
+    return raw
+
+
+def _strip_inline_roles(text: str) -> str:
+    """Strip reStructuredText inline roles (e.g. ``:func:`x```) from `text`.
+
+    :param text: Prose that may contain Sphinx inline roles such as
+        ``:func:``, ``:class:``, ``:mod:`` or ``:data:``.
+    :returns: `text` with each role replaced by its rendered target (see
+        `_role_target`); unchanged when `text` carries no role.
+    """
+    return _INLINE_ROLE_RE.sub(lambda m: _role_target(m.group(1)), text)
+
+
+def _prose_only(doc: str | None) -> str:
+    """Extract a MyST field-list docstring's prose lead-in for ``--help``.
+
+    Typer renders a command function's raw ``__doc__`` as its ``--help`` text
+    when no explicit ``help=`` is given, but ``CLAUDE.md`` requires MyST
+    field-list docstrings (``:param:``/``:returns:``/``:raises:``) on every
+    command for maintainers, mypy and the docs build. Showing that field list
+    verbatim in a terminal leaks reStructuredText markup at a user
+    (defendable-science#152) — this keeps the two conventions from colliding
+    without touching `doc` itself, so the source-facing docstring is unchanged.
+
+    :param doc: The command function's raw ``__doc__``, or `None`.
+    :returns: The dedented prose that precedes the first field-list line
+        (a line whose stripped form starts with e.g. ``:param``,
+        ``:returns:``, ``:raises`` or ``:rtype:``), with inline roles such as
+        ``:func:`x``` rendered as plain text. ``""`` when `doc` is `None`,
+        empty, or entirely a field list.
+    """
+    if not doc:
+        return ""
+    cleaned = inspect.cleandoc(doc)
+    prose_lines: list[str] = []
+    for line in cleaned.splitlines():
+        if _FIELD_LIST_RE.match(line.strip()):
+            break
+        prose_lines.append(line)
+    return _strip_inline_roles("\n".join(prose_lines).rstrip())
+
+
+class DocstringTyper(typer.Typer):
+    """A `typer.Typer` that keeps MyST field lists out of ``--help`` text.
+
+    Overrides `command` and `callback` so that, when the caller has not
+    passed an explicit ``help=``, the registered command's ``--help`` text is
+    derived from the decorated function's docstring prose only (see
+    `_prose_only`) instead of Typer's own default of the raw docstring. The
+    function's ``__doc__`` is never modified, so mypy, Sphinx and
+    ``CLAUDE.md``'s MyST-docstring convention are unaffected
+    (defendable-science#152). Applies to every group built on this class
+    without any command opting in, so a command added later cannot regress.
+    """
+
+    def command(  # type: ignore[override]
+        self, *args: Any, **kwargs: Any
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Register a command, computing ``help=`` from the docstring when absent.
+
+        :param args: Forwarded to `typer.Typer.command` (its optional
+            positional ``name``).
+        :param kwargs: Forwarded to `typer.Typer.command`; ``help`` is
+            computed from the decorated function's docstring via
+            `_prose_only` unless the caller already passed one.
+        :returns: The command-registering decorator.
+        """
+        if "help" in kwargs:
+            return super().command(*args, **kwargs)
+
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            kwargs["help"] = _prose_only(fn.__doc__)
+            return super(DocstringTyper, self).command(*args, **kwargs)(fn)
+
+        return decorator
+
+    def callback(  # type: ignore[override]
+        self, *args: Any, **kwargs: Any
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Register a callback, computing ``help=`` from the docstring when absent.
+
+        :param args: Forwarded to `typer.Typer.callback`.
+        :param kwargs: Forwarded to `typer.Typer.callback`; ``help`` is
+            computed from the decorated function's docstring via
+            `_prose_only` unless the caller already passed one.
+        :returns: The callback-registering decorator.
+        """
+        if "help" in kwargs:
+            return super().callback(*args, **kwargs)
+
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            kwargs["help"] = _prose_only(fn.__doc__)
+            return super(DocstringTyper, self).callback(*args, **kwargs)(fn)
+
+        return decorator
+
+
+app = DocstringTyper(
     name="defendable-science",
     help="Supporting tooling for the defendable-science research-workflow plugin.",
     no_args_is_help=True,
@@ -546,7 +660,7 @@ def check(
 
 
 # --- progress (defendable-science#130) --------------------------------------------
-progress = typer.Typer(
+progress = DocstringTyper(
     help="Read-only reporting: regenerate the dashboard projection.",
     no_args_is_help=True,
 )
@@ -669,7 +783,7 @@ def progress_dashboard(
 
 
 # --- literature (defendable-science#1) ------------------------------------------------
-literature = typer.Typer(
+literature = DocstringTyper(
     help="Citation-graph and metadata tools.", no_args_is_help=True
 )
 app.add_typer(literature, name="literature")
@@ -1357,7 +1471,7 @@ def lit_mirror(
 
 
 # --- dataset (defendable-science#2 manifest / #3 retrieval) ---------------------------
-dataset = typer.Typer(
+dataset = DocstringTyper(
     help="Dataset manifest, retrieval and mirroring.", no_args_is_help=True
 )
 app.add_typer(dataset, name="dataset")
@@ -1670,7 +1784,7 @@ def audit(
 
 
 # --- defend (defendable-science#4, defendable-science#68) ----------------------------------
-defend = typer.Typer(help="Defensibility record helpers.", no_args_is_help=True)
+defend = DocstringTyper(help="Defensibility record helpers.", no_args_is_help=True)
 app.add_typer(defend, name="defend")
 
 
@@ -1812,7 +1926,7 @@ def record(
 
 
 # --- backlog (defendable-science#5) ---------------------------------------------------
-backlog = typer.Typer(help="Exploration backlog management.", no_args_is_help=True)
+backlog = DocstringTyper(help="Exploration backlog management.", no_args_is_help=True)
 app.add_typer(backlog, name="backlog")
 
 _BacklogPath = Annotated[
@@ -2228,7 +2342,7 @@ def drop(
 
 
 # --- keys (defendable-science#42) -----------------------------------------------------
-keys = typer.Typer(
+keys = DocstringTyper(
     help="Store, list and check API keys & credentials (ADR-0029).",
     no_args_is_help=True,
 )
@@ -2417,9 +2531,9 @@ def path() -> None:
 
 
 # --- digest extract (defendable-science#100, spec §3.1) -------------------------------
-digest = typer.Typer(help="Reading-record helpers (digest).", no_args_is_help=True)
+digest = DocstringTyper(help="Reading-record helpers (digest).", no_args_is_help=True)
 app.add_typer(digest, name="digest")
-extract = typer.Typer(
+extract = DocstringTyper(
     help="Extraction mode: breadth reading into located matrix cells.",
     no_args_is_help=True,
 )

--- a/defendable-science/tests/test_cli_help.py
+++ b/defendable-science/tests/test_cli_help.py
@@ -1,0 +1,184 @@
+"""``--help`` output must never leak MyST field-list markup (#152).
+
+Typer renders a command's raw docstring as its ``--help`` text when no
+explicit ``help=`` is given, but ``CLAUDE.md`` requires MyST field-list
+docstrings (``:param:``/``:returns:``/``:raises:``) for maintainers, mypy and
+the docs build. `defendable_science.cli.DocstringTyper` reconciles the two by
+deriving each command's ``--help`` text from the docstring's prose only. This
+module walks the full Click command tree — so a command added later is
+covered automatically — and pins that no leaf leaks field-list syntax.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+import typer
+from typer.testing import CliRunner
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from defendable_science.cli import (
+    _prose_only,
+    _role_target,
+    _strip_inline_roles,
+    app,
+)
+
+runner = CliRunner()
+
+# The full set of MyST field-list markers actually used in cli.py docstrings
+# (confirmed by grepping `^\s*:\w` there); `:rtype` is included even though
+# unused today, matching the issue's acceptance criterion.
+_FIELD_MARKERS = (":param", ":returns", ":raises", ":rtype")
+
+
+def _unstyled(text: str) -> str:
+    """Strip ANSI styling from rendered help.
+
+    Rich styles parts of the output when colour is forced, which can split a
+    marker like ``:param`` with escape sequences, so a plain substring search
+    finds nothing. CI sets ``FORCE_COLOR``, so a test asserting on raw
+    ``--help`` output passes on a developer's machine and fails there — assert
+    on the text a reader sees, not on how a terminal happened to paint it.
+    See ``tests/test_progress_cli.py::_unstyled`` for the same helper.
+
+    :param text: Raw, possibly ANSI-styled, command output.
+    :returns: `text` with SGR escape sequences removed.
+    """
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _flatten(text: str) -> str:
+    """Collapse Rich's panel borders and line-wrap newlines to single spaces.
+
+    Rich wraps option help text inside a bordered panel, so a phrase can be
+    split by a ``│`` border plus a newline rather than by plain whitespace.
+
+    :param text: Unstyled command output that may be wrapped across lines.
+    :returns: `text` with panel borders removed and every run of whitespace
+        collapsed to one space, so a multi-word substring survives regardless
+        of terminal width.
+    """
+    return re.sub(r"\s+", " ", text.replace("│", " ")).strip()
+
+
+def _iter_commands(
+    command: Any, path: tuple[str, ...] = ()
+) -> Iterator[tuple[tuple[str, ...], Any]]:
+    """Yield every command and group in the tree rooted at `command`.
+
+    Typer vendors its own Click fork (``typer._click``) rather than depending
+    on an installed ``click`` package, so this walks the tree structurally
+    (``commands`` is a group's mapping of name to sub-command) instead of
+    importing Click types directly.
+
+    :param command: The Typer/Click command (or group) to walk.
+    :param path: The argv path already taken to reach `command`.
+    :returns: A depth-first iterator of (`path`, `command`) pairs, covering
+        `command` itself and every nested subcommand.
+    """
+    yield path, command
+    sub_commands = getattr(command, "commands", None)
+    if sub_commands:
+        for name, sub in sub_commands.items():
+            yield from _iter_commands(sub, (*path, name))
+
+
+def test_no_command_help_leaks_a_myst_field_list() -> None:
+    """Every registered command/group's ``--help`` is free of field-list syntax."""
+    root = typer.main.get_command(app)
+    seen = []
+    for path, _command in _iter_commands(root):
+        result = runner.invoke(app, [*path, "--help"])
+        assert result.exit_code == 0, (path, result.output)
+        output = _unstyled(result.stdout)
+        for marker in _FIELD_MARKERS:
+            assert marker not in output, (path, marker, output)
+        seen.append(path)
+
+    # Sanity check the walk actually reached every documented group, so a
+    # change that (e.g.) stops recursing into subgroups can't pass silently.
+    for group in ("literature", "dataset", "defend", "backlog", "keys", "digest"):
+        assert (group,) in seen
+    assert ("digest", "extract") in seen
+    assert ("progress", "dashboard") in seen
+    # Root + ~9 groups + ~35 leaf commands, give or take.
+    assert len(seen) > 30
+
+
+def test_init_help_keeps_prose_and_option_help() -> None:
+    result = runner.invoke(app, ["init", "--help"])
+    assert result.exit_code == 0
+    output = _flatten(_unstyled(result.stdout))
+    assert (
+        "Scaffold the consumer layout, and report every path considered as JSON."
+        in output
+    )
+    assert "Also scaffold the optional thesis tree." in output
+    assert "Report what would be written; write nothing." in output
+
+
+def test_check_help_keeps_prose_and_option_help() -> None:
+    result = runner.invoke(app, ["check", "--help"])
+    assert result.exit_code == 0
+    output = _flatten(_unstyled(result.stdout))
+    assert "Report the repo's validity state as JSON." in output
+    assert "Print a human-readable summary instead of JSON." in output
+
+
+def test_defend_record_help_keeps_prose_and_option_help() -> None:
+    result = runner.invoke(app, ["defend", "record", "--help"])
+    assert result.exit_code == 0
+    output = _flatten(_unstyled(result.stdout))
+    assert "Record a" in output
+    assert "examination: patch understanding + log." in output
+    assert "Transcript file, or '-' for stdin." in output
+
+
+def test_prose_only_strips_a_field_list_and_dedents() -> None:
+    doc = """Summary line.
+
+    More prose here.
+
+    :param x: something
+    :returns: a value
+    :raises ValueError: whatever
+    """
+    assert _prose_only(doc) == "Summary line.\n\nMore prose here."
+
+
+def test_prose_only_leaves_a_fieldless_docstring_unchanged_modulo_dedent() -> None:
+    doc = """Only prose, no fields.
+
+    Second paragraph.
+    """
+    assert _prose_only(doc) == "Only prose, no fields.\n\nSecond paragraph."
+
+
+def test_prose_only_of_none_or_empty_is_empty() -> None:
+    assert _prose_only(None) == ""
+    assert _prose_only("") == ""
+
+
+def test_prose_only_strips_an_inline_role_in_the_kept_prose() -> None:
+    doc = """Mentions :func:`resolve_root` inline.
+
+    :param x: something
+    """
+    assert _prose_only(doc) == "Mentions resolve_root inline."
+
+
+def test_strip_inline_roles_renders_tilde_targets_as_their_last_component() -> None:
+    text = "See :func:`resolve_root` and :class:`~pkg.mod.Thing`."
+    assert _strip_inline_roles(text) == "See resolve_root and Thing."
+
+
+def test_role_target_passes_through_a_plain_target() -> None:
+    assert _role_target("resolve_root") == "resolve_root"
+
+
+def test_role_target_resolves_a_tilde_prefixed_dotted_target() -> None:
+    assert _role_target("~pkg.mod.Thing") == "Thing"


### PR DESCRIPTION
## What

`--help` output no longer leaks MyST field-list docstrings (`:param:`,
`:returns:`, `:raises:`) or inline reStructuredText roles (`` :func:`x` ``)
— across every command in every Typer group, with no per-command opt-in.

A new `DocstringTyper(typer.Typer)` subclass overrides `command()`/
`callback()`: when a command doesn't pass an explicit `help=`, it derives
one from the function's docstring **prose only** (everything before the
first field-list line), via `_prose_only()`. The function's `__doc__` itself
is never touched, so `CLAUDE.md`'s MyST-docstring convention, mypy, and the
docs build are all unaffected. All 9 `typer.Typer(...)` instantiations
(`app`, `progress`, `literature`, `dataset`, `defend`, `backlog`, `keys`,
`digest`, `extract`) now use `DocstringTyper`, confirmed by grep — zero
plain `typer.Typer(` call sites remain.

Inline-role stripping was needed for at least one command
(`digest extract record`'s lead-in paragraph references
`` :func:`~.literature.registry.patch_triage` ``); `_role_target` renders it
the way Sphinx would (a leading `~` collapses to the last dotted component).

## Closes

Closes #152.

## Test plan

- [x] `uv run pytest -q` — 1537 passed, 100% coverage
- [x] `FORCE_COLOR=1 uv run pytest -q` — same result (CI sets `FORCE_COLOR`,
      which makes Rich inject ANSI codes into `--help` output; the new test
      strips them the same way `test_progress_cli.py::_unstyled` already
      does for the same reason)
- [x] `uv run mypy` / `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uvx pre-commit run --all-files` — clean
- [x] A test walks the entire Click command tree (via
      `typer.main.get_command(app)`) and asserts no command's `--help`
      contains `:param`/`:returns`/`:raises`/`:rtype` — covers every command
      without hand-listing them, so one added later can't regress
- [x] Positive tests: `init`/`check`/`defend record` still show their prose
      description and full per-option help
- [x] Direct unit tests for `_prose_only`/`_strip_inline_roles`/`_role_target`
- [x] Independently verified: eyeballed real `--help` output for `init`,
      `defend record`, and `digest extract record` (the inline-role case) —
      clean prose, full Options panel, no markup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
