### PR TITLE
feat(check): validate a depth-sourced cells block with no status.extraction

### DIFF
--- a/defendable-science/defendable_science/check/checks.py
+++ b/defendable-science/defendable_science/check/checks.py
@@ -1246,7 +1246,7 @@ def _check_extraction_cells(
 
 
 def check_extraction(layout: Layout, probe: Probe) -> list[Finding]:
-    """Report every digest artifact whose ``status.extraction`` block is unsound.
+    """Report every digest artifact whose recorded cells are unsound.
 
     Extraction mode (#100) writes a second status contract into a paper's
     digest artifact — ``status.extraction`` — that ``progress`` reads into its
@@ -1258,28 +1258,38 @@ def check_extraction(layout: Layout, probe: Probe) -> list[Finding]:
 
     Reuses the writer's own parsers
     (:func:`~.artifact.extraction_status_from_text`,
-    :func:`~.artifact.cells_from_text`) and the extraction library's own
-    rules (:func:`~.extraction.is_valid_locator`,
+    :func:`~.artifact.cells_markers_present`, :func:`~.artifact.cells_from_text`)
+    and the extraction library's own rules (:func:`~.extraction.is_valid_locator`,
     :data:`~.artifact.BATCH_CHECK_VERDICTS`) rather than reimplementing them,
     so a block this reports as sound can never be one the writer, or
     ``digest extract sample``, would refuse.
 
-    An artifact with no ``status.extraction`` block is not a finding at all —
-    it may be a depth-mode-only reading record, or a paper never digested,
-    and both are legitimately silent here. An artifact carrying both
+    A ``status.extraction`` block, when present, is validated in full:
+    ``batch-check``/``locators``/``in-sample`` (:func:`_check_extraction_fields`)
+    and the claimed ``cells`` count against the actual block
+    (:func:`_check_extraction_cells`). A depth-sourced cells block — one with
+    **no** ``status.extraction`` at all (ADR-0042, defendable-science#142) —
+    has no such count to claim, so it is validated per-cell only
+    (:func:`_check_cell`: locator shape, ``NOT_ADDRESSED`` justification),
+    the same rigor an extraction-sourced cell gets (defendable-science#167).
+    An artifact with **neither** a ``status.extraction`` block **nor** any
+    cells recorded is not a finding at all — it may be a depth-mode-only
+    reading record with no matrix cells yet, or a paper never digested, and
+    both are legitimately silent here. An artifact carrying both
     ``understanding`` and ``extraction`` is validated only against
     ``extraction``'s own rules; ``understanding`` is a different, stronger
     claim this check does not touch.
 
     :param layout: The resolved layout.
     :param probe: The filesystem seam.
-    :returns: Findings for each unsound ``status.extraction`` block.
-        ``unreadable`` for a digest artifact that could not be read at all;
-        ``invalid`` for every other defect — a malformed frontmatter block, a
-        cells-block mismatch, a bad enum, a wrong type, or a cell missing its
-        locator or justification. Every one of these is a structurally wrong
-        value in a machine-read contract, never a legitimately-incomplete
-        state, so none is a ``gap``.
+    :returns: Findings for each unsound recorded-cells block, extraction- or
+        depth-sourced. ``unreadable`` for a digest artifact that could not be
+        read at all; ``invalid`` for every other defect — a malformed
+        frontmatter block, malformed cells markers, a cells-block mismatch, a
+        bad enum, a wrong type, or a cell missing its locator or
+        justification. Every one of these is a structurally wrong value in a
+        machine-read contract, never a legitimately-incomplete state, so none
+        is a ``gap``.
     """
     findings: list[Finding] = []
     patterns: list[re.Pattern[str]] | None = None
@@ -1307,16 +1317,97 @@ def check_extraction(layout: Layout, probe: Probe) -> list[Finding]:
                 )
             )
             continue
-        if extraction is None:
+        if extraction is not None:
+            if patterns is None:
+                patterns = _extraction_locator_patterns(layout, probe)
+            findings.extend(_check_extraction_fields(rel, extraction))
+            findings.extend(
+                _check_extraction_cells(rel, path, text, extraction, patterns)
+            )
             continue
 
-        if patterns is None:
-            patterns = _extraction_locator_patterns(layout, probe)
-
-        findings.extend(_check_extraction_fields(rel, extraction))
-        findings.extend(_check_extraction_cells(rel, path, text, extraction, patterns))
+        depth_findings, depth_patterns = _check_depth_sourced_cells(
+            layout, probe, rel, path, text, patterns
+        )
+        findings.extend(depth_findings)
+        if depth_patterns is not None:
+            patterns = depth_patterns
 
     return findings
+
+
+def _check_depth_sourced_cells(
+    layout: Layout,
+    probe: Probe,
+    rel: str,
+    path: Path,
+    text: str,
+    patterns: list[re.Pattern[str]] | None,
+) -> tuple[list[Finding], list[re.Pattern[str]] | None]:
+    """Validate a cells block on an artifact with no ``status.extraction`` (#167).
+
+    Either nothing has been recorded for this paper at all (legitimately
+    silent), or it carries a depth-sourced cells block (#142) — no
+    ``status.extraction.cells`` count to cross-check against, but every cell
+    still owes the same locator/justification rigor an extraction-sourced one
+    is held to (:func:`_check_cell`).
+
+    :param layout: The resolved layout.
+    :param probe: The filesystem seam.
+    :param rel: The artifact's repo-relative path, for the findings.
+    :param path: The artifact's absolute path, for the parsers' own errors.
+    :param text: The artifact's full contents, already read through `probe`.
+    :param patterns: The locator patterns computed so far, or ``None`` if none
+        have been needed yet.
+    :returns: The findings for this artifact, and the locator patterns to
+        carry forward (``None`` if this artifact never needed them).
+    """
+    try:
+        has_cells = artifact_mod.cells_markers_present(text, path)
+    except extraction_mod.ExtractionError as exc:
+        return (
+            [
+                Finding(
+                    severity="invalid",
+                    check=EXTRACTION_CHECK,
+                    file=rel,
+                    message=str(exc),
+                    remedy=(
+                        f"fix the extracted-cells markers in {rel}, or delete "
+                        "the block by hand"
+                    ),
+                )
+            ],
+            patterns,
+        )
+    if not has_cells:
+        return [], patterns
+
+    if patterns is None:
+        patterns = _extraction_locator_patterns(layout, probe)
+    try:
+        cells = artifact_mod.cells_from_text(text, path)
+    except extraction_mod.ExtractionError as exc:
+        return (
+            [
+                Finding(
+                    severity="invalid",
+                    check=EXTRACTION_CHECK,
+                    file=rel,
+                    message=str(exc),
+                    remedy=(
+                        f"{rel} has a cells block with no `status.extraction` "
+                        "(depth-sourced), but its content is malformed; "
+                        "repair it or re-run `digest depth cells record`"
+                    ),
+                )
+            ],
+            patterns,
+        )
+    findings: list[Finding] = []
+    for cell in cells:
+        findings.extend(_check_cell(rel, cell, patterns))
+    return findings, patterns
 
 
 # --- registries checks -------------------------------------------------------

--- a/defendable-science/defendable_science/digest/artifact.py
+++ b/defendable-science/defendable_science/digest/artifact.py
@@ -271,6 +271,35 @@ def _load_payload(payload: str, path: Path) -> tuple[str, list[Any]]:
     return citekey, items
 
 
+def cells_markers_present(text: str, path: Path) -> bool:
+    """Whether `text`'s body carries delimited cells markers, sound or not.
+
+    Distinguishes "no cells were ever recorded" (a legitimate absence,
+    ``False``) from "cells were recorded, but the markers are malformed" (a
+    defect, raised) — the split :func:`~.check.checks.check_extraction`
+    needs to validate a depth-sourced cells block (an artifact with no
+    ``status.extraction`` block, defendable-science#142) without treating
+    "nothing recorded yet" as a finding (defendable-science#167).
+    :func:`cells_from_text` cannot answer this alone: it raises the same
+    `ExtractionError` type whether the markers are simply absent or present
+    but broken, and a caller needs to tell those two apart before deciding
+    whether silence is correct.
+
+    :param text: The artifact's full contents, already read.
+    :param path: The artifact's path, named in any raised error.
+    :returns: Whether cells markers are present. Their *content* may still be
+        malformed — call :func:`cells_from_text` to find out once this
+        returns ``True``.
+    :raises ExtractionError: If `text` has no frontmatter, or the markers are
+        present but not a single well-ordered pair.
+    """
+    try:
+        _, body = split_frontmatter(text)
+    except FrontmatterError as exc:
+        raise ExtractionError(f"{path}: {exc}") from exc
+    return _locate_block(body, path) is not None
+
+
 def cells_from_text(text: str, path: Path) -> list[Cell]:
     """Parse a paper's recorded cells out of already-read artifact `text`.
 

--- a/defendable-science/tests/test_check.py
+++ b/defendable-science/tests/test_check.py
@@ -1172,6 +1172,33 @@ def _strip_cells_block(text: str) -> str:
     return "\n".join(lines[:begin] + lines[end + 1 :]) + "\n"
 
 
+def _depth_cells_artifact(
+    tmp_path: Path,
+    citekey: str = EXTRACT_CITEKEY,
+    cells: list[ex.Cell] | None = None,
+) -> str:
+    """Build a real depth-sourced cells artifact through the actual writer.
+
+    `write_depth_cells` requires a pre-existing `status.understanding` block
+    (defendable-science#142) — seeded here exactly as a real depth digest
+    would carry one — and never writes `status.extraction`, which is the
+    provenance signal `check_extraction` reads (defendable-science#167).
+    """
+    path = tmp_path / f"{citekey}.md"
+    path.write_text(
+        "---\nstatus:\n  understanding: {status: ok, unresolved: []}\n---\n\n"
+        f"# {citekey}\n",
+        encoding="utf-8",
+    )
+    art.write_depth_cells(
+        path,
+        _extraction_cells(citekey) if cells is None else cells,
+        log_dir=tmp_path / "log",
+        date="2026-08-28",
+    )
+    return path.read_text(encoding="utf-8")
+
+
 def test_extraction_check_is_silent_on_a_scaffolded_repo() -> None:
     assert c.check_extraction(LAYOUT, FakeProbe(_scaffolded())) == []
 
@@ -1407,6 +1434,137 @@ def test_extraction_check_uses_configured_locator_patterns(tmp_path: Path) -> No
     files[DIGEST_PATH] = text
     files[LAYOUT.config_file] = (
         "literature:\n  extraction:\n    locator_patterns:\n      - 'Widget-\\d+'\n"
+    )
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+# --- depth-sourced cells: no `status.extraction`, still validated (#167) -------
+
+
+def test_extraction_check_accepts_a_sound_depth_sourced_cells_block(
+    tmp_path: Path,
+) -> None:
+    """A depth-sourced row (#142) is validated exactly as an extracted one."""
+    files = _scaffolded()
+    files[DIGEST_PATH] = _depth_cells_artifact(tmp_path)
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_flags_a_depth_sourced_cell_with_no_locator(
+    tmp_path: Path,
+) -> None:
+    text = _depth_cells_artifact(tmp_path).replace("  locator: §2, Eq. (3)\n", "")
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "'guarantee type' cell has no locator" in findings[0].message
+
+
+def test_extraction_check_flags_a_depth_sourced_cell_locator_with_a_bad_shape(
+    tmp_path: Path,
+) -> None:
+    text = _depth_cells_artifact(tmp_path).replace(
+        "locator: §2, Eq. (3)", "locator: somewhere in the middle"
+    )
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "matches no known form" in findings[0].message
+
+
+def test_extraction_check_flags_a_depth_sourced_not_addressed_cell_with_no_justification(
+    tmp_path: Path,
+) -> None:
+    text = _depth_cells_artifact(tmp_path).replace(
+        "  justification: scoped to fully-monotone inputs in §1\n", ""
+    )
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert (
+        "'scope' cell is 'not-addressed' with no justification" in findings[0].message
+    )
+
+
+def test_extraction_check_does_not_cross_check_a_cells_count_for_depth_sourced_cells(
+    tmp_path: Path,
+) -> None:
+    """No `status.extraction.cells` claim exists for a depth-sourced block.
+
+    Unlike an extraction-sourced artifact, there is nothing here for a
+    hand-edit to desynchronise a count from — `_check_extraction_fields` and
+    the count cross-check in `_check_extraction_cells` must never run against
+    this shape at all.
+    """
+    text = _depth_cells_artifact(tmp_path)
+    assert '"batch-check"' not in text
+    assert '"in-sample"' not in text
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_flags_a_malformed_depth_sourced_cells_block(
+    tmp_path: Path,
+) -> None:
+    """Broken markers on a `status.extraction`-free artifact are still a defect."""
+    text = _depth_cells_artifact(tmp_path).replace("```yaml", "```", 1)
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "no ```yaml fence" in findings[0].message
+
+
+def test_extraction_check_flags_malformed_depth_sourced_cells_markers(
+    tmp_path: Path,
+) -> None:
+    """Duplicated markers (not just missing ones) are also a defect, not silence."""
+    text = _depth_cells_artifact(tmp_path)
+    text += f"\n{art.CELLS_BEGIN}\n{art.CELLS_END}\n"
+    files = _scaffolded()
+    files[DIGEST_PATH] = text
+
+    findings = c.check_extraction(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "malformed" in findings[0].message
+
+
+def test_extraction_check_reuses_locator_patterns_across_depth_sourced_artifacts(
+    tmp_path: Path,
+) -> None:
+    """Patterns are computed once and reused, mirroring the extraction-sourced path."""
+    other_citekey = "jones2023gadget"
+    files = _scaffolded()
+    files[DIGEST_PATH] = _depth_cells_artifact(tmp_path)
+    files[LAYOUT.digest(other_citekey)] = _depth_cells_artifact(
+        tmp_path, citekey=other_citekey
+    )
+
+    assert c.check_extraction(LAYOUT, FakeProbe(files)) == []
+
+
+def test_extraction_check_is_silent_on_a_depth_digest_with_no_cells_recorded() -> None:
+    """Neither `status.extraction` nor a cells block: legitimately silent."""
+    files = _scaffolded()
+    files[DIGEST_PATH] = (
+        "---\nstatus:\n  understanding: {status: ok, unresolved: []}\n---\n\n"
+        f"# {EXTRACT_CITEKEY}\n"
     )
 
     assert c.check_extraction(LAYOUT, FakeProbe(files)) == []

--- a/defendable-science/tests/test_digest_artifact.py
+++ b/defendable-science/tests/test_digest_artifact.py
@@ -1217,3 +1217,31 @@ def test_has_understanding_without_cells_refuses_unparseable_frontmatter(
     target.write_text("not a digest at all\n", encoding="utf-8")
     with pytest.raises(ex.ExtractionError, match="no YAML frontmatter"):
         art.has_understanding_without_cells(target)
+
+
+def test_cells_markers_present_is_false_with_no_markers_at_all(tmp_path: Path) -> None:
+    path = tmp_path / f"{CITEKEY}.md"
+    assert (
+        art.cells_markers_present("---\nstatus:\n---\n\nno cells here\n", path) is False
+    )
+
+
+def test_cells_markers_present_is_true_for_a_well_formed_block(tmp_path: Path) -> None:
+    path = tmp_path / f"{CITEKEY}.md"
+    target = tmp_path / f"{CITEKEY}.md"
+    target.write_text(DEPTH_ARTIFACT, encoding="utf-8")
+    _write_depth(target, tmp_path / "log")
+    assert art.cells_markers_present(target.read_text(encoding="utf-8"), path) is True
+
+
+def test_cells_markers_present_raises_on_duplicated_markers(tmp_path: Path) -> None:
+    path = tmp_path / f"{CITEKEY}.md"
+    text = f"---\nstatus:\n---\n\n{art.CELLS_BEGIN}\n{art.CELLS_END}\n{art.CELLS_BEGIN}\n{art.CELLS_END}\n"
+    with pytest.raises(ex.ExtractionError, match="malformed"):
+        art.cells_markers_present(text, path)
+
+
+def test_cells_markers_present_refuses_unparseable_frontmatter(tmp_path: Path) -> None:
+    path = tmp_path / f"{CITEKEY}.md"
+    with pytest.raises(ex.ExtractionError, match="no YAML frontmatter"):
+        art.cells_markers_present("not a digest at all\n", path)


### PR DESCRIPTION
## What

`check_extraction` now validates a depth-sourced cells block — one with
recorded cells but **no** `status.extraction` (the provenance signal
ADR-0042 establishes for #142's depth-mode matrix contribution) — exactly
as rigorously as an extraction-sourced one, closing a gap #142 deliberately
scoped out to stay reviewable.

- New `cells_markers_present(text, path) -> bool` in `digest/artifact.py`:
  distinguishes "no cells recorded" (`False`, legitimately silent) from
  "cells recorded but markers malformed" (raises) — `cells_from_text` alone
  can't tell these apart, since it raises the same exception type for both.
- New `_check_depth_sourced_cells` helper, run when `status.extraction` is
  absent: validates each cell via the **same** `_check_cell` extraction-sourced
  cells use (locator shape, `NOT_ADDRESSED` justification) — deliberately
  does not run `_check_extraction_fields` or any cells-count cross-check,
  since a depth-sourced block has no `status.extraction.cells` claim to
  compare against.
- `check_extraction`'s locator-pattern cache is threaded through the new
  helper so patterns are still computed at most once per run, shared across
  extraction- and depth-sourced artifacts alike.

## Closes

Closes #167.

## Test plan

- [x] `uv run pytest -q` — 1626 passed, 100% coverage
- [x] `uv run mypy` / `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uvx pre-commit run --all-files` — clean
- [x] A depth-sourced cells block with a bad locator / missing `NOT_ADDRESSED`
      justification / malformed markers each produce the expected `invalid`
      finding; a sound one produces none; no `status.extraction`/no cells at
      all stays legitimately silent
- [x] No regression to the extraction-sourced path (count cross-check,
      `batch-check`/`locators`/`in-sample` validation all unchanged)
- [x] Manual end-to-end: wrote a depth-sourced cell with a bad locator by
      hand, confirmed `defendable-science check` now flags it (previously
      invisible); fixed the locator, confirmed `check` returns clean
- [x] Independent adversarial review verified the locator-pattern cache is
      shared correctly across mixed extraction-/depth-sourced artifacts
      (including when an earlier artifact errors before ever touching
      patterns), confirmed the two branches can never both run against the
      same artifact, and confirmed `_check_cell` is the literal same
      function object in both call sites, not a copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
