### PR TITLE
feat(check): report a registry orphaned by a moved layout

### DIFF
--- a/defendable-science/defendable_science/check/checks.py
+++ b/defendable-science/defendable_science/check/checks.py
@@ -46,6 +46,7 @@ from defendable_science.scaffold import render as r
 from defendable_science.scaffold import status as st
 from defendable_science.scaffold.layout import (
     STAGED_DOCUMENTS,
+    Layout,
     LayoutError,
     resolve_layout,
 )
@@ -56,7 +57,6 @@ if TYPE_CHECKING:
     from defendable_science.check.probe import Probe
     from defendable_science.digest.extraction import Cell
     from defendable_science.exploration.backlog import Level, Row
-    from defendable_science.scaffold.layout import Layout
 
 #: The check family names carried on every finding these two emit.
 LAYOUT_CHECK = "layout"
@@ -261,6 +261,131 @@ def _wrong_type(layout: Layout, path: Path, *, required: str) -> Finding:
     )
 
 
+def _stale_registry_pairs(layout: Layout, probe: Probe) -> list[tuple[Path, Path]]:
+    """Pair every default-location registry with its live path, for moved keys.
+
+    An orphan can only appear where a *previous* layout put a file, and the
+    overwhelmingly common previous layout is the packaged default (#154) — so
+    this stays scoped to :meth:`Layout.default`, never a general repo scan,
+    which would risk flagging an author's own files.
+
+    Each of :data:`~defendable_science.scaffold.layout.LAYOUT_KEYS` owns a
+    disjoint set of registries (``research_root`` → the three under it,
+    ``literature_dir`` → references/triage, ``datasets_manifest`` → itself,
+    ``thesis_dir`` → aims/milestones), so the pairs this returns can never
+    collide across keys — there is no dedup to do downstream.
+
+    ``thesis_dir`` is additionally gated on the *default* thesis directory
+    existing at all: a repo that never had a thesis tree has no orphan to
+    report just because the default thesis path differs from where a moved
+    ``thesis_dir`` now resolves to, mirroring how :func:`_required_files`
+    conditions thesis files on a thesis tree existing at the *resolved*
+    location.
+
+    :param layout: The resolved layout.
+    :param probe: The filesystem seam, asked whether a default thesis tree
+        exists.
+    :returns: ``(stale_default_path, live_resolved_path)`` pairs, one per
+        registry whose owning key has moved away from the default.
+    """
+    default = Layout.default(layout.repo_root)
+    pairs: list[tuple[Path, Path]] = []
+    if layout.research_root != default.research_root:
+        pairs += [
+            (default.papers_registry, layout.papers_registry),
+            (default.portfolio_backlog, layout.portfolio_backlog),
+            (default.dashboard, layout.dashboard),
+        ]
+    if layout.literature_dir != default.literature_dir:
+        pairs += [
+            (default.references, layout.references),
+            (default.triage, layout.triage),
+        ]
+    if layout.datasets_manifest != default.datasets_manifest:
+        pairs.append((default.datasets_manifest, layout.datasets_manifest))
+    if layout.thesis_dir != default.thesis_dir and probe.exists(default.thesis_dir):
+        pairs += [
+            (default.aims, layout.aims),
+            (default.milestones, layout.milestones),
+        ]
+    return pairs
+
+
+def _orphan_finding(
+    layout: Layout, probe: Probe, stale: Path, live: Path
+) -> Finding | None:
+    """Report `stale` if it still holds a registry the layout no longer reads.
+
+    Severity is chosen deliberately, on content rather than on the key that
+    moved: an **empty** orphan is untidiness, not a defect — nothing is lost,
+    the repo is merely carrying a leftover file, so this is a ``gap`` (matches
+    how an unbound ``experiment_backend`` is a ``gap`` rather than
+    ``invalid`` — see :func:`_check_registered_paper`) and its remedy is safe
+    to say "delete", since there is nothing in the file worth keeping. A
+    **non-empty** orphan is the author's real content sitting somewhere no
+    ``defendable-science`` command will ever read again — closer to a defect
+    than to untidiness — so this is ``invalid``, and the remedy never
+    suggests deleting it: ``check`` is read-only, and #129's planned
+    ``--fix`` mode explicitly refuses to touch anything material.
+
+    "Empty" means exactly zero bytes (``probe.read_text(stale) == ""``), not
+    whitespace-stripped-empty: a file holding only a stray blank line is still
+    something an author put there, and this check must never be the reason a
+    real (if minimal) edit gets silently proposed for deletion. `Probe` has no
+    byte-size method, and none is added for this — reading the text the same
+    way every other check does is enough to make the zero-byte judgement.
+
+    A stale path that cannot be read is reported exactly like any other read
+    failure (:func:`read_or_finding`): "empty" and "could not be read" must
+    never be conflated, since only one of them means deleting the file loses
+    nothing.
+
+    :param layout: The resolved layout, used to render both paths repo-relative.
+    :param probe: The filesystem seam.
+    :param stale: The default-location path a registry used to live at.
+    :param live: The path the resolved layout reads the same registry from
+        now.
+    :returns: ``None`` if `stale` is not a file (already cleaned up, or never
+        existed at the default location); the ``unreadable`` finding if it
+        exists but cannot be read; otherwise a ``gap`` (empty) or ``invalid``
+        (non-empty) finding naming both `stale` and `live`.
+    """
+    if not is_file(probe, stale):
+        return None
+    stale_rel = layout.rel(stale)
+    live_rel = layout.rel(live)
+    text = read_or_finding(stale, layout, probe, LAYOUT_CHECK)
+    if isinstance(text, Finding):
+        return text
+    if text == "":
+        return Finding(
+            severity="gap",
+            check=LAYOUT_CHECK,
+            file=str(stale_rel),
+            message=(
+                f"{stale_rel} is an empty orphan: the layout now resolves "
+                f"this registry to {live_rel}, and nothing at {stale_rel} "
+                "reads it any more"
+            ),
+            remedy=f"delete {stale_rel} — it is empty, so nothing is lost",
+        )
+    return Finding(
+        severity="invalid",
+        check=LAYOUT_CHECK,
+        file=str(stale_rel),
+        message=(
+            f"{stale_rel} is an orphan holding content: the layout now "
+            f"resolves this registry to {live_rel}, but {stale_rel} was "
+            "never moved and no command reads it any more"
+        ),
+        remedy=(
+            f"move {stale_rel}'s content into {live_rel}, or reconsider the "
+            "layout change that stranded it; keep what is there — it is real "
+            "content, not scratch"
+        ),
+    )
+
+
 def check_layout(layout: Layout, probe: Probe) -> list[Finding]:
     """Report every required path this repo does not have in the right shape.
 
@@ -275,12 +400,21 @@ def check_layout(layout: Layout, probe: Probe) -> list[Finding]:
     not an independent fact, and reporting both would make one defect look like
     several.
 
+    Also reports a registry **orphaned** by a moved ``layout:`` key (#154): a
+    file still sitting at the packaged default location for a registry whose
+    key now resolves somewhere else. This is additive, not overlapping, with
+    the required-file check above — that check only ever looks at *resolved*
+    paths, so an orphan at the old default location never also reads as a
+    missing-file finding for the live one. See :func:`_orphan_finding` for the
+    empty/non-empty severity split and why it is chosen that way.
+
     :param layout: The resolved layout — the one definition of where each file
         lives, so a repo with a non-default ``research_root`` is checked where
         its files actually are.
     :param probe: The filesystem seam.
-    :returns: One ``invalid`` finding per defect: mis-typed directories first
-        (outermost first), then the required files in layout order.
+    :returns: Mis-typed directories first (outermost first), then the required
+        files, then any orphaned registries, all ``invalid`` except an empty
+        orphan, which is a ``gap``.
     """
     required = _required_files(layout, probe)
     findings: list[Finding] = []
@@ -306,6 +440,10 @@ def check_layout(layout: Layout, probe: Probe) -> list[Finding]:
                     remedy=remedy,
                 )
             )
+    for stale, live in _stale_registry_pairs(layout, probe):
+        orphan = _orphan_finding(layout, probe, stale, live)
+        if orphan is not None:
+            findings.append(orphan)
     return findings
 
 

--- a/defendable-science/defendable_science/check/checks.py
+++ b/defendable-science/defendable_science/check/checks.py
@@ -272,8 +272,14 @@ def _stale_registry_pairs(layout: Layout, probe: Probe) -> list[tuple[Path, Path
     Each of :data:`~defendable_science.scaffold.layout.LAYOUT_KEYS` owns a
     disjoint set of registries (``research_root`` → the three under it,
     ``literature_dir`` → references/triage, ``datasets_manifest`` → itself,
-    ``thesis_dir`` → aims/milestones), so the pairs this returns can never
-    collide across keys — there is no dedup to do downstream.
+    ``thesis_dir`` → aims/milestones) *among their own default locations* —
+    but a customised layout can still point one key's *live* path at another
+    key's *default* one (e.g. ``datasets_manifest: docs/research/papers.md``
+    while ``research_root`` moves away from ``docs/research``). A candidate
+    "stale" path that is actually some key's live target is not an orphan —
+    it is exactly the content that key resolves to — so any such candidate is
+    excluded below rather than trusted on the strength of one key having
+    moved.
 
     ``thesis_dir`` is additionally gated on the *default* thesis directory
     existing at all: a repo that never had a thesis tree has no orphan to
@@ -286,7 +292,8 @@ def _stale_registry_pairs(layout: Layout, probe: Probe) -> list[tuple[Path, Path
     :param probe: The filesystem seam, asked whether a default thesis tree
         exists.
     :returns: ``(stale_default_path, live_resolved_path)`` pairs, one per
-        registry whose owning key has moved away from the default.
+        registry whose owning key has moved away from the default and whose
+        stale candidate path is not itself some key's live target.
     """
     default = Layout.default(layout.repo_root)
     pairs: list[tuple[Path, Path]] = []
@@ -308,7 +315,17 @@ def _stale_registry_pairs(layout: Layout, probe: Probe) -> list[tuple[Path, Path
             (default.aims, layout.aims),
             (default.milestones, layout.milestones),
         ]
-    return pairs
+    live_paths = {
+        layout.papers_registry,
+        layout.portfolio_backlog,
+        layout.dashboard,
+        layout.references,
+        layout.triage,
+        layout.datasets_manifest,
+        layout.aims,
+        layout.milestones,
+    }
+    return [(stale, live) for stale, live in pairs if stale not in live_paths]
 
 
 def _orphan_finding(

--- a/defendable-science/tests/test_check.py
+++ b/defendable-science/tests/test_check.py
@@ -15,7 +15,7 @@ from defendable_science.digest import artifact as art
 from defendable_science.digest import extraction as ex
 from defendable_science.scaffold import render as r
 from defendable_science.scaffold import status as st
-from defendable_science.scaffold.layout import Layout
+from defendable_science.scaffold.layout import Layout, resolve_layout
 
 
 def _finding(severity: str) -> m.Finding:
@@ -329,6 +329,158 @@ def test_layout_check_requires_aims_once_a_thesis_dir_exists() -> None:
     assert any(f.file == "docs/research/thesis/aims.md" for f in findings)
     assert any(f.file == "docs/research/thesis/milestones.yml" for f in findings)
     assert all("--thesis" in f.remedy for f in findings)
+
+
+# --- orphaned registries (#154) -----------------------------------------------
+#
+# A layout: block moving research_root/literature_dir/datasets_manifest/
+# thesis_dir away from the default can leave a real defendable-science-owned
+# file behind at the packaged default location. `check_layout` scopes orphan
+# detection to exactly those default locations, never a general repo scan.
+
+
+def _moved(**overrides: str) -> Layout:
+    """Resolve a layout with `overrides` recorded under a ``layout:`` block."""
+    return resolve_layout({"layout": overrides}, ROOT)
+
+
+def test_layout_check_finds_no_orphans_on_the_default_layout() -> None:
+    """The "obvious way this goes wrong" (#154): a layout that moved nothing."""
+    default_layout = resolve_layout({}, ROOT)
+
+    assert c.check_layout(default_layout, FakeProbe(_scaffolded())) == []
+
+
+def _scaffolded_at(layout: Layout) -> dict[Path, str]:
+    """Return the file map a clean `init` produces, written at `layout`'s locations."""
+    return {
+        layout.papers_registry: r.render_papers_registry(),
+        layout.portfolio_backlog: r.render_portfolio_backlog(),
+        layout.dashboard: r.render_dashboard(),
+        layout.references: r.render_references(),
+        layout.triage: r.render_triage(),
+        layout.datasets_manifest: r.render_datasets_manifest(),
+        layout.config_file: r.render_config(),
+    }
+
+
+def test_layout_check_flags_an_empty_orphan_left_by_a_moved_research_root() -> None:
+    moved = _moved(research_root="writing")
+    files = _scaffolded_at(moved)
+    files[LAYOUT.papers_registry] = ""  # stale, empty, at the old default path
+
+    findings = c.check_layout(moved, FakeProbe(files))
+
+    assert len(findings) == 1, findings
+    finding = findings[0]
+    assert finding.severity == "gap"
+    assert finding.check == "layout"
+    assert finding.file == "docs/research/papers.md"
+    assert "docs/research/papers.md" in finding.message
+    assert "writing/papers.md" in finding.message
+    assert "delete" in finding.remedy
+
+
+def test_layout_check_flags_a_content_orphan_left_by_a_moved_research_root() -> None:
+    """A non-empty orphan is `invalid`, and its remedy never says to delete it."""
+    moved = _moved(research_root="writing")
+    files = _scaffolded_at(moved)
+    files[LAYOUT.papers_registry] = _registry("| p1 | writing/p1 | |\n")
+
+    findings = c.check_layout(moved, FakeProbe(files))
+
+    assert len(findings) == 1, findings
+    finding = findings[0]
+    assert finding.severity == "invalid"
+    assert finding.check == "layout"
+    assert finding.file == "docs/research/papers.md"
+    assert "docs/research/papers.md" in finding.message
+    assert "writing/papers.md" in finding.message
+    assert "delete" not in finding.remedy.lower()
+
+
+def test_layout_check_finds_no_orphan_once_the_stale_file_is_gone() -> None:
+    moved = _moved(research_root="writing")
+    files = _scaffolded_at(moved)  # nothing left at the old default paths
+
+    assert c.check_layout(moved, FakeProbe(files)) == []
+
+
+def test_layout_check_reports_an_unreadable_orphan_as_unreadable() -> None:
+    """A read failure is never conflated with "empty" — the fact is unknown."""
+    moved = _moved(research_root="writing")
+    files = _scaffolded_at(moved)
+    files[LAYOUT.papers_registry] = "stale but unreadable"
+
+    findings = c.check_layout(
+        moved, FakeProbe(files, unreadable={LAYOUT.papers_registry})
+    )
+
+    assert len(findings) == 1, findings
+    assert findings[0].severity == "unreadable"
+    assert findings[0].file == "docs/research/papers.md"
+
+
+def test_layout_check_flags_an_orphan_left_by_a_moved_literature_dir() -> None:
+    moved = _moved(literature_dir="lit")
+    files = _scaffolded_at(moved)
+    files[LAYOUT.references] = ""  # stale, empty
+    # LAYOUT.triage is intentionally absent: already cleaned up, no finding.
+
+    findings = c.check_layout(moved, FakeProbe(files))
+
+    assert len(findings) == 1, findings
+    finding = findings[0]
+    assert finding.severity == "gap"
+    assert finding.file == "docs/research/literature/references.json"
+    assert "lit/references.json" in finding.message
+
+
+def test_layout_check_flags_an_orphan_left_by_a_moved_datasets_manifest() -> None:
+    moved = _moved(datasets_manifest="data/datasets.yml")
+    files = _scaffolded_at(moved)
+    files[LAYOUT.datasets_manifest] = ""  # stale, empty
+
+    findings = c.check_layout(moved, FakeProbe(files))
+
+    assert len(findings) == 1, findings
+    finding = findings[0]
+    assert finding.severity == "gap"
+    assert finding.file == "datasets.yml"
+    assert "data/datasets.yml" in finding.message
+
+
+def test_layout_check_does_not_flag_thesis_orphans_without_a_thesis_tree() -> None:
+    """No thesis tree ever existed, so there is nothing for `thesis_dir` to orphan."""
+    moved = _moved(thesis_dir="framing")
+    files = _scaffolded_at(moved)
+
+    assert c.check_layout(moved, FakeProbe(files)) == []
+
+
+def test_layout_check_flags_orphans_left_by_a_moved_thesis_dir() -> None:
+    moved = _moved(thesis_dir="framing")
+    files = _scaffolded_at(moved)
+    files[moved.aims] = "# Aims\n"
+    files[moved.milestones] = "gates: []\n"
+    # A default thesis tree exists (kappa.md marks it), with stale aims/
+    # milestones left behind: one empty, one with content.
+    files[LAYOUT.thesis_dir / "kappa" / "kappa.md"] = (
+        "---\nstatus:\n  level: thesis\n---\n"
+    )
+    files[LAYOUT.aims] = ""
+    files[LAYOUT.milestones] = "old: true\n"
+
+    findings = c.check_layout(moved, FakeProbe(files))
+
+    by_file = {f.file: f for f in findings}
+    assert set(by_file) == {
+        "docs/research/thesis/aims.md",
+        "docs/research/thesis/milestones.yml",
+    }
+    assert by_file["docs/research/thesis/aims.md"].severity == "gap"
+    assert by_file["docs/research/thesis/milestones.yml"].severity == "invalid"
+    assert "delete" not in by_file["docs/research/thesis/milestones.yml"].remedy.lower()
 
 
 # --- path-type mismatches (#131) ---------------------------------------------

--- a/defendable-science/tests/test_check.py
+++ b/defendable-science/tests/test_check.py
@@ -406,6 +406,25 @@ def test_layout_check_finds_no_orphan_once_the_stale_file_is_gone() -> None:
     assert c.check_layout(moved, FakeProbe(files)) == []
 
 
+def test_layout_check_does_not_flag_another_keys_live_target_as_an_orphan() -> None:
+    """A customised layout can point one key's live path at another key's default.
+
+    ``research_root`` moves to ``writing``, and ``datasets_manifest`` is
+    separately pointed at ``docs/research/papers.md`` — exactly the default
+    ``papers_registry`` path. That file is genuinely live content
+    (``datasets_manifest`` resolves there), not an orphan left behind by the
+    ``research_root`` move, even though it sits at ``papers_registry``'s
+    stale default location.
+    """
+    moved = _moved(research_root="writing", datasets_manifest="docs/research/papers.md")
+    files = _scaffolded_at(moved)
+    files[moved.datasets_manifest] = "datasets:\n  - id: foo\n"
+
+    findings = c.check_layout(moved, FakeProbe(files))
+
+    assert not any(f.file == "docs/research/papers.md" for f in findings)
+
+
 def test_layout_check_reports_an_unreadable_orphan_as_unreadable() -> None:
     """A read failure is never conflated with "empty" — the fact is unknown."""
     moved = _moved(research_root="writing")


### PR DESCRIPTION
## What

`check_layout` now reports a defendable-science-owned registry left behind
at its packaged default location when a `layout:` block moves the key that
owns it — `research_root`, `literature_dir`, `datasets_manifest`, or
`thesis_dir`. Scoped to default locations only (never a general repo scan,
which would risk flagging an author's own files).

Severity is chosen on content: an **empty** orphan is `gap` (untidy, not
broken; safe to delete). A **non-empty** orphan is `invalid` (real content
sitting where nothing reads it again), with a remedy that never suggests
deletion — `check` is read-only, and #129's planned `--fix` mode explicitly
refuses to touch anything material. Both cases name the stale and live
paths.

## Closes

Closes #154.

## Test plan

- [x] `uv run pytest -q` — 1536 passed, 100% coverage
- [x] `uv run mypy` / `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uvx pre-commit run --all-files` — clean
- [x] Default layout → zero findings; each of the four keys moved
      independently; empty vs. content severity split; stale file already
      cleaned up → zero findings; unreadable orphan → `unreadable`, never
      conflated with "empty"; `thesis_dir` moved with no thesis tree at all
      → zero findings
- [x] **Independent adversarial review caught a real false positive**: a
      customised layout can point one key's live path at another key's
      *default* location (e.g. `datasets_manifest: docs/research/papers.md`
      while `research_root` moves elsewhere) — the orphan check was
      trusting "this key moved" without checking whether the stale
      candidate was actually some other key's live target, and flagged
      genuinely live, actively-read content as an orphan to be moved or
      deleted. Fixed in a second commit: `_stale_registry_pairs` now
      excludes any candidate whose stale path coincides with any of the
      layout's own live registry paths. Re-verified end-to-end against the
      real CLI — the false positive is gone, and a genuinely separate,
      real orphan in the same repo is still correctly caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)
