### PR TITLE
feat(defend): consume extraction cells as cited-work examination targets

### DIFF
--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -1741,12 +1741,35 @@ def record(
             "--log-dir", help="Accountability log; from the layout if omitted."
         ),
     ] = None,
+    no_understanding: Annotated[
+        bool,
+        typer.Option(
+            "--no-understanding",
+            help=(
+                "Skip patching status.understanding into --artifact; use for a "
+                "cited-work examination whose artifact is a digest extraction "
+                "artifact (owns status.extraction, never status.understanding)."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Record a ``defend``/``digest`` examination: patch understanding + log.
 
     Writes ``status.understanding`` into the artifact frontmatter and appends the
     full evidentiary point record (ADR-0033) to the accountability log. Records
     observed facts only — never a verdict, score, or answer key.
+
+    Pass ``--no-understanding`` when ``--artifact`` is a `digest` extraction
+    artifact rather than a reading/writing record of the author's own — for
+    instance a `cited-work` examination that probes an extracted cell (`digest
+    extract cells`) against its locator in the cited paper's own source. That
+    artifact owns ``status.extraction``; a digest carrying an ``understanding``
+    block reads to `progress` as "digested & understood", which would be false
+    for a paper nobody has read. With the flag, the artifact's frontmatter is
+    left untouched and only the accountability-log entry is written — a
+    checked cell is durable and reviewable there, distinguishable from an
+    unchecked one, without forging comprehension of the paper
+    (defendable-science#141).
 
     :param artifact: The examined markdown artifact.
     :param target: ``claim`` / ``cited-work`` / ``methodology`` /
@@ -1762,6 +1785,8 @@ def record(
         than the cwd because this command is meant to be run from inside a
         paper directory, and a cwd-relative default would bury the run's
         evidence there, where no reviewer would look for it.
+    :param no_understanding: Skip the ``status.understanding`` frontmatter
+        patch; only the accountability log is written.
     :raises typer.Exit: Code 1 on a guard violation or malformed artifact/input.
     """
     _config, layout = _layout_or_exit()
@@ -1793,6 +1818,7 @@ def record(
             acknowledgements=_parse_acks(acks),
             transcript=transcript_text,
             log_dir=log_root,
+            record_understanding=not no_understanding,
         )
     except (record_mod.RecordError, OSError) as exc:
         typer.echo(f"defend record failed: {exc}", err=True)
@@ -2536,6 +2562,74 @@ def extract_axes(paper: _PaperOpt = None, positioning: _PositioningOpt = None) -
                 "ok": error is None,
                 "positioning": str(path.resolve()),
                 "axes": axes,
+                "error": error,
+            },
+            indent=2,
+        )
+    )
+    raise typer.Exit(code=0 if error is None else 1)
+
+
+@extract.command(name="cells")
+def extract_cells(
+    citekey: Annotated[
+        str,
+        typer.Option("--citekey", help="The extracted paper's citekey."),
+    ],
+) -> None:
+    """Print one paper's recorded extraction cells as JSON — a pure read (#141).
+
+    The machine-readable counterpart to reading the digest artifact's
+    generated cells block by eye: it reads back exactly what `extract record`
+    wrote, via `~.digest.artifact.read_cells` (the one parser for that block —
+    this command adds no second one), and prints each cell's `axis`, `value`,
+    `locator` (or, for a `not-addressed` cell, `justification`). No write, no
+    log entry, no status mutation — extraction's own claim is unchanged by
+    reading it back.
+
+    This is the input `defend --target cited-work` reads when probing an
+    extracted cell against its source (`../../skills/defend/SKILL.md`): the
+    examiner opens the source at each cell's `locator` and asks whether it
+    actually supports `value`. That examination is *not* recorded through
+    this command, and not through `digest extract sample --verdict` either —
+    ``extract sample`` records that *a human spot-checked a sample of the
+    batch* (spec §8), a claim about the run's population; a `defend`
+    examination records that *this one cell was checked against its source*
+    (ADR-0033's per-point evidentiary model), a claim about that cell. The two
+    answer different questions and must not share a recording path, so the
+    outcome goes through the existing, unmodified ``defend record --target
+    cited-work`` command instead (with ``--no-understanding``, since the
+    artifact checked here owns ``status.extraction``, never
+    ``status.understanding``).
+
+    Unlike `extract_axes`/`extract_record`/`extract_sample`/`extract_render`,
+    this command takes ``--citekey`` rather than ``--paper``: those resolve
+    *the author's own paper* (whose ``positioning.md`` holds the concept
+    matrix), inferred from the cwd when omitted, but the cells read here
+    belong to the *cited* paper's digest artifact (`Layout.digest`), which has
+    no cwd-inferable identity — so the citekey is always named explicitly,
+    the same convention `extract sample --citekey` already uses.
+
+    :param citekey: The digested paper's citekey (`Layout.digest`'s key).
+    :raises typer.Exit: Code 0 with the cells as JSON; code 1 if the paper has
+        not been extracted, or its cells block is absent or malformed.
+    """
+    _config, layout = _layout_or_exit()
+    artifact = layout.digest(citekey)
+    cells: list[dict[str, Any]] | None = None
+    error: str | None = None
+    try:
+        cells = [dataclasses.asdict(c) for c in artifact_mod.read_cells(artifact)]
+    except extraction_mod.ExtractionError as exc:
+        typer.echo(f"digest extract cells failed: {exc}", err=True)
+        error = str(exc)
+    typer.echo(
+        json.dumps(
+            {
+                "ok": error is None,
+                "citekey": citekey,
+                "artifact": str(artifact),
+                "cells": cells,
                 "error": error,
             },
             indent=2,

--- a/defendable-science/defendable_science/defend/record.py
+++ b/defendable-science/defendable_science/defend/record.py
@@ -232,8 +232,27 @@ def record(
     transcript: str | None = None,
     log_dir: str | Path = DEFAULT_LOG_DIR,
     today: str | None = None,
+    record_understanding: bool = True,
 ) -> RecordResult:
     """Record an examination outcome: patch the artifact and append the log.
+
+    `target` alone does not say what `artifact` owns: for `claim`/
+    `methodology`/`paper-comprehension`, and for a `cited-work` examination of
+    the *author's own* artifact, `artifact` is a reading/writing record that
+    owns ``status.understanding``, and patching it is exactly right. But a
+    `cited-work` examination can also be driven from `digest` extraction
+    (`../digest/artifact.py`) — probing an extracted cell's value against its
+    locator in the *cited* paper's own source — and there `artifact` is that
+    paper's **digest artifact**, which owns ``status.extraction``, never
+    ``status.understanding`` (`~.digest.artifact`'s own guarantee: a digest
+    carrying an ``understanding`` block reads as "digested & understood" to
+    `progress`, so writing one from an extraction-sourced check would forge
+    exactly that signal for a paper nobody has read). `record` cannot infer
+    which case it is from `target` alone, so the caller states it: pass
+    `record_understanding=False` (CLI: ``--no-understanding``) whenever
+    `artifact` is a digest artifact being checked from its extracted cells.
+    Every other write — the log entry, its `status`/`outcome`, per-point
+    evidence — is identical either way; only the frontmatter patch is skipped.
 
     :param artifact: The examined markdown artifact.
     :param target: ``claim`` / ``cited-work`` / ``methodology`` /
@@ -246,6 +265,11 @@ def record(
     :param transcript: Optional transcript content to persist beside the artifact.
     :param log_dir: Directory for the append-only accountability log.
     :param today: ISO date (defaults to today).
+    :param record_understanding: Whether to patch ``status.understanding``
+        into `artifact`. ``True`` for every existing caller; pass ``False``
+        for a `cited-work` examination whose `artifact` is a `digest`
+        extraction artifact, which must never gain an ``understanding``
+        block from this path (defendable-science#141).
     :returns: What was written.
     :raises RecordError: On an invalid target, or if gaps are passed without a
         named sign-off.
@@ -262,10 +286,11 @@ def record(
         raise RecordError("passing surfaced gaps requires a named --signed-off-by")
 
     artifact_path = Path(artifact)
-    patched = patch_understanding(
-        artifact_path.read_text(encoding="utf-8"), status, gaps, last_updated=date
-    )
-    artifact_path.write_text(patched, encoding="utf-8")
+    if record_understanding:
+        patched = patch_understanding(
+            artifact_path.read_text(encoding="utf-8"), status, gaps, last_updated=date
+        )
+        artifact_path.write_text(patched, encoding="utf-8")
 
     transcript_path: Path | None = None
     if transcript is not None:

--- a/defendable-science/tests/test_digest_cli.py
+++ b/defendable-science/tests/test_digest_cli.py
@@ -216,6 +216,131 @@ def test_axes_reports_an_invalid_layout_block(
     assert "unknown layout key" in result.stderr
 
 
+# --- cells: the read-only accessor (defendable-science#141) -----------------------
+
+
+def test_cells_prints_the_recorded_cells_as_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    assert _record(root, GOOD_CELLS, monkeypatch=monkeypatch).exit_code == 0
+    result = runner.invoke(
+        app, ["digest", "extract", "cells", "--citekey", "sill1997monotonic"]
+    )
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["citekey"] == "sill1997monotonic"
+    assert payload["error"] is None
+    artifact = Layout.default(root.resolve()).digest("sill1997monotonic")
+    assert payload["artifact"] == str(artifact)
+    assert payload["cells"] == [
+        {
+            "citekey": "sill1997monotonic",
+            "axis": "guarantee type",
+            "value": "architectural — monotone by construction",
+            "locator": "§2, Eq. (3)",
+            "justification": None,
+        },
+        {
+            "citekey": "sill1997monotonic",
+            "axis": "partial monotonicity",
+            "value": "not-addressed",
+            "locator": None,
+            "justification": ("scoped to fully-monotone inputs in §1; never revisited"),
+        },
+    ]
+
+
+def test_cells_is_read_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No write, no log entry — a pure reader over an already-recorded paper."""
+    root = _repo(tmp_path)
+    assert _record(root, GOOD_CELLS, monkeypatch=monkeypatch).exit_code == 0
+    artifact = Layout.default(root.resolve()).digest("sill1997monotonic")
+    before = artifact.read_text(encoding="utf-8")
+    log_dir = root / "docs" / "research" / "defend-log"
+    before_log = sorted(log_dir.iterdir()) if log_dir.is_dir() else []
+    result = runner.invoke(
+        app, ["digest", "extract", "cells", "--citekey", "sill1997monotonic"]
+    )
+    assert result.exit_code == 0, result.stderr
+    assert artifact.read_text(encoding="utf-8") == before
+    after_log = sorted(log_dir.iterdir()) if log_dir.is_dir() else []
+    assert after_log == before_log
+
+
+def test_cells_refuses_a_paper_with_no_digest_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    monkeypatch.chdir(root)
+    result = runner.invoke(
+        app, ["digest", "extract", "cells", "--citekey", "never-extracted"]
+    )
+    assert result.exit_code == 1
+    assert "digest extract cells failed" in result.stderr
+    assert "digest artifact not found" in result.stderr
+    assert "Traceback" not in (result.stdout + result.stderr)
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["cells"] is None
+    assert payload["error"]
+
+
+def test_cells_refuses_an_artifact_with_no_cells_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A digest that exists (e.g. depth mode only) but was never extracted."""
+    root = _repo(tmp_path)
+    layout = Layout.default(root.resolve())
+    layout.digests_dir.mkdir(parents=True)
+    artifact = layout.digest("neverextracted2020")
+    artifact.write_text(
+        "---\nstatus:\n  understanding: {status: ok, unresolved: []}\n---\n\nBody.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(root)
+    result = runner.invoke(
+        app, ["digest", "extract", "cells", "--citekey", "neverextracted2020"]
+    )
+    assert result.exit_code == 1
+    assert "has not been extracted" in result.stderr
+    assert "Traceback" not in (result.stdout + result.stderr)
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["cells"] is None
+
+
+def test_cells_refuses_a_malformed_cells_block(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _repo(tmp_path)
+    layout = Layout.default(root.resolve())
+    layout.digests_dir.mkdir(parents=True)
+    artifact = layout.digest("corrupt2021")
+    artifact.write_text(
+        "---\nstatus:\n  extraction: {cells: 1, locators: ok, in-sample: false, "
+        "batch-check: pending}\n---\n\n"
+        f"{artifact_mod.CELLS_END}\n{artifact_mod.CELLS_BEGIN}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(root)
+    result = runner.invoke(
+        app, ["digest", "extract", "cells", "--citekey", "corrupt2021"]
+    )
+    assert result.exit_code == 1
+    assert "markers are malformed" in result.stderr
+    assert "Traceback" not in (result.stdout + result.stderr)
+
+
+def test_cells_missing_citekey_option_exits_2(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(_repo(tmp_path))
+    result = runner.invoke(app, ["digest", "extract", "cells"])
+    assert result.exit_code == 2
+
+
 # --- record: the happy path ------------------------------------------------------
 
 

--- a/defendable-science/tests/test_record.py
+++ b/defendable-science/tests/test_record.py
@@ -200,6 +200,75 @@ def test_record_never_writes_a_verdict_field(tmp_path: Path) -> None:
     assert parsed["status"]["verdict"] == "pending"
 
 
+def test_record_understanding_false_leaves_the_artifact_untouched(
+    tmp_path: Path,
+) -> None:
+    """A cited-work check sourced from digest extraction must not patch understanding.
+
+    Reproduces the extraction-artifact scenario directly (defendable-science#141):
+    the artifact owns ``status.extraction``, so ``record`` must not add — or
+    even touch — an ``understanding`` key when the caller says so.
+    """
+    artifact = _artifact(tmp_path)
+    before = artifact.read_text(encoding="utf-8")
+    result = r.record(
+        artifact,
+        "cited-work",
+        [_resolved()],
+        log_dir=tmp_path / "log",
+        today="2026-07-18",
+        record_understanding=False,
+    )
+    assert artifact.read_text(encoding="utf-8") == before
+    assert result.outcome == "resolved"
+
+
+def test_record_understanding_false_still_logs_a_gap(tmp_path: Path) -> None:
+    """The accountability log is unaffected — only the frontmatter patch is skipped."""
+    artifact = _artifact(tmp_path)
+    before = artifact.read_text(encoding="utf-8")
+    result = r.record(
+        artifact,
+        "cited-work",
+        [_gap("locator points at §3 but the claim is in §5")],
+        log_dir=tmp_path / "log",
+        today="2026-07-18",
+        record_understanding=False,
+    )
+    assert artifact.read_text(encoding="utf-8") == before
+    assert result.outcome == "unresolved"
+    entry = yaml.safe_load(result.log_entry.read_text(encoding="utf-8"))[0]
+    assert entry["target"] == "cited-work"
+    assert entry["status"] == "gaps"
+    assert (
+        entry["points"][0]["gap_note"] == "locator points at §3 but the claim is in §5"
+    )
+
+
+def test_cli_record_no_understanding_leaves_the_artifact_untouched(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact(tmp_path)
+    before = artifact.read_text(encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "defend",
+            "record",
+            "--artifact",
+            str(artifact),
+            "--target",
+            "cited-work",
+            "--no-understanding",
+            "--log-dir",
+            str(tmp_path / "log"),
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    assert artifact.read_text(encoding="utf-8") == before
+    assert json.loads(result.stdout)["outcome"] == "resolved"
+
+
 def test_record_unresolved_outcome(tmp_path: Path) -> None:
     result = r.record(
         _artifact(tmp_path),

--- a/skills/defend/SKILL.md
+++ b/skills/defend/SKILL.md
@@ -39,6 +39,9 @@ the author elects to stop and record the gap.
    artifact under examination. Load the relevant sources: the author's own cited
    works, the methodology digests under `../../resources/references/`, and the
    rigor-kit element in play. Confirm the active persona (see Mentor personas).
+   For a `cited-work` target driven by `digest` extraction, the artifact under
+   examination is a paper's digest artifact and the source is its recorded
+   cells, not prose — see "Extracted cells as a `cited-work` source" below.
 2. **Probe.** Ask one open, reasoning-eliciting question at a time — the
    reviewer/examiner agenda: novelty vs. prior work, "why this method,"
    entailments, assumptions, limitations & threats to validity, rival
@@ -64,7 +67,9 @@ the author elects to stop and record the gap.
    plus what the author actually said, resolved or not (ADR-0033) — goes to the
    accountability log, not just the frontmatter. Unanswered probes and any
    logged overrides are the accountability trail. If fired as a guardrail,
-   follow Guardrail semantics.
+   follow Guardrail semantics. **Exception:** a `cited-work` examination
+   sourced from `digest` extraction cells never writes `understanding` — see
+   below.
 
 > **Tooling.** The record step is the `defendable-science defend record` CLI command
 > (`defendable_science/defend/record.py`) — ensure via
@@ -77,7 +82,10 @@ the author elects to stop and record the gap.
 > `status:` block set `understanding: {status: ok|gaps, unresolved: [...]}` to
 > match the schema `progress` reads (`../progress/SKILL.md`), and bump
 > `status.last-updated` (do **not** nest a date inside `understanding`); if a
-> transcript is kept, write it beside the artifact as `defend-<date>.md`.
+> transcript is kept, write it beside the artifact as `defend-<date>.md`. When
+> examining an extracted cell, pass `--no-understanding` instead (see below) —
+> the artifact is a digest artifact, and this flag skips the frontmatter patch
+> while still appending the log entry.
 
 ## Example (a methodology probe)
 
@@ -111,6 +119,67 @@ On a `cited-work` gap — you can't explain what the source says, or the
 citation misrepresents it — offer a deeper remediation than an inline
 correction: a full `digest` session on that paper (`../digest/SKILL.md`).
 Same guardrail stop/offer/log semantics; no new mechanism.
+
+### Extracted cells as a `cited-work` source
+
+`digest`'s **extraction mode** (`../digest/SKILL.md` § "The extraction
+artifact") records, per paper, a concept-matrix cell per axis, each cell
+carrying a mandatory source locator — but the locator's *shape* is all
+extraction validates, never its correctness (a cell can cite §3 when the
+claim is in §5). Closing that gap is exactly what the `cited-work` target is
+for, so an extracted cell is a **named `cited-work` source**, alongside the
+author's own prose citations:
+
+1. **Entry point: the citekey.** Given a paper's citekey, read its recorded
+   cells with `defendable-science digest extract cells --citekey <citekey>`
+   (ensure via [`ensure-tooling`](../../resources/ensure-tooling.md)). This is
+   a pure read over the digest artifact's generated cells block — no write, no
+   log entry, no status change — and fails with a distinct, actionable message
+   (naming the artifact and the remedy) if the paper was never extracted or its
+   cells block is malformed; it never reports a clean empty result.
+2. **Probe cell by cell.** For each cell, ask the Scope→Probe question
+   directly: "the matrix says *`value`* for axis *`axis`*, cited at
+   *`locator`*; open the source at that locator and tell me what it actually
+   says." If the source cannot be resolved at all (no mirrored copy, a locator
+   that doesn't exist in the document), that is its own distinct refusal —
+   name the paper and the locator, and do not silently skip the cell.
+3. **Detect gap / Teach / Re-probe** exactly as for any other `cited-work`
+   probe (established knowledge → teach freely from the source). On a gap,
+   the existing escalation to a full `digest` session applies unchanged.
+4. **Record — without touching `status.understanding`.** The outcome still
+   goes through the existing `defendable-science defend record --target
+   cited-work` command, unmodified in shape — one `PointRecord` per probed
+   cell (`point` = the axis, `source_quote` = what the source actually says,
+   `reader_answer` = what the matrix cell claims, `resolved` = whether they
+   agree) — but with `--artifact` set to the paper's **digest artifact** and
+   `--no-understanding` passed. The accountability log entry is the durable,
+   reviewable record of the check (`target: cited-work`, the per-cell points,
+   `outcome`) — a checked cell shows up there even though the artifact's
+   frontmatter does not change. This is the one exception to step 6 of the
+   core loop above.
+
+**Why a distinct accessor and the existing recording path, not `digest
+extract sample --verdict`.** `extract sample --verdict` already exists and
+looks like the obvious reuse — it carries a human-check semantics
+(`in-sample` / `batch-check`) that sounds like exactly this. It was
+deliberately **not** reused, because it answers a different question. `extract
+sample --verdict` records that *a human spot-checked a deterministic sample of
+an extraction batch* — a statement about the population a survey-scale run
+produced (ADR-0040), set once per batch, not per cell. A `defend` examination
+records that *this one cell was probed against its source, right now, by
+whoever is running this loop* — a single evidentiary point in ADR-0033's
+per-point model, exactly like a `claim` or `methodology` probe. Routing the
+extraction-cell check through `extract sample --verdict` would conflate "the
+batch was sampled" with "an examination was run," letting one satisfy
+`progress`'s reporting of the other. Keeping them apart costs one small,
+purely-read CLI command (`digest extract cells`); reusing `defend record`
+for the outcome costs nothing new at all — `record()`/`patch_understanding()`
+in `defend/record.py` are already generic over `target`, so no new recording
+mechanism was needed, only the `--no-understanding` escape hatch described
+above (`record()` previously patched `status.understanding` unconditionally
+for every target, which would have forged comprehension of a paper nobody
+read — see `defendable_science/defend/record.py`'s docstring on
+`record_understanding`).
 
 **Stage presets** (suggested defaults, overridable):
 

--- a/skills/digest/SKILL.md
+++ b/skills/digest/SKILL.md
@@ -508,7 +508,12 @@ destroyed.
 The body carries the cells themselves in a delimited, generated block — that is
 the durable record. **The matrix row is a projection of it**, never authored
 independently, which is what lets `defend --target cited-work` check a cell
-later without parsing a table out of the author's prose.
+later without parsing a table out of the author's prose: it reads the block
+back with `defendable-science digest extract cells --citekey <citekey>` (a
+pure read, no write) and probes each cell's `value` against its `locator` in
+the source — see `../defend/SKILL.md` § "Extracted cells as a `cited-work`
+source" for the full loop and why the outcome is recorded through `defend
+record`, not through `extract sample --verdict`.
 
 The file is the paper's reading record *at whatever depth it has been read*. A
 survey extracts forty papers; three later get digested properly and grow an


### PR DESCRIPTION
## What

Wires `defend --target cited-work` to the cell a paper's `digest` extraction
recorded, closing the loop `is_valid_locator`'s own docstring names: it
"proves the locator's shape, never its correctness ... what catches that is
`defend --target cited-work` later".

- New read-only command `digest extract cells --citekey <citekey>`: reads a
  paper's recorded cells via the existing `digest/artifact.py:read_cells`
  (no second parser) and prints `axis`/`value`/`locator`/`justification` as
  JSON. No write, no log entry, no status mutation.
- New `record_understanding: bool = True` parameter on `defend/record.py`'s
  `record()` (CLI: `--no-understanding`, default off — every existing
  caller is unaffected). When set, the `status.understanding` frontmatter
  patch is skipped; the accountability-log entry is written exactly as
  before. This closes a real gap: `record()` previously patched
  `status.understanding` unconditionally for every target, and a digest
  artifact carrying that block reads to `progress` as "digested &
  understood" — forging comprehension of a paper nobody read, for a
  `cited-work` check that only examined one extracted cell.
- `skills/defend/SKILL.md` / `skills/digest/SKILL.md` document the new
  source and why it reuses `defend record --target cited-work
  --no-understanding` rather than `digest extract sample --verdict` — the
  two record different claims (a batch-sampling verdict vs. a per-cell
  evidentiary check) and must not share a recording path.

## Closes

Closes #141.

## Test plan

- [x] `uv run pytest -q` — 1535 passed, 100% coverage
- [x] `uv run mypy` / `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `./tools/validate-plugin.sh` / `uvx pre-commit run --all-files` — clean
- [x] Independent adversarial review reproduced the forged-comprehension
      scenario directly: recorded a `cited-work` examination against a
      digest artifact **with** `--no-understanding` (frontmatter
      byte-identical before/after, sha256-verified, full log entry
      written) and **without** it (confirmed `status.understanding` *does*
      get added — proving the flag is load-bearing, not a no-op)
- [x] All three `digest extract cells` failure modes (never extracted, no
      cells block, malformed markers) produce distinct, actionable,
      non-zero-exit errors — never an empty/clean result
- [x] Confirmed `extract_cells` reuses the same `read_cells`/`cells_from_text`
      parser `check` and `extract render` already use — no second parser
- [x] Confirmed every pre-existing `defend record` test (claim/methodology/
      paper-comprehension targets) still writes `status.understanding`
      exactly as before, unaffected by the new parameter's default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
