### PR TITLE
docs(audit): deep codebase audit of the plugin and package

### DIFF
--- a/.codebase_audit/AUDIT-PROMPT.md
+++ b/.codebase_audit/AUDIT-PROMPT.md
@@ -1,0 +1,272 @@
+# Audit prompt
+
+The spec that produced the reports in this directory, kept here so the audit can
+be **re-run after fixes** and the results compared. Hand this file to an agent
+working in an isolated git worktree.
+
+It is deliberately adapted to *this* repo. A generic web-app audit template
+(FastAPI roles, SQLAlchemy models, Alembic migrations, Celery tasks, async
+patterns) does not fit and produces invented findings; § Stack reality records
+how each of those categories was remapped, and every remapping is load-bearing.
+
+**First run:** 2026-08-29, against `main` at `baae091`. Result: 6.5 / 10.
+
+---
+
+## Ground rules
+
+- **Audit only.** Do not modify, refactor or "fix" any source file, test, config
+  or doc. The only files you create are under `.codebase_audit/`.
+- **Do not open GitHub issues.** The report is the deliverable; recommendations
+  live in it. The maintainer triages and files.
+- **Cite `path/to/file.py:LINE` for every finding.** A finding without a line
+  citation is not a finding. Verify each citation by reading the file — never
+  cite from memory, and never trust a line number you did not confirm after your
+  last edit to your understanding of the file.
+- **Provide concrete fix snippets**, showing current code and proposed
+  replacement — not prose descriptions of a fix.
+- **Systemic issues only.** Recurring patterns, or single issues with broad blast
+  radius. No one-off nitpicks.
+- **No code style or formatting findings.** ruff, a strict pre-commit stack and
+  strict mypy already handle that. Nothing about line length, import order, quote
+  style, naming or docstring formatting.
+- **No architectural rewrites.** Identify debt and gaps. Do not propose replacing
+  Typer, adding a database, introducing async, or removing Pydantic from the
+  parsing boundary (see § Sanctioned decisions).
+- **Be calibrated, in both directions.** This repo has genuinely high discipline
+  in places — a 100% branch-coverage gate, strict mypy, 40+ ADRs, a deliberate
+  failure-honesty posture. Do not manufacture severity to fill a template; if a
+  category has no real finding, say so in one line and move on. Equally, do not
+  soften a real problem. A short report of true findings beats a padded one.
+  *The first run's most useful moves were downgrades:* `cli.py` is 3,500+ lines
+  but no function exceeds McCabe 10, so the god-module concern was reported Low
+  with the measurement attached; and a mutation spot-check killed 7/7
+  non-equivalent mutants, so the report states the coverage gate is not theatre.
+- **Where a category has no analogue, write "Not applicable — <one-line why>"**
+  rather than inventing a finding.
+- **Weight severity by research integrity.** This tool exists to produce
+  defensible scientific claims. A silent wrong value that enters the record is
+  categorically worse than a crash: a traceback announces itself, a plausible
+  wrong answer does not. Rank accordingly — the first run ranked one
+  silent-wrong-value defect above four tracebacks on exactly this reasoning.
+
+## Stack reality
+
+Verify anything you doubt, but do not re-derive from scratch.
+
+Two independently-versioned artifacts:
+
+1. **The plugin** (repo root) — the *primary* deliverable. Markdown skills in
+   `skills/<name>/SKILL.md`, plus `resources/` (contracts, templates, rigor,
+   references), `docs/design/`, `decisions/` (MADR ADRs), `.claude-plugin/`.
+2. **The package** (`defendable-science/`, module `defendable_science/`) — a
+   Typer CLI the skills shell out to. Published to PyPI, installed **isolated**
+   from the consumer's ML env.
+
+There is **no** web framework, **no** ORM, **no** database, **no** Alembic, **no**
+Celery/Redis/S3 and **no** async. Runtime deps are `typer`, `requests`, `pyyaml`,
+`pooch`, plus the optional `rclone` binary invoked as a subprocess.
+
+| Generic audit category | This repo's analogue |
+| --- | --- |
+| REST API surface | The `defendable-science <group> <cmd>` tree and **the JSON each command emits** — skills parse it, so a shape change is a breaking API change |
+| HTTP status codes | Exit-code discipline: does every failure exit non-zero, and are failure classes distinguishable? |
+| Roles / auth / middleware | The agency boundary — what the agent may decide vs. what needs a human signature; `defend`; the trusted/gated/quarantine tiers; API-key handling |
+| Rate limiting | Outbound politeness: OpenAlex polite pool, User-Agent, backoff on 429/5xx |
+| ORM / models / migrations | Git-native files: YAML frontmatter, CSL-JSON, Croissant manifests, an on-disk HTTP cache, a key store, a literature registry |
+| Missing indexes | Full-directory walks and registry rescans per invocation; cost as a consumer repo grows to hundreds of papers |
+| Transaction boundaries | Atomicity of multi-file writes; the write-temp-then-rename idiom, applied consistently or not |
+| Migrations | Artifact schema evolution in *already-initialised consumer repos*: no schema-version field, no upgrade path, `research-init adopt` behaviour on pre-existing files |
+| Soft delete | Whether the evidentiary audit trail is ever destructively overwritten |
+| Async / concurrency | Blocking-I/O discipline (timeouts, retry, subprocess handling) and partial-write races |
+| N+1 queries | Redundant uncached network round-trips and repeated filesystem walks |
+| Pydantic validation | Hand-rolled parsing of untrusted external input — see § Sanctioned decisions |
+| Raw SQL injection | `yaml.load` vs `safe_load`, path traversal from externally-derived names, zip-slip, rclone argument injection, URL/query construction from unescaped input |
+| Coverage % by module | Coverage *quality* — the gate already forces 100% (see § Coverage) |
+
+## Sanctioned decisions
+
+Things that look like findings but are settled. Do not report them as debt.
+
+- **Pydantic is permitted at the external-input parsing boundary** — third-party
+  API responses, and disk formats a human or outside party authored (Croissant,
+  CSL-JSON, YAML frontmatter, `config.yml`, the key store). It is **not** a
+  general model layer: internal value objects stay stdlib `dataclasses`, and a
+  `ValidationError` must be caught at the boundary and degraded into an explicit
+  failure signal, never a traceback or a silent default. Tracked in **#169**.
+  - At the time of the first run this was decided but not yet recorded, so
+    `CLAUDE.md` still carried a blanket "Pydantic is deliberately rejected" and
+    several ADRs cited it secondhand. **Check whether #169 has landed** before
+    reporting that inconsistency.
+  - Do **not** recommend Pydantic for sites that already validate honestly.
+    Several do — see § Known-good.
+- **Engineering is delegated** via the contract in ADR-0023. The plugin never
+  implements design/plan/code, and that is deliberate.
+- **`progress` never emits a score.** No rolled-up number, percentage or
+  completion bar; gaps are named, never counted (ADR-0014, ADR-0041). A
+  "missing summary metric" is not a finding, it is the design.
+- **The dashboard has no timestamp** (ADR-0041), so regeneration is byte-stable.
+- **`resources/templates/` is guarded against `scaffold/status.py`** by
+  `tests/test_status.py`, because the wheel cannot read plugin content
+  (ADR-0026). The status block has a single definition; do not report it as
+  four-way drift.
+
+## Known-good — do not recommend churning these
+
+The first run's most important calibration. These already do the right thing;
+report them under "Positive patterns to preserve", not as debt:
+
+- `core/keys.py:170-184`, `literature/registry.py:290-307`, `cli.py:1805-1823`,
+  `cli.py:2383-2395`, `cli.py:2774-2800` — JSON parsers that `isinstance`-check,
+  raise typed domain errors naming the file, and distinguish malformed from
+  absent.
+- `core/config.py:81-98`, `literature/registry.py:505-516`,
+  `digest/artifact.py:256-271,385-390`, `progress/collect.py:456-490`,
+  `dataset/manifest.py:301-330` — the YAML equivalents. `progress/collect.py`
+  separates unreadable / invalid / missing-key / wrong-type, each with a remedy.
+- `core/frontmatter.py` — a deliberately host-preserving *line editor* that
+  refuses a write it cannot round-trip. Replacing it with a YAML round-trip
+  would destroy user comments and key order. Never recommend that.
+- `core/http.py:169-180` — write-temp-then-rename on the cache. The pattern
+  other write sites should follow.
+
+## Open issues — cite, do not re-recommend
+
+Check each is still open before relying on this list; if one has landed, verify
+the fix rather than repeating the finding.
+
+- **#169** — Pydantic ADR + adoption at the JSON boundaries. Covers six verified
+  defects in `literature/graph.py`, `literature/acquire.py` and `cli.py:1549`.
+- **#171** — the YAML boundaries: the status-block enums are declared in
+  `scaffold/status.py` but enforced only in `check/checks.py`, so `progress`
+  renders an invalid `verdict` as though it were a decision.
+- **#173** — the silent-wrong-value sites outside #169: the unescaped OpenAlex
+  `filter` in `acquire.py:713` and the `str()` coercion in `dataset/manifest.py`.
+
+Where a finding of yours matches one of these, note "tracked in #NNN" beside it.
+Where it does not, report it normally. **Audit independently — do not skip a
+finding because you assume an issue covers it, and say so if you disagree with
+one.** A second run that only echoes the first is worth nothing.
+
+## Setup — measure, do not assume
+
+```bash
+cd defendable-science && uv sync
+uv run pytest -q                       # hermetic suite + coverage
+uv run mypy                            # strict
+uv run ruff check                      # for C901 complexity counts only, NOT style findings
+uv run bandit -r defendable_science/
+cd .. && ./tools/validate-plugin.sh
+git log --format='%an|%ae|%ad' --date=short
+git log --merges --format='%s'
+```
+
+Also read `.github/workflows/`, `.pre-commit-config.yaml`, `codecov.yml`,
+`tools/`, `RELEASING.md`, `CONTRIBUTING.md`, `STATUS.md`.
+
+**Measure every metric yourself.** The first run was handed baseline numbers that
+were wrong (a truncated `find` had undercounted the package by twelve files) and
+correcting them was the right call. Do not carry numbers forward from the
+existing reports either — recount, and note any drift. Never present an
+unmeasured number as measured; if a command fails or is slow, say what happened.
+
+Alembic is absent; record that explicitly in `data-tech-debt.md` and audit the
+real analogue (artifact schema evolution) rather than skipping the section.
+
+## Deliverables
+
+Seven files in `.codebase_audit/`. The seventh is not optional — the plugin is
+the primary deliverable and is invisible to pytest, mypy and ruff.
+
+1. **`executive-summary.md`** — rating out of 10 with a weighted scoring table
+   over: architecture & plugin↔package boundary; test-suite quality (not raw
+   coverage %); code duplication; CLI/JSON-contract design; artifact/data model;
+   failure honesty & degradation; dependency management & supply chain;
+   git/DevOps/release discipline; bus factor & contributor scaling;
+   documentation & ADR discipline. Plus: contributor table (with merge-commit
+   analysis and how many merged PRs carry a review record); project metrics;
+   what works (4–6, cited); critical gaps (top 5–6, systemic, cited); risk table
+   (risk · severity · likelihood · blast radius); recommendations grouped
+   Immediate / Short-Term / Medium-Term; links to the other six.
+   **Write this last**, so its scores are traceable to the detail files.
+2. **`project-brief.md`** — domain documentation derived from the code and
+   skills, not the README: the three nested levels and the exploration→resolution
+   firewall; actors and the agency/access-control model with `file:line` for each
+   enforcement point; every entity with attributes, statuses and state machines;
+   an automation trigger→effect table; a concepts glossary.
+3. **`be-tech-debt.md`** — package internals. God modules (quantify: functions
+   per module, C901 hotspots); type-annotation weakness despite strict mypy
+   (hunt `Any`, `cast(`, `type: ignore` — **`cast()` as a substitute for runtime
+   validation is a package-wide pattern worth sweeping for**); exception
+   handling and failure-honesty violations; blocking-I/O discipline and
+   non-atomic writes; redundant network/filesystem work; dependency-injection
+   claims vs. reality; hardcoded config/paths/magic strings; unvalidated
+   untrusted input; the real injection surface; circular imports; global mutable
+   state; duplication. End with "Positive patterns to preserve".
+4. **`api-tech-debt.md`** — the CLI + JSON contract. Inventory every command's
+   output shape and tabulate it; exit-code discipline; unbounded result sets;
+   option validation; outbound politeness; thin/missing help text; key leakage
+   into output, logs or cache; the plugin↔package compat pin; machine-readable
+   error shapes; chatty commands. **Highest-value automated check: extract every
+   `defendable-science …` / `dsci …` invocation from `skills/**`, `resources/**`
+   and `docs/**`, and verify each command, subcommand and flag against the real
+   Typer tree in `cli.py`.** The first run found four that do not run. Nothing
+   tests this. End with "Positive patterns to preserve".
+5. **`data-tech-debt.md`** — the git-native artifact layer, per the mapping
+   table. Alembic explicitly N/A. End with "Positive patterns to preserve".
+6. **`coverage.md`** — the gate forces 100% branch coverage, so grouping modules
+   by percentage is a table of identical numbers. Report the measured result,
+   then audit what a 100% gate structurally cannot catch: strongly vs. weakly
+   asserted vs. incidentally covered; every `# pragma: no cover` and
+   `exclude_also` pattern judged individually; what only `@pytest.mark.live`
+   exercises; whether fixtures are recorded responses or idealised hand-written
+   ones; concurrency and crash-recovery; malformed/`null`/huge/unicode inputs;
+   whether the hand-rolled parsers are fuzzed; test-suite duplication; and the
+   untested plugin half. A mutation spot-check is worth doing if cheap — the
+   first run hand-built a harness in `/tmp` and covered one module.
+7. **`plugin-tech-debt.md`** — skill consistency and firewall integrity;
+   domain-neutrality violations; skill↔CLI drift from the plugin side;
+   duplication across skills and `resources/`; the `ensure-tooling.md` bootstrap
+   and its compat pin; ADR hygiene (superseded-but-unmarked, and material
+   decisions in the code with no ADR); spec-vs-reality drift in `docs/design/`;
+   packaging and the two-artifact versioning rule (ADR-0026). End with "Positive
+   patterns to preserve".
+
+## Method
+
+1. Set up, run the tooling, collect real numbers.
+2. Deep-read the package **and** the plugin before writing anything, so findings
+   are consistent and cross-references accurate.
+3. You may parallelise drafting after that shared pass, but you own final
+   consistency: no contradictory claims between files, no duplicate findings
+   presented as distinct, every citation verified. Read everything a subagent
+   produces before committing.
+4. Cross-link the reports; write the executive summary last.
+
+## Re-run mode
+
+When a previous report set exists in this directory, additionally:
+
+- **Classify every prior finding** as `fixed` / `partially fixed` / `persisting`
+  / `no longer applicable`, with the evidence. A finding marked fixed needs the
+  commit or PR that fixed it and a citation showing the current code.
+- **Verify, do not assume.** A closed issue is not proof; read the code.
+- **Say what got worse.** New debt since the last run matters as much as
+  progress, especially in modules that were recently touched.
+- Add a short **`delta.md`** (an eighth file) leading with the score change and
+  the fixed/persisting/new counts, then the per-finding table. Keep the seven
+  main reports current in themselves — a reader should not have to reconstruct
+  the present state by replaying deltas.
+- Re-measure every metric and note drift from the previous run's figures.
+
+## Finishing
+
+Open a PR with the local **`create-pr`** skill (`.claude/skills/create-pr/`).
+Never commit to `main`. Commit only `.codebase_audit/`; verify with `git status`
+that nothing else is staged. Authored **Davor Runje `<davor@synthpop.ai>`** with
+the `Co-Authored-By: Claude` trailer — these are not skill-produced research
+artifacts, so the discovery trailers do not apply. No `Closes #`.
+
+In the PR body: state it is documentation-only, give the headline rating (and
+the delta on a re-run), summarise the top findings with links into the report
+files, and list anything you could not complete and why.

--- a/.codebase_audit/api-tech-debt.md
+++ b/.codebase_audit/api-tech-debt.md
@@ -1,0 +1,802 @@
+# The CLI + JSON contract surface
+
+**Framing.** This package has no HTTP API. Its public interface is the
+`defendable-science <group> <cmd>` command tree and **the JSON each command prints**,
+because markdown skills parse that output and branch on it. A change to a JSON key is
+a breaking change to a consumer exactly as a REST field rename would be. `cli.py` is
+the authoritative Typer tree; `skills/**/SKILL.md` are the clients.
+
+Tree measured 2026-08-29 by walking the live Click tree: **38 commands** across 8
+groups.
+
+---
+
+## Priority index
+
+| # | Finding | Severity |
+|---|---|---|
+| API-1 | No response envelope: 38 commands, 7 incompatible output shapes | **High** |
+| API-2 | Four skill/doc invocations do not run against the shipped CLI | **High** |
+| API-3 | Nothing tests the skill↔CLI contract | **High** |
+| API-4 | Output shape switches on a flag: `--all` returns an array, the bare form an object | **High** |
+| API-5 | Exit-code taxonomy is inconsistent; only one command distinguishes transport failure | **Medium** |
+| API-6 | The compat pin names a package version that has never been released | **Medium** |
+| API-7 | Failures are plain-text stderr, not machine-readable | **Medium** |
+| API-8 | Unbounded result sets: no `--limit`/`--offset` anywhere | **Medium** |
+| API-9 | No version field in any emitted JSON, and no stated policy for a breaking change | **Medium** |
+| API-10 | Chatty commands the skills must loop over | **Low** |
+| API-11 | Flag-combination validation is ad hoc | **Low** |
+| API-12 | Nine design-record invocations describe flags that never existed | **Low** |
+
+Documentation coverage is a non-finding: every command has a MyST field-list
+docstring, and `DocstringTyper` (`cli.py:120`) strips the field list out of `--help`
+so the two conventions do not collide. `tests/test_cli_help.py` walks the whole tree
+and enforces it. That is better than most CLIs manage.
+
+---
+
+## High
+
+### API-1 — No response envelope: 38 commands, 7 incompatible output shapes
+
+Every command was read and its `typer.echo(json.dumps(...))` payload recorded.
+
+| Shape | Commands | Payload |
+|---|---|---|
+| **A. `{ok, …, error, errors[]}`** — a real envelope | `digest extract axes/cells/record/sample/render` (`cli.py:2673`, `:2740`, `:2833`, `:3188`, `:3519`) | `ok` bool, per-item `errors[]`, whole-run `error` |
+| **B. `{ok, …}`** — partial | `dataset validate` (`cli.py:1529`), `dataset verify` (`cli.py:1704`), `dataset audit` (`cli.py:1768`), `literature verify` (`acquire.py:2214`) | `ok`, no `error` field |
+| **C. domain dict, no `ok`** | `init` (`cli.py:576`), `check` (`cli.py:657`), `progress dashboard` (`cli.py:757`), `defend record` (`cli.py:1940`), `literature fetch` (`acquire.py:2120`), `literature confirm` (`acquire.py:935`), `literature mirror` (`acquire.py:2317`), `dataset mirror` (`cli.py:1739`), `dataset ingest` (`cli.py:1560`), `literature resolve` (`graph.py:221`) | success inferred from the exit code or from a domain field |
+| **D. bare array** | `literature cites` (`cli.py:932`), `literature refs` (`cli.py:944`), `literature enrich` (`cli.py:964`), `dataset fetch` (`cli.py:1682`), `dataset emit --all` (`cli.py:1589`), `backlog list` (`cli.py:2110`), `keys list` (`cli.py:2522`), `keys check` (`cli.py:2533`) | no envelope at all |
+| **E. bare object** | `backlog park/add/rank/drop` and `promote` without `--scaffold` (`cli.py:2035`), `literature neighbors` (`cli.py:990`), `dataset emit <id>` (`cli.py:1596`) | the row / result, nothing else |
+| **F. array *or* object depending on a flag** | `literature verify` (`cli.py:1402`), `literature mirror` (`cli.py:1467`), `dataset emit` (`cli.py:1589` vs `:1596`), `backlog promote` (`cli.py:2339` vs `:2340`) | see API-4 |
+| **G. plain text, not JSON** | `doctor` (`cli.py:242`), `keys set` (`cli.py:2479`), `keys unset` (`cli.py:2546`), `keys path` (`cli.py:2555`), `check --text` (`cli.py:645`) | human-readable lines |
+
+There is no consistent way to answer "did this succeed?", "is this empty?" or "what
+went wrong?" across the tree. A skill must know, per command, which of seven
+conventions applies. The newest family (shape A, added with `digest extract`) got it
+right and nothing was retrofitted.
+
+Two smaller inconsistencies in the same area:
+
+- **`literature refs` alone omits `indent=2`.** `cli.py:944`:
+  ```python
+        typer.echo(
+            json.dumps(graph_mod.refs(_openalex_id(client, identifier), client=client))
+        )
+  ```
+  Every one of its 20 siblings passes `indent=2`. A consumer diffing or hashing output
+  sees two formats.
+- **`literature fetch` duplicates rows across buckets.** `acquire.py:2151`:
+  ```python
+        report[outcome.bucket].append(outcome.as_json())
+        if outcome.committable:
+            report["committable"].append(outcome.as_json())
+  ```
+  A committable outcome appears in both `fetched[]` and `committable[]` as two
+  independent copies of the same 14-key object. A consumer counting rows across
+  buckets over-counts; the payload roughly doubles for an open-access sweep.
+
+**Fix** — one envelope helper, applied to new commands immediately and to shape B–F
+commands at the next major bump (this is a breaking change; see API-9):
+
+```python
+# cli/_emit.py
+from typing import Any, NoReturn
+
+
+def emit(
+    payload: dict[str, Any],
+    *,
+    ok: bool,
+    error: str | None = None,
+    errors: list[dict[str, Any]] | None = None,
+    exit_code: int | None = None,
+) -> NoReturn:
+    """Print one command's result in the house envelope and exit.
+
+    Every command answers the same three questions in the same three keys, so a
+    skill never has to know which of seven conventions a command follows:
+    ``ok`` (did the whole run succeed), ``error`` (the one thing that stopped it,
+    or ``null``), ``errors`` (the per-item failures, ``[]`` when there were none).
+    An empty ``errors`` with ``ok: true`` is a *legitimately empty* result; the
+    same list with ``ok: false`` is a failed run — the distinction the
+    failure-honesty rule exists to preserve.
+
+    :param payload: The command's own domain keys, merged in at the top level.
+    :param ok: Whether the run did what it was asked.
+    :param error: The whole-run failure, if any.
+    :param errors: Per-item failures.
+    :param exit_code: Override; defaults to 0 when `ok`, else 1.
+    """
+    typer.echo(
+        json.dumps(
+            {
+                "ok": ok,
+                "api_version": 1,
+                **payload,
+                "error": error,
+                "errors": errors or [],
+            },
+            indent=2,
+        )
+    )
+    raise typer.Exit(code=exit_code if exit_code is not None else (0 if ok else 1))
+```
+
+Bare-array commands wrap their list under a named key (`{"ok": true, "works": [...]}`),
+which also gives them somewhere to put the pagination fields API-8 wants. The three
+plain-text `keys` commands should gain JSON output rather than lose their text
+(`keys path` is read by shell scripts); add `--json` to those three specifically.
+
+---
+
+### API-2 — Four skill/doc invocations do not run against the shipped CLI
+
+Extracted every `defendable-science …` / `dsci …` invocation from `skills/**`,
+`resources/**`, `docs/**`, `README.md`, `CHANGELOG.md`, `STATUS.md` and checked each
+against the live tree. Four hard failures — each reproduced.
+
+**(a) `docs/USER-GUIDE.md:182` — wrong-case flag**
+```
+defendable-science backlog rank <id> --EIG high --feas med --interest high \
+```
+The option is `--eig` (`cli.py:2119`). `EIG` is the *table column* name
+(`exploration/backlog.py:44`), not the flag. → `No such option: --EIG`, exit 2.
+
+**(b) `docs/guides/dataset.md:32` — missing required positional, in the example that
+defines the guide's own convention**
+```bash
+# Anything in a shell block is a real command, verbatim.
+defendable-science dataset verify
+```
+`identifier` is required (`cli.py:1687`). → `Missing argument 'IDENTIFIER'.`, exit 2.
+The block immediately above it (`docs/guides/dataset.md:28`) says "You are not meant to
+type it into a shell" about quote blocks — so this is the line asserting that shell
+blocks *are* verbatim, and it is broken.
+
+**(c) `docs/guides/dataset.md:139` — same command, and the prose asks for a sweep**
+```bash
+defendable-science dataset verify
+```
+The surrounding prose (`docs/guides/dataset.md:142`) reads *"do the bytes on this
+machine still match what I published?"* — a whole-manifest question. `verify` has no
+`--all` and no optional-id form; the sweep is `dataset audit` (`cli.py:1744`, id
+optional). So this is both a broken command and the wrong command.
+
+**(d) `skills/hypothesis-exploration/SKILL.md:56` — a documented column header the CLI
+refuses**
+```
+| id | one-line hypothesis | move/type | provenance | EIG | feas | interest | frame | status | note |
+```
+The canonical column is `one-line` (`exploration/backlog.py:39`). This is load-bearing
+because `skills/hypothesis-exploration/SKILL.md:79` tells the agent to *"edit the
+`backlog.md` table directly, keeping the column order above so the `backlog` verbs
+(`rank`, `promote`, `list`) can parse it."* `Backlog.columns` uses the file's own header
+(`exploration/backlog.py:169`) and `_append` calls
+`_require("id", "one-line", "provenance", "status")` (`exploration/backlog.py:303`), so
+a table built to this documented spec is permanently unwritable:
+
+```
+backlog table cannot carry required column(s) ['one-line']: its header is
+['id', 'one-line hypothesis', ...]; add them, or migrate the table to the
+hypothesis profile ['id', 'one-line', ...]
+```
+
+The error message is excellent. The document that caused it is the problem.
+
+**Fix**: `--EIG` → `--eig`; both `dataset verify` calls → `dataset verify imagenet-c`
+(or `dataset audit` at `:139` if the sweep is meant); `one-line hypothesis` →
+`one-line`. All four are one-token edits. The systemic fix is API-3.
+
+---
+
+### API-3 — Nothing tests the skill↔CLI contract
+
+`defendable-science/tests/test_plugin_content.py` is the only test that opens a
+`SKILL.md`. It asserts exactly one thing —
+`test_no_skill_hard_codes_the_research_tree` (`tests/test_plugin_content.py:52`) greps
+for the literal `docs/research/` in prose — and it **deliberately skips fenced code
+blocks** (`tests/test_plugin_content.py:70`), which is where every CLI invocation
+lives.
+
+`tests/test_cli_help.py:90` walks the whole Click tree but only asserts the help text
+carries no MyST markup. `tools/validate-plugin.sh` reads only the two
+`.claude-plugin/*.json` manifests and never opens `skills/`. `.pre-commit-config.yaml:69`
+scopes the plugin hook to `files: ^\.claude-plugin/.*\.json$`, so editing a SKILL.md
+triggers nothing but whitespace and codespell.
+
+All four API-2 failures are mechanically detectable. This is the highest-value missing
+test in the repository.
+
+**Fix**:
+
+```python
+# tests/test_skill_cli_contract.py
+"""Every documented invocation must run against the shipped Typer tree.
+
+The plugin's skills are its clients: a skill that names a flag the CLI dropped is
+a broken skill, and nothing else in the suite reads a `SKILL.md` code fence
+(`test_plugin_content.py` explicitly skips them). Four such breaks were shipping
+when this guard was written.
+"""
+
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+from typer.main import get_command
+
+from defendable_science.cli import app
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCS = [
+    *ROOT.glob("skills/*/SKILL.md"),
+    *ROOT.glob("resources/**/*.md"),
+    *ROOT.glob("docs/guides/*.md"),
+    ROOT / "docs/USER-GUIDE.md",
+    ROOT / "README.md",
+]
+_INVOCATION = re.compile(r"^\s*(?:\$ )?(?:defendable-science|dsci)\s+(.+?)(?:\s*\\)?$", re.M)
+
+
+def _invocations() -> list[tuple[Path, int, str]]:
+    out = []
+    for doc in DOCS:
+        for n, line in enumerate(doc.read_text(encoding="utf-8").splitlines(), 1):
+            if (m := _INVOCATION.match(line)) and "<" not in m.group(1).split()[0]:
+                out.append((doc, n, m.group(1)))
+    return out
+
+
+@pytest.mark.parametrize(("doc", "line", "invocation"), _invocations())
+def test_documented_invocation_resolves(doc, line, invocation):
+    root = get_command(app)
+    try:
+        argv = shlex.split(invocation)
+    except ValueError:
+        pytest.skip(f"{doc.name}:{line}: not shell-parseable (prose)")
+    cmd, rest = root, argv
+    while rest and hasattr(cmd, "commands"):
+        name, *rest = rest
+        assert name in cmd.commands, (
+            f"{doc.relative_to(ROOT)}:{line}: no such command {name!r} "
+            f"(have {sorted(cmd.commands)})"
+        )
+        cmd = cmd.commands[name]
+    known = {o for p in cmd.params for o in getattr(p, "opts", [])}
+    for token in rest:
+        if token.startswith("-") and "<" not in token:
+            assert token.split("=")[0] in known, (
+                f"{doc.relative_to(ROOT)}:{line}: {cmd.name} has no {token!r} "
+                f"(have {sorted(known)})"
+            )
+```
+
+Plus a second, tiny guard for API-2(d) — the documented backlog headers against
+`columns_for(level)`:
+
+```python
+def test_documented_backlog_header_matches_the_column_profile():
+    """A header a skill tells the author to hand-write must be one `Backlog` accepts."""
+    text = (ROOT / "skills/hypothesis-exploration/SKILL.md").read_text("utf-8")
+    documented = [c.strip() for c in re.search(r"^\| id \|.*$", text, re.M)[0].strip("|").split("|")]
+    assert documented == columns_for("hypothesis")
+```
+
+Wire both into `ci.yml`'s existing `test` job — no new workflow needed.
+
+---
+
+### API-4 — Output shape switches on a flag
+
+Four commands return a JSON **array** with `--all` and a JSON **object** without it.
+
+`defendable-science/defendable_science/cli.py:1402`
+```python
+    output: Any = (
+        reports[0].as_json() if citekeys is not None else [r.as_json() for r in reports]
+    )
+```
+`defendable-science/defendable_science/cli.py:1467`
+```python
+    output: Any = reports[0] if citekeys is not None else reports
+```
+
+Same at `cli.py:1589` vs `:1596` (`dataset emit --all` vs `dataset emit <id>`), and
+`backlog promote` emits a bare row (`cli.py:2339` → `_emit_row`) or
+`{"row": …, "artifacts": …}` (`cli.py:2340`) depending on `--scaffold`.
+
+The `output: Any` annotation at both sites is the type system reporting the problem.
+A skill parsing `literature verify` must branch on its own flags to know whether to
+index `[0]` or read a key — and if it guesses wrong it gets a `TypeError` from `jq` or
+a silent wrong read.
+
+**Fix** — always return the collection, and let arity be a property of the data:
+
+```python
+    reports = [acquire_mod.verify_entry(e, cache_dir=cache_dir) for e in entries]
+    emit(
+        {"entries": [r.as_json() for r in reports]},
+        ok=all(r.ok for r in reports),
+    )
+```
+
+`backlog promote` always emits `{"row": …, "artifacts": … | null}` — `null` when
+`--scaffold` was not given, which is a fact the caller can read rather than infer.
+
+---
+
+## Medium
+
+### API-5 — Exit-code taxonomy is inconsistent
+
+The intended taxonomy is documented once, on one command:
+
+`defendable-science/defendable_science/cli.py:895`
+```
+    :raises typer.Exit: Code ``0`` on a resolution. Code ``1`` on a genuine
+        miss (no such paper). Code ``2`` on a Click/Typer usage error … Code
+        ``3`` on a transport failure (``transport_error: true`` in the JSON) —
+        deliberately distinct from ``2`` so a caller can never confuse "you
+        typed it wrong" with "the network failed".
+```
+
+That reasoning is right and it is applied to `literature resolve` alone
+(`cli.py:911`). Every other network command routes through `_http_guard`, which
+collapses every transport failure to 1:
+
+`defendable-science/defendable_science/cli.py:864`
+```python
+    except RateLimitError as exc:
+        typer.echo(f"rate-limited by Semantic Scholar after {client.max_retries} retries …", err=True)
+        raise typer.Exit(code=1) from exc
+    except HttpError as exc:
+        typer.echo(f"literature request failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+```
+
+So `literature cites <id>` exits 1 both when the paper has no citations *and* when the
+network died — the exact confusion `resolve`'s docstring says must never happen.
+`RateLimitError` is a distinct type all the way up from `core/http.py:52` and is
+discarded at the last step.
+
+Observed codes across the tree:
+
+| Code | Meaning | Emitted by |
+|---|---|---|
+| 0 | success | all |
+| 1 | *everything else*: not-found, integrity failure, transport failure, config error, write failure | all |
+| 2 | usage error | Click's own; plus `_one_of_citekey_or_all` (`cli.py:1227`), `_paper_dir_or_exit` (`cli.py:1989`), `_resolve_backlog` (`cli.py:2012`), `_open_backlog` (`cli.py:2028`), `_check_scaffold_opts` (`cli.py:2169`), `_set_many` (`cli.py:2431`), `set_` (`cli.py:2470`, `:2475`) |
+| 3 | transport failure | `literature resolve` only (`cli.py:911`) |
+
+Two commands use 1 where their siblings use 2 for the same class of mistake:
+`dataset emit` with neither an id nor `--all` exits **1** (`cli.py:1593`), while
+`literature fetch` in the identical situation exits **2** (`cli.py:1227`).
+
+No failure path exits 0 — that part is sound, and `_fetch_report_exit_code`
+(`cli.py:1231`) is a good example: it returns 1 when the sweep is incomplete
+specifically so "no CI loop reads a half-swept registry as a finished one".
+
+**Fix** — make `_http_guard` honour the taxonomy already written down, and document it
+once in `--help`:
+
+```python
+#: The house exit codes. 3 and 4 are distinct because a researcher's next action
+#: differs: retry later vs. investigate the bytes.
+EXIT_OK, EXIT_FAILED, EXIT_USAGE, EXIT_TRANSPORT, EXIT_INTEGRITY = 0, 1, 2, 3, 4
+
+@contextmanager
+def _http_guard(client: HttpClient) -> Iterator[None]:
+    try:
+        yield
+    except RateLimitError as exc:
+        typer.echo(f"rate-limited after {client.max_retries} retries — …", err=True)
+        raise typer.Exit(code=EXIT_TRANSPORT) from exc
+    except HttpError as exc:
+        # A 404 is a fact about the paper (EXIT_FAILED); anything else is a fact
+        # about us, and a caller must be able to tell them apart without parsing
+        # the message — the distinction `literature resolve` already documents.
+        code = EXIT_FAILED if exc.status_code == 404 else EXIT_TRANSPORT
+        typer.echo(f"literature request failed: {exc}", err=True)
+        raise typer.Exit(code=code) from exc
+```
+
+and change `cli.py:1593` to `EXIT_USAGE`. Reserve 4 for a checksum/fixity mismatch
+(`literature verify`, `dataset verify`, `dataset audit`), which today is
+indistinguishable from a missing manifest.
+
+---
+
+### API-6 — The compat pin names a package version that has never been released
+
+`resources/ensure-tooling.md:26` pins the bootstrap to `defendable-science>=0.3.0,<0.4.0`.
+`defendable-science/pyproject.toml:7` reads `version = "0.2.2"`; the newest git tag is
+`v0.2.2`. **0.3.0 does not exist on PyPI.** The file itself says so
+(`resources/ensure-tooling.md:73`, "that same unreleased `0.3.0` line").
+
+Two further defects in the same bootstrap, both of which matter more than the number:
+
+- **The pin is never passed to any install command.** Every literal is bare —
+  `uv tool install defendable-science` (`resources/ensure-tooling.md:28`),
+  `pipx install defendable-science` (`:30`), `pip install defendable-science` (`:32`).
+  The constraint exists only in the surrounding prose at `:26`, so an agent executing
+  the documented procedure installs whatever is latest.
+- **There is no upgrade path.** Step 1 (`:16`) says "If it matches the pinned version →
+  done", but the pin is a *range* and "matches" is undefined. On a mismatch the
+  procedure falls through to step 3's bare `uv tool install`, which is a **no-op** on an
+  already-installed older version. ADR-0026 line 35 promises the bootstrap
+  "installs/**upgrades**"; this file never upgrades. A stale CLI is silently kept — a
+  failure-honesty violation in the one document whose entire job is honest
+  bootstrapping.
+
+The pin also enumerates `digest extract axes | record | sample | render`
+(`resources/ensure-tooling.md:72`) and omits `cells`, which
+`skills/defend/SKILL.md:134` and `skills/digest/SKILL.md:512` now depend on.
+
+**Fix** — release 0.3.0 or drop the floor to `>=0.2.2,<0.3.0`; put the constraint in
+every command; define the mismatch action; and add the CI guard that would have caught
+it (API-3's file is the natural home):
+
+```python
+def test_the_compat_pin_is_satisfiable():
+    """The bootstrap's pinned range must admit a package version that exists.
+
+    `ensure-tooling.md` is the first thing every skill executes. A floor above
+    the newest release makes the documented PyPI path fail for every consumer,
+    which is what shipped in 0.2.2.
+    """
+    pin = re.search(
+        r"defendable-science>=([\d.]+),<([\d.]+)",
+        (ROOT / "resources/ensure-tooling.md").read_text("utf-8"),
+    )
+    floor = Version(pin.group(1))
+    shipped = Version(
+        re.search(r'^version = "(.+)"', (ROOT / "defendable-science/pyproject.toml").read_text("utf-8"), re.M).group(1)
+    )
+    assert floor <= shipped, (
+        f"ensure-tooling.md pins >={floor} but the package is {shipped}; "
+        f"release {floor} or lower the floor"
+    )
+```
+
+---
+
+### API-7 — Failures are plain-text stderr, not machine-readable
+
+`grep -c 'err=True' cli.py` → **57**. Only the five `digest extract` commands emit a
+failure as JSON as well; every other error path writes prose to stderr and exits
+non-zero, leaving nothing structured on stdout.
+
+`defendable-science/defendable_science/cli.py:1447`
+```python
+        typer.echo(
+            "no 'literature.mirror' configured in .defendable-science/config.yml",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+```
+
+The `digest extract` family shows the intended pattern, and the comment says exactly
+why (`cli.py:2668`):
+
+> Emitted on the refusal too, and `axes` is then `null` rather than `[]`: all four
+> verbs report the same way, and a caller must never be able to read a matrix this run
+> could not parse as a matrix with no axes.
+
+That reasoning applies to the other 33 commands and was not extended to them. A skill
+scripting `literature mirror --all` gets an empty stdout and a prose sentence on
+stderr, so it must regex an English message to distinguish "no mirror configured"
+from "the mirror is unreachable" from "one file is corrupt" — three cases with three
+different human remedies.
+
+**Fix** — API-1's `emit()` with `ok=False` on every failure path, plus a stable
+`error.kind` discriminator so a skill matches on a token rather than a sentence:
+
+```python
+        emit(
+            {},
+            ok=False,
+            error={
+                "kind": "mirror-not-configured",
+                "message": "no 'literature.mirror' in .defendable-science/config.yml",
+                "remedy": "add a `literature.mirror.remote`, or drop --check",
+            },
+        )
+```
+
+The `kind`/`message`/`remedy` triple is already the shape of `check.model.Finding`
+(`check/model.py:36`) — reuse it rather than inventing a second one.
+
+---
+
+### API-8 — Unbounded result sets
+
+No command has `--limit` or `--offset`. Two caps exist and neither is a general
+mechanism: `literature cites --max` (`cli.py:918`, default `0` = unlimited) and
+`literature neighbors --top` (`cli.py:974`, default 20).
+
+`literature cites` with no `--max` paginates to exhaustion at 200 rows/page
+(`literature/graph.py:249`), accumulating every record in memory before serialising:
+
+`defendable-science/defendable_science/literature/graph.py:247`
+```python
+    results: list[dict[str, Any]] = []
+    cursor: str | None = "*"
+    while cursor:
+        page = client.get_json(..., {"filter": f"cites:{openalex_id}", "per-page": "200", "cursor": cursor})
+        ...
+        cursor = (page.get("meta") or {}).get("next_cursor")
+    return results
+```
+
+For a canonical paper (say 40,000 citations) that is 200 requests, and each record
+carries a reconstructed abstract from the inverted index (`graph.py:79`) — call it
+2 KB — so ~80 MB held in memory and then `json.dumps(..., indent=2)`'d to stdout in
+one go. There is no way to ask for the first page.
+
+Also unbounded: `dataset emit --all` (whole manifest, `cli.py:1588`), `backlog list`
+(whole table, `cli.py:2109`), `literature verify --all` / `mirror --all` (whole
+registry, `cli.py:1400`/`:1457`), `digest extract sample` (every cell of every drawn
+paper, `cli.py:3081`), `keys list` (bounded in practice). Every one also reads its
+whole source file into memory first — `Path.read_text` at `registry.py:363`,
+`manifest.py:350`, `backlog.py:230`.
+
+**Fix** — a shared option pair and one cursor field in the envelope:
+
+```python
+_Limit = Annotated[int, typer.Option("--limit", min=0, help="Max rows; 0 = all.")]
+_Offset = Annotated[int, typer.Option("--offset", min=0, help="Rows to skip.")]
+```
+
+with the envelope carrying `{"total": n, "offset": k, "limit": m, "truncated": bool}`.
+`truncated` matters most: `neighbors` already reports `capped`
+(`literature/graph.py:459`) precisely so truncation is never silent, and that principle
+should be the tree's, not one command's.
+
+For `cites` specifically, change the default from unlimited to a documented cap and
+make unlimited the explicit opt-in — the current default is a footgun that only fires
+on the most-cited papers, i.e. the ones a literature review is most likely to start
+from.
+
+---
+
+### API-9 — No version field in emitted JSON, and no stated policy for a breaking change
+
+No command emits a schema or API version. `--version` prints the package version
+(`cli.py:190`) but nothing on stdout ties a JSON document to the CLI that produced it.
+`ADR-0026` governs *package* versioning and the compat pin; it says nothing about the
+JSON contract. Searching the ADR set for the output shape returns nothing (confirmed by
+the plugin audit: no ADR covers the JSON envelope or the exit codes).
+
+So the current policy is: a skill pins `defendable-science>=0.3.0,<0.4.0` and hopes.
+Since the pin's *floor* is what gets bumped when a skill needs a new capability
+(`resources/ensure-tooling.md:65`), and the ceiling only moves on a minor bump, a
+breaking output change inside `0.3.x` would be invisible to the pin.
+
+The consequence is already visible in the shape drift catalogued in API-1: five
+different envelope conventions accreted across five feature waves, and nothing forced a
+decision about whether changing an older one was allowed.
+
+**Fix** — three parts:
+
+1. `"api_version": 1` in the envelope (API-1's helper already emits it).
+2. An ADR recording the contract and the change policy: *additive changes (a new key)
+   are minor; removing or retyping a key, or changing an exit code's meaning, bumps
+   `api_version` and the pin ceiling*.
+3. A golden-output test per command so a shape change cannot land silently:
+
+```python
+@pytest.mark.parametrize("argv", [["dataset", "validate", …], …])
+def test_output_shape_is_stable(argv, snapshot):
+    """The emitted key set is the plugin's contract; a diff here is a breaking change."""
+    result = CliRunner().invoke(app, argv)
+    assert sorted(json.loads(result.stdout)) == snapshot
+```
+
+---
+
+## Low
+
+### API-10 — Chatty commands the skills must loop over
+
+Read against the skills' actual invocation patterns:
+
+- **`literature enrich`** already takes `list[str]` (`cli.py:951`) — good — but resolves
+  each identifier with its own round-trip first (`cli.py:962`) and then fetches each
+  work separately (`literature/graph.py:375`). See BE-7 in
+  [`be-tech-debt.md`](be-tech-debt.md); the CLI-facing consequence is that a single
+  unresolvable identifier aborts the whole batch (`cli.py:883`) and discards the work
+  already done on the others. A batch command should report per-item failures in
+  `errors[]`, not exit.
+- **`literature resolve`** takes exactly one identifier (`cli.py:888`).
+  `skills/literature/SKILL.md` drives it per citekey during triage, so a 40-paper
+  screening is 40 process launches. Each launch re-reads `config.yml` (twice — see
+  BE-7), rebuilds the `HttpClient`, and re-resolves the layout.
+- **`literature confirm`** is one citekey per invocation (`cli.py:1318`), so working the
+  `manual[]` worklist a sweep produced is N launches. `fetch`/`verify`/`mirror` all
+  have `--all`; `confirm` does not, which is defensible (each promotion is a human act)
+  but means the batch case has no path.
+- **`digest extract cells`** is one citekey (`cli.py:2689`) while its four siblings all
+  accept `--citekey` repeatably or `--all`. Inconsistent within one group.
+
+**Fix** — make `resolve` variadic like `enrich`, add `--citekey` repeatability to
+`extract cells`, and change batch commands from fail-fast to
+`errors[]`-and-continue (the posture `fetch_all` already takes at
+`literature/acquire.py:2148`).
+
+---
+
+### API-11 — Flag-combination validation is ad hoc
+
+Three different mechanisms for the same job:
+
+`defendable-science/defendable_science/cli.py:1223` — helper, exit 2, prose:
+```python
+    if bool(citekey) == all_flag:
+        typer.echo("give exactly one of CITEKEY or --all, not neither or both", err=True)
+        raise typer.Exit(code=2)
+```
+`defendable-science/defendable_science/cli.py:1347` — inline copy of the same rule:
+```python
+    if bool(sha256) == bool(file):
+        typer.echo("give exactly one of --sha256 or --file, not neither or both", err=True)
+        raise typer.Exit(code=2)
+```
+`defendable-science/defendable_science/cli.py:3290` — `BadParameter` instead:
+```python
+    if bool(citekey) == all_papers:
+        raise typer.BadParameter("give exactly one of --citekey (repeatable) or --all: …")
+```
+
+`BadParameter` is the right one — Click renders it with usage context — and only the
+newest command uses it.
+
+Enum values are validated in three places too: `--level` in a helper
+(`cli.py:2026`), `--verdict` inline (`cli.py:3296`), `--kind` in the kernel
+(`literature/graph.py:452`), `--target` in the kernel (`defend/record.py:277`). None
+uses Typer's `enum` support, so none appears in `--help` as a choice list and none is
+tab-completable. `--size` has a hand-rolled range check (`cli.py:3300`) where
+`typer.Option(min=1)` would do it declaratively and document itself.
+
+Path existence is checked inconsistently: `--root` goes through `resolve_root`
+(`core/config.py:17`, strict and well-reasoned), but `--file` (`cli.py:1325`),
+`--cells` (`cli.py:2855`), `--points` (`cli.py:1838`) and `--transcript`
+(`cli.py:1850`) are plain `str` and fail at read time. `--file` is handled cleanly
+(`literature/acquire.py:1990` raises `RetrievalError`); the other three rely on
+`cli.py:1937`/`:2917` catching `OSError`.
+
+**Fix** — one helper and Typer's declarative validators:
+
+```python
+def _exactly_one(**named: object) -> None:
+    """Refuse unless exactly one of the named options was supplied.
+
+    :raises typer.BadParameter: Naming all of them, so the message reads the same
+        wherever the rule is enforced.
+    """
+    given = [k for k, v in named.items() if v]
+    if len(given) != 1:
+        flags = ", ".join(f"--{k.replace('_', '-')}" for k in named)
+        raise typer.BadParameter(
+            f"give exactly one of {flags} — got {given or 'none'}"
+        )
+```
+
+and, for the enums, `class Verdict(str, Enum)` so Typer renders the choices in
+`--help` and rejects the rest before the body runs. Use
+`typer.Option(exists=True, dir_okay=False)` on the four file-taking options.
+
+---
+
+### API-12 — Nine design-record invocations describe flags that never existed
+
+Not agent-executed, but each file is headed `Status: implemented`, which invites a
+reader to trust it:
+
+| Location | Documents | Reality |
+|---|---|---|
+| `docs/design/proposals/literature-citation-graph-client.md:36` | `--json`, `--provenance-dir` | **no `--json` flag exists anywhere in the tree** |
+| `:43` | `resolve --id` | `resolve` has no options (`cli.py:888`) |
+| `:44` | `cites --per-page --max --since` | only `--max` (`cli.py:918`) |
+| `:45` | `refs --max` | `refs` has no options (`cli.py:937`) |
+| `:46` | `enrich --fields --context` | only `--context` (`cli.py:953`) |
+| `docs/design/proposals/dataset-manifest-tooling.md:118` | `ingest --into` | no `--into` (`cli.py:1539`) |
+| `:119` | `emit -o` | no `-o`; prints to stdout (`cli.py:1565`) |
+| `docs/design/proposals/dataset-retrieval-mirror-tooling.md:102` | `dataset verify [<id>\|--all]` | no `--all`; id required (`cli.py:1687`) |
+
+The last one is almost certainly the origin of API-2(b) and (c) — the guide was written
+from the proposal rather than from the CLI.
+
+**Fix** — either re-title these sections "as designed" and add a pointer to the
+generated CLI reference, or regenerate them from the Typer tree.
+`tools/build_docs_site.py` already walks that tree for the docs site, so the
+authoritative rendering exists; the proposals just predate it.
+
+---
+
+## Correct-but-fragile
+
+Documented behaviours that work today but rest on an unstated assumption.
+
+- **`skills/dataset/SKILL.md:57`** and **`docs/design/03-dataset.md:28`** both say
+  `verify` reports `` `verified-against-registry` `` — backticked, so it reads as a
+  literal key. It exists nowhere in the package; `VerifyReport` emits
+  `{entry_id, verified[], missing[], corrupt[], ok}` (`dataset/retrieval.py:171`,
+  serialised at `cli.py:1704`). The phrase traces to methodology prose in
+  `resources/references/dataset-management-standards.md:55`.
+- **`skills/research-init/SKILL.md:70`** describes "one entry per path considered, each
+  `created` | `exists` | `merged`, plus a `counts` object". `counts` is named
+  correctly; the array is under **`actions`** (`cli.py:581`) and the skill names
+  neither it nor the `{path, status}` element shape.
+- **`skills/hypothesis-exploration/SKILL.md:73`** and
+  **`skills/paper-exploration/SKILL.md:63`** say `promote --scaffold` "reports the
+  created path(s) as JSON". The key is **`artifacts`**, beside `row` (`cli.py:2340`).
+  Unnamed, and see API-4.
+- **`skills/defend/SKILL.md:112`** and **`docs/guides/defend.md:52`** list three
+  `--target` values; the CLI accepts four (`paper-comprehension`,
+  `defend/record.py:33`). Used correctly elsewhere
+  (`skills/digest/SKILL.md:120`), but the tables read as exhaustive.
+- **`docs/guides/defend.md:125`** says `--log-dir` "defaults to
+  `docs/research/defend-log`". The default is layout-anchored
+  (`cli.py:1907`), so the literal path holds only for the default layout — the exact
+  thing `tests/test_plugin_content.py` guards against in skills but not in guides.
+- **`skills/progress/SKILL.md:46`** invokes `defendable-science check` and
+  `progress dashboard` but is the only CLI-invoking skill that never links
+  `resources/ensure-tooling.md`. The other eight all do.
+
+**Verified correct — no action needed.** The skills' JSON-key claims were checked
+against each command's `json.dumps` payload and these all hold:
+`skills/progress/SKILL.md:58` (`ok`, `changed`, `artifact_count`, `findings` ←
+`cli.py:757`); the whole `skills/digest/SKILL.md` extraction contract at `:210`,
+`:307`, `:316`, `:379`, `:384`, `:464` (← `cli.py:2673`, `:2833`, `:3188`, `:3519`);
+`skills/defend/SKILL.md:134` (← `cli.py:2740`); `skills/literature/SKILL.md:193`,
+`:222`, `:229` (← `literature/acquire.py:128`, `:865`, `:2123`); and the fourteen-key
+fetch-report row in `docs/guides/literature.md:224-315`, which matches
+`literature/acquire.py:935` verbatim. That is a substantial contract, documented
+accurately.
+
+---
+
+## Positive patterns to preserve
+
+1. **The `digest extract` envelope is the model the rest of the tree should adopt.**
+   `{ok, error, errors[], …}` with `error` for the whole-run failure and `errors[]` for
+   per-item ones, emitted on *every* outcome including the refusal. The reasoning at
+   `cli.py:2668`, `cli.py:2810` and `cli.py:3164` is explicit about why — including the
+   decision to report `axes: null` rather than `[]` on a matrix that could not be
+   parsed, and to split `verdict` from `verdict_requested` because "a key called
+   `verdict` reading `verified` on a run that wrote nothing is one careless read away
+   from being taken for the outcome".
+
+2. **Exit codes keyed to severity, not to count.** `check` exits 1 on
+   `invalid`/`unreadable` and 0 on `gap` (`check/model.py:31`), so "incomplete science"
+   never fails a build while "an unreadable file" always does. That is the right axis
+   and it is documented in the model rather than in a command.
+
+3. **`_fetch_report_exit_code`** (`cli.py:1231`) returns 1 when `complete` is false,
+   specifically so an incomplete sweep cannot be read as a finished one. Most tools
+   would return 0 with a warning.
+
+4. **`DocstringTyper`** (`cli.py:120`) resolves the MyST-docstring/`--help` collision
+   at the framework level, so no command can regress. Enforced by
+   `tests/test_cli_help.py` walking the whole tree.
+
+5. **Politeness is real.** `mailto` is added for OpenAlex only and *never* for arXiv,
+   with the privacy reasoning spelled out (`core/http.py:229`); the S2 key goes in a
+   header, never a query parameter (`core/http.py:206`); per-host proactive rate caps
+   default below each provider's documented ceiling (`core/http.py:128-137`).
+
+6. **No key can leak through the CLI.** `keys set` takes the value from stdin or a
+   hidden prompt, never argv (`cli.py:2448`); `_key_report` returns presence and source
+   but never a value (`cli.py:2483`); `scoped_env` hands a child process only the
+   variables that child needs (`core/keys.py:279`); and `keys set` warns when the
+   resolved store sits in a non-gitignored work tree (`cli.py:2403`). The one defect in
+   this area is the file-mode race at `core/keys.py:201` (BE-6), not the CLI surface.
+
+---
+
+*Cross-references: implementation-side detail for API-5/7/8 in
+[`be-tech-debt.md`](be-tech-debt.md) (BE-4, BE-7); the plugin's side of API-2/3/6 in
+[`plugin-tech-debt.md`](plugin-tech-debt.md); the missing tests in
+[`coverage.md`](coverage.md).*

--- a/.codebase_audit/be-tech-debt.md
+++ b/.codebase_audit/be-tech-debt.md
@@ -1,0 +1,1546 @@
+# Package internals — technical debt
+
+Scope: `defendable-science/defendable_science/` (17,081 LOC, 41 files). Measured
+2026-08-29 against `0489114`. All line numbers verified by reading the file.
+
+Everything below is **debt in an otherwise disciplined codebase**. `uv run pytest -q`
+is 1562 passed / 14 skipped at 100.00 % statement *and* branch coverage; `uv run mypy`
+is clean over 79 files under `strict = true`; `uv run ruff check` is clean; bandit
+reports 2 Low findings, both `random` for jitter/sampling and both correct. Read the
+"Positive patterns to preserve" section at the end before acting on any of this.
+
+**Note on Pydantic.** The repo owner has lifted the blanket Pydantic prohibition
+*for the external-input parsing boundary only* (see the constraint note in
+`plugin-tech-debt.md` → ADR hygiene). Fixes in **BE-9** are therefore written as
+Pydantic v2 models. Everywhere else, stdlib `dataclasses` remain the norm and no
+fix below proposes changing that.
+
+---
+
+## Priority index
+
+| # | Finding | Severity |
+|---|---|---|
+| BE-1 | Path traversal from an externally-derived citekey writes outside the repo | **High** |
+| BE-2 | The atomic write-temp-then-rename idiom is applied to 3 of 18 write sites | **High** |
+| BE-3 | `defend record` mutates the claim before writing the evidence, with no rollback | **High** |
+| BE-4 | Six unvalidated JSON boundaries: four tracebacks and one silently wrong value | **High** |
+| BE-5 | The rclone and `git` subprocesses have no timeout | **Medium** |
+| BE-6 | The key store is written world-readable, then chmod'd, and non-atomically | **Medium** |
+| BE-7 | Per-item HTTP round-trips where OpenAlex offers a batch filter | **Medium** |
+| BE-8 | `check` walks and re-parses every artifact three times per run | **Medium** |
+| BE-9 | External JSON/YAML is parsed by hand; wrong shapes crash or coerce silently | **Medium** |
+| BE-10 | `dict[str, Any]` used as a de-facto schema (42 occurrences in one module) | **Medium** |
+| BE-11 | Injectable-callable fields typed `object`, forcing four `type: ignore[operator]` | **Medium** |
+| BE-12 | Layout constants duplicated outside `scaffold/layout.py` | **Medium** |
+| BE-13 | `keys check` shadows the top-level `check` command at module scope | **Low** |
+| BE-14 | Unescaped title interpolated into an OpenAlex filter expression | **Low** |
+| BE-15 | God modules — quantified, and *not* the problem it looks like | **Low** |
+| BE-16 | `warn_unused_ignores = false` + `ignore_missing_imports = true` weaken strict mypy | **Low** |
+
+No circular imports were found (see BE-15). No global mutable state beyond
+`HttpClient._last_request`, which is instance-scoped and correct. No bare
+`except:`, no `except Exception: pass`, no mutable default arguments.
+
+---
+
+## High
+
+### BE-1 — Path traversal from an externally-derived citekey writes outside the repository
+
+`Layout.digest()` interpolates a caller-supplied citekey straight into a path with no
+sanitisation and no containment check:
+
+`defendable-science/defendable_science/scaffold/layout.py:144`
+```python
+def digest(self, citekey: str) -> Path:
+    """Return the digest artifact of `citekey`."""
+    return self.digests_dir / f"{citekey}.md"
+```
+
+The citekey reaches it from a JSON file the agent writes. `cell_from_mapping`
+(`digest/extraction.py:239`) type-checks the field but never constrains its content:
+
+`defendable-science/defendable_science/digest/extraction.py:230`
+```python
+_CELL_FIELD_TYPES: dict[str, tuple[tuple[type, ...], str]] = {
+    "citekey": ((str,), "a string"),
+    ...
+```
+
+Call sites that feed it: `cli.py:2732`, `cli.py:2927`, `cli.py:3071`, `cli.py:3121`,
+`cli.py:3409`. Same class of hole in `Layout.paper_dir` / `backlog` / `positioning`
+(`layout.py:179`, `:183`, `:195`), reached from `backlog promote --id`.
+
+**Reproduced.** With a one-cell `--cells` file whose citekey is
+`../../../../../../tmp/dsaudit/PWNED`, `digest extract record` created
+`/tmp/tmp/dsaudit/PWNED.md` — outside the work tree — and `mkdir(parents=True)`'d the
+intervening directories to get there (`cli.py:2931`, `digest/artifact.py:547`). The
+run then exited 1 only because the *log* filename carried the same `..` into a
+directory that did not exist; the artifact write had already succeeded.
+
+The codebase already knows this rule. `acquire.py:1019` sanitises exactly this input
+for the cache, with a comment explaining why:
+
+`defendable-science/defendable_science/literature/acquire.py:1019`
+```python
+def _safe_name(citekey: str) -> str:
+    """Reduce a citekey to a filename-safe token.
+    ...
+    One containing a path separator would otherwise write outside the cache, which
+    is not a risk worth carrying for a field nobody validates.
+    """
+    return _UNSAFE_NAME.sub("_", citekey)
+```
+
+And `layout._relative` (`layout.py:241`) and `cli._repo_relative` (`cli.py:359`) both
+enforce repo containment on *config-supplied* paths. Neither rule was applied to the
+derived per-artifact paths. The protection is inconsistent, not absent — which is what
+makes it a systemic finding rather than a one-off.
+
+**Fix** — validate the identifier at the layout boundary, so every derived path is
+covered by one rule:
+
+```python
+# scaffold/layout.py
+_SAFE_ID = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+
+
+def _safe_id(kind: str, value: str) -> str:
+    """Return `value` if it is a usable single path component, else refuse.
+
+    :raises LayoutError: If it is empty, carries a path separator, or is a
+        relative-path token — an identifier that escaped the tree would put a
+        research artifact somewhere no reviewer will look for it.
+    """
+    if not _SAFE_ID.match(value) or value in (".", ".."):
+        msg = (
+            f"{kind} {value!r} is not a usable path component: use only "
+            "letters, digits, '.', '_' and '-'"
+        )
+        raise LayoutError(msg)
+    return value
+
+
+def digest(self, citekey: str) -> Path:
+    """Return the digest artifact of `citekey`."""
+    return self.digests_dir / f"{_safe_id('citekey', citekey)}.md"
+```
+
+Apply the same call in `paper_dir`, `backlog`, `positioning`, `hypothesis_dir`
+(with `slug`), and in `append_log_entry`'s `stem`
+(`defend/record.py:343`) — that one builds a filename from the same untrusted value.
+
+---
+
+### BE-2 — The atomic write idiom is applied to 3 of 18 write sites
+
+Commit `0489114` ("remove the orphan `.tmp` patch_triage leaves on a failed write")
+hardened one writer. The pattern it hardened is not applied anywhere else, and the
+sites that lack it include the most integrity-critical files the tool owns.
+
+Full inventory (`grep -rn "write_text\|\.replace(\|\.open(\"w"`, each verified):
+
+| Site | Writes | Temp+rename | `.tmp` cleanup |
+|---|---|---|---|
+| `literature/registry.py:827` | `triage.yml` | yes | **yes** |
+| `literature/registry.py:468` | `references.json` spine | yes | **no** |
+| `core/http.py:177` | HTTP response cache entry | yes | no (benign — cache) |
+| `defend/record.py:293` | artifact `status.understanding` | **no** | — |
+| `defend/record.py:298` | defend transcript | **no** | — |
+| `defend/record.py:348` | accountability-log entry | **no** | — |
+| `digest/artifact.py:548` | digest artifact + cells block | **no** | — |
+| `digest/artifact.py:579` | digest `status.extraction` | **no** | — |
+| `literature/acquire.py:1069` | quarantine sidecar JSON | **no** | — |
+| `core/keys.py:201` | the API key store | **no** | — |
+| `exploration/backlog.py:242` | backlog table | **no** | — |
+| `exploration/backlog.py:486` | `hypothesis.md` | **no** | — |
+| `exploration/backlog.py:541` | `papers.md` registry | **no** | — |
+| `exploration/backlog.py:604`, `:608` | paper backlog + pitch | **no** | — |
+| `scaffold/init_repo.py:81`, `:121` | scaffold files, `.gitignore` merge | **no** | — |
+| `cli.py:696` | `dashboard.md` | **no** | — |
+| `cli.py:3509` | `positioning.md` matrix merge | **no** | — |
+
+`cli.py:3506` is the sharpest case. `digest extract render` reads the author's
+positioning document, merges, and truncates-and-rewrites it in place:
+
+`defendable-science/defendable_science/cli.py:3505`
+```python
+try:
+    before = path.read_text(encoding="utf-8")
+    merged = render_mod.render_matrix(path, rows)
+    if merged != before:
+        path.write_text(merged, encoding="utf-8")
+```
+
+The command's own docstring (`cli.py:3441`) promises "**Nothing is ever deleted.**" A
+crash or a full disk between truncate and flush deletes everything after the write
+offset — the taxonomy prose, the PRISMA log, the author's own delta.
+
+`registry.py:468` is the near-miss: the same file already contains the fixed version
+350 lines below it.
+
+`defendable-science/defendable_science/literature/registry.py:468`
+```python
+    tmp = target.with_name(target.name + ".tmp")
+    tmp.write_text(
+        json.dumps(items, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    tmp.replace(target)
+```
+
+**Fix** — promote the already-correct helper to `core/` and route every artifact write
+through it:
+
+```python
+# core/atomic.py  (new, ~15 lines)
+from pathlib import Path
+
+
+def write_atomic(target: Path, text: str, *, encoding: str = "utf-8") -> None:
+    """Write `text` to `target` via a sibling ``.tmp``, cleaned up on failure.
+
+    :param target: The file to write; its parent must exist.
+    :param text: The full new contents.
+    :raises OSError: If the write or the replace fails; no orphan ``.tmp`` is
+        left behind either way.
+    """
+    tmp = target.with_name(target.name + ".tmp")
+    try:
+        tmp.write_text(text, encoding=encoding)
+        tmp.replace(target)
+    except OSError:
+        tmp.unlink(missing_ok=True)
+        raise
+```
+
+Then `registry._write_triage_atomically` (`registry.py:817`) becomes a one-line call,
+`registry.py:468-472` becomes `write_atomic(target, json.dumps(...) + "\n")`, and the
+15 direct `write_text` sites above each lose one line and gain crash-safety. This is a
+mechanical change with no behavioural difference on the success path.
+
+---
+
+### BE-3 — `defend record` mutates the claim before writing the evidence, with no rollback
+
+`record()` performs three writes in the wrong order and with no transaction:
+
+`defendable-science/defendable_science/defend/record.py:288`
+```python
+    artifact_path = Path(artifact)
+    if record_understanding:
+        patched = patch_understanding(
+            artifact_path.read_text(encoding="utf-8"), status, gaps, last_updated=date
+        )
+        artifact_path.write_text(patched, encoding="utf-8")     # 1. the claim
+
+    transcript_path: Path | None = None
+    if transcript is not None:
+        transcript_path = artifact_path.with_name(f"defend-{date}.md")
+        transcript_path.write_text(transcript, encoding="utf-8")  # 2.
+    ...
+    log_entry_path = _append_log(Path(log_dir), entry)            # 3. the evidence
+```
+
+If step 3 fails — an unwritable `log_dir`, a full disk — the artifact's frontmatter
+already reads `status.understanding: {"status": "ok", "unresolved": []}` while **no
+accountability-log entry exists**. `cli.py:1937` catches the `OSError` and exits 1
+honestly, but the on-disk state is the one thing this tool exists to prevent: a
+recorded claim of verified understanding with no evidence behind it. `progress` and
+`check` both read the frontmatter, not the log, so the false claim propagates to the
+dashboard.
+
+`digest/artifact.py:548-551` has the identical ordering: `write_extraction` writes
+`status.extraction` to the artifact, then appends the log.
+
+A second, independent problem in the same area: `append_log_entry` uses a
+check-then-write race on an append-only audit log.
+
+`defendable-science/defendable_science/defend/record.py:343`
+```python
+    target = log_dir / f"{date}-{stem}.yml"
+    n = 2
+    while target.exists():
+        target = log_dir / f"{date}-{stem}-{n}.yml"
+        n += 1
+    target.write_text(body, encoding="utf-8")
+```
+
+Two concurrent runs both observe the same free name and the second silently overwrites
+the first's evidence. The docstring at `record.py:337` states "Never overwrites: … the
+log is append-only evidence" — which is exactly the guarantee the `exists()`/`write`
+gap breaks.
+
+**Fix** — evidence first, claim second, and make the log write exclusive:
+
+```python
+# defend/record.py — append_log_entry
+    log_dir.mkdir(parents=True, exist_ok=True)
+    n = 1
+    while True:
+        suffix = "" if n == 1 else f"-{n}"
+        target = log_dir / f"{date}-{stem}{suffix}.yml"
+        try:
+            # "x" fails if the name was taken between the check and the write,
+            # which `exists()` cannot rule out — the log is append-only evidence.
+            with target.open("x", encoding="utf-8") as handle:
+                handle.write(body)
+        except FileExistsError:
+            n += 1
+            continue
+        return target
+```
+
+```python
+# defend/record.py — record(), reordered
+    entry = LogEntry(...)                       # build first, write first
+    log_entry_path = _append_log(Path(log_dir), entry)
+    try:
+        if record_understanding:
+            patched = patch_understanding(...)
+            write_atomic(artifact_path, patched)   # BE-2's helper
+        if transcript is not None:
+            transcript_path = artifact_path.with_name(f"defend-{date}.md")
+            write_atomic(transcript_path, transcript)
+    except OSError:
+        # The log entry is evidence of an examination that happened; the artifact
+        # patch is a claim about it. An orphan evidence row is safe to leave and
+        # honest to read; an orphan claim is not.
+        raise
+```
+
+An orphan log entry with no frontmatter patch is recoverable and reads correctly to a
+reviewer. The current failure mode is neither. Apply the same reordering to
+`digest/artifact.write_extraction` (`digest/artifact.py:548`).
+
+---
+
+### BE-4 — Six unvalidated JSON boundaries: four tracebacks and one silently wrong value
+
+`CLAUDE.md:65` requires that a failure "never let a transient error surface as a raw
+traceback", and that a failure never be "silently reported as a legitimate … result".
+Six sites violate one or the other. **All six were reproduced independently for this
+audit**; each is also tracked in **#169**.
+
+The debt here is **concentrated, not uniform** — four of the six are in
+`literature/graph.py`, which is the one module that projects a third party's JSON
+straight into the CLI's own output. The rest of the package's external-input parsing is
+good, and is listed under *Positive patterns to preserve* (item 8) rather than here.
+
+| # | Site | Symptom | Class |
+|---|---|---|---|
+| 1 | `literature/graph.py:256` | `AttributeError` mid-pagination | traceback |
+| 2 | `literature/graph.py:81` | `AttributeError` | traceback |
+| 3 | `literature/graph.py:348` | **a single character** recorded as the citation context | **silent wrong value** |
+| 4 | `literature/graph.py:110` | wrong-typed values pass into emitted JSON | silent wrong value |
+| 5 | `literature/acquire.py:1939` | `KeyError` / `JSONDecodeError` | traceback |
+| 6 | `cli.py:1549` → `dataset/manifest.py:548` | `AttributeError` | traceback |
+
+**Site 3 is the most serious, and it is worse than a wrong type.**
+`_aggregate_s2_edges` indexes into whatever S2 returned:
+
+`defendable-science/defendable_science/literature/graph.py:345`
+```python
+    for edge in edges:
+        if not isinstance(edge, dict):
+            continue
+        if out["context_snippet"] is None and edge.get("contexts"):
+            out["context_snippet"] = edge["contexts"][0]
+        if out["intent"] is None and edge.get("intents"):
+            out["intent"] = edge["intents"][0]
+```
+
+The `isinstance(edge, dict)` guard is there — the *field* guard is not. Reproduced:
+
+```python
+_aggregate_s2_edges([{"contexts": "the whole sentence", "intents": "background"}], out)
+# out["context_snippet"] == 't'
+# out["intent"]          == 'b'
+```
+
+If Semantic Scholar ever returns a bare string where the docs promise a list, the tool
+records the letter `t` as the sentence in which a paper was cited, and `b` as the
+citation intent — and emits both as legitimate values with no `degraded` marker, in the
+same shape it uses for real data (`literature/graph.py:379-382` reserves `degraded` for
+the no-key case). A researcher reading `literature enrich --context` gets a confident,
+wrong answer about how a work was cited. This is precisely the failure the whole module
+is otherwise built to prevent, and it is the only place in the package I found where a
+malformed upstream field becomes a *plausible-looking* value rather than a crash or a
+`None`.
+
+**Site 1** — the page is checked, the elements are not:
+
+`defendable-science/defendable_science/literature/graph.py:254`
+```python
+        if not isinstance(page, dict):
+            raise HttpError(f"{OPENALEX}/works: citation page is not a JSON object")
+        for work in page.get("results", []):
+            record = enrich_work(work)
+```
+Reproduced: a `results` array containing a string raises
+`AttributeError: 'str' object has no attribute 'get'` from inside `enrich_work`
+(`graph.py:96`), mid-pagination, after an arbitrary number of pages have already been
+accumulated. The guard one line above shows the author knew to check the envelope; the
+elements were missed.
+
+**Site 2** — `_abstract` assumes a mapping (`literature/graph.py:81`):
+```python
+    index = work.get("abstract_inverted_index")
+    if not index:
+        return None
+    for word, where in index.items():
+```
+Reproduced: `abstract_inverted_index: ["a", "b"]` → `AttributeError: 'list' object has
+no attribute 'items'`. The falsy guard handles `null` and `{}` but not a wrong type.
+
+**Site 4** — untyped pass-through into emitted JSON (`literature/graph.py:110`):
+```python
+        "title": work.get("display_name") or work.get("title"),
+        "year": work.get("publication_year"),
+        "cited_by_count": work.get("cited_by_count"),
+```
+Reproduced: `publication_year: "not-a-year"` emerges as the *string* `'not-a-year'` in
+`literature enrich`'s JSON. No crash, no marker. A consumer that sorts or filters on
+`year` gets a `TypeError` at its own boundary, or worse, a lexicographic sort. Note the
+contrast with `acquire.candidate_from_work` (`literature/acquire.py:549`), which reads
+the *same* two fields and does guard them:
+```python
+        year=year if isinstance(year, int) else None,
+        title=title if isinstance(title, str) else None,
+```
+So the rule exists in the codebase and was applied in one of the two readers of the
+same upstream record.
+
+**Site 5 — a truncated quarantine sidecar.** `_write_quarantine` moves the PDF
+atomically and then writes the sidecar non-atomically (BE-2):
+
+`defendable-science/defendable_science/literature/acquire.py:1068`
+```python
+    src.replace(pdf)
+    (directory / f"{sha}.json").write_text(
+        json.dumps({...}, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+```
+
+`confirm_quarantined` then reads it back with unguarded indexing:
+
+`defendable-science/defendable_science/literature/acquire.py:1939`
+```python
+    data: dict[str, Any] = json.loads(sidecar.read_text(encoding="utf-8"))
+    candidate = cast("dict[str, Any]", data["candidate"])
+    match = cast("dict[str, Any]", data["match"])
+    rung = cast("str", data["rung"])
+    url = cast("str | None", data["url"])
+```
+
+A run interrupted during the sidecar write leaves a present-but-truncated file. The
+`is_file()` guard at `acquire.py:1916` passes; `json.loads` then raises
+`JSONDecodeError`, or the four lookups raise `KeyError`. `lit_confirm` catches only
+`RetrievalError` (`cli.py:1360`). The four `cast()`s are the tell — see the `cast()`
+sub-finding in BE-10.
+
+**Site 6 — `dataset ingest` on a non-object JSON document.** Reproduced:
+
+```
+$ defendable-science dataset ingest arr.json      # file contains: []
+AttributeError: 'list' object has no attribute 'get'
+```
+
+`defendable-science/defendable_science/cli.py:1548`
+```python
+    try:
+        doc = json.loads(Path(croissant).read_text(encoding="utf-8"))
+        entry = manifest_mod.entry_from_croissant(doc)
+    except (OSError, json.JSONDecodeError, manifest_mod.ManifestError) as exc:
+```
+
+`entry_from_croissant` is annotated `json_ld: dict[str, Any]` (`manifest.py:534`) and
+calls `json_ld.get("name")` at `manifest.py:548` with no runtime shape check. Strict
+mypy is satisfied because `json.loads` returns `Any`. The `except` clause at
+`cli.py:1551` does not list `AttributeError`, so the documented exit 1 becomes a
+traceback.
+
+**Fix for sites 1–4** — the guards these sites need already exist elsewhere in the same
+package; this is applying them consistently, and is what a `_WorkIn` model (BE-9) does
+declaratively:
+
+```python
+# literature/graph.py:254 — guard the elements, not just the envelope
+        for work in page.get("results", []):
+            if not isinstance(work, dict):
+                # A page whose elements are not works is a page we cannot read.
+                # Skipping silently would return a short frontier as if complete —
+                # the same reason the envelope check above is a hard error.
+                raise HttpError(f"{OPENALEX}/works: citation page holds a non-work entry")
+            record = enrich_work(work)
+
+# literature/graph.py:81 — a wrong-typed index is no abstract, not a crash
+    index = work.get("abstract_inverted_index")
+    if not isinstance(index, dict):
+        return None
+
+# literature/graph.py:345 — a scalar where a list was promised is *not* data
+        contexts = edge.get("contexts")
+        if out["context_snippet"] is None and isinstance(contexts, list) and contexts:
+            snippet = contexts[0]
+            out["context_snippet"] = snippet if isinstance(snippet, str) else None
+
+# literature/graph.py:110 — the guard `acquire.candidate_from_work:549` already uses
+    year = work.get("publication_year")
+    cited = work.get("cited_by_count")
+    ...
+        "year": year if isinstance(year, int) else None,
+        "cited_by_count": cited if isinstance(cited, int) else None,
+```
+
+For site 3 specifically, consider marking the record `degraded` rather than silently
+`None`, reusing the mechanism already at `literature/graph.py:382` — "S2 returned
+something we could not read" and "S2 returned nothing" are different facts, and this
+module distinguishes exactly that pair everywhere else.
+
+**Fix for site 5** — same file, same style as its neighbours:
+
+```python
+    try:
+        data = json.loads(sidecar.read_text(encoding="utf-8"))
+        candidate = data["candidate"]
+        match = data["match"]
+        rung = data["rung"]
+        url = data["url"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise RetrievalError(
+            f"quarantine sidecar {sidecar} is unreadable ({exc}) — most likely a "
+            "run interrupted mid-write. Delete it and the matching .pdf, then "
+            "re-run `literature fetch --refetch` for this citekey."
+        ) from exc
+    if not (isinstance(candidate, dict) and isinstance(match, dict)
+            and isinstance(rung, str) and (url is None or isinstance(url, str))):
+        raise RetrievalError(f"quarantine sidecar {sidecar} has the wrong shape …")
+```
+
+For **site 6**, see BE-9 — that surface is better served by a parse model than by
+widening an `except` clause.
+
+**Where I differ from #169's framing.** #169 lists these as six parsing defects. Sites
+3 and 4 are worth separating out: they are not tracebacks, they are **silent wrong
+values emitted as legitimate CLI output**, and by this repository's own severity logic
+(`CLAUDE.md:65`) that is the more serious class. A traceback is loud and the researcher
+re-runs; a citation context reading `'t'` is indistinguishable from a real one and can
+end up quoted in a related-work section. I would fix 3 first, not last.
+
+---
+
+## Medium
+
+### BE-5 — The rclone and `git` subprocesses have no timeout
+
+Three subprocess call sites; one passes a timeout.
+
+`defendable-science/defendable_science/cli.py:221` — correct:
+```python
+        proc = subprocess.run(  # nosec B603 - `path` resolved from PATH; fixed args
+            [path, "--version"],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+```
+
+`defendable-science/defendable_science/core/mirror.py:149` — no timeout:
+```python
+        kwargs: dict[str, object] = {"capture_output": True, "check": False}
+        if self.env is not None:
+            kwargs["env"] = {**os.environ, **self.env}
+        try:
+            proc = self.run(  # nosec B603 - fixed rclone args, no shell
+                self._cmd(*args), **kwargs
+            )
+```
+
+`defendable-science/defendable_science/core/keys.py:393` — no timeout:
+```python
+        proc = run(  # nosec B603 - fixed git args, no shell
+            ["git", "check-ignore", "-q", str(path)],
+            capture_output=True, check=False,
+            cwd=str(cwd) if cwd is not None else None,
+        )
+```
+
+Blast radius for `mirror.py`: every `dataset fetch|mirror|audit` and
+`literature fetch|mirror` hangs indefinitely against a stalled remote, a hung DNS
+lookup, or an rclone build that prompts on stdin. `mirror_entry` calls `check()`
+once per file in a loop (`acquire.py:2330`), so a `literature mirror --all` over a
+degraded remote hangs on the first entry with no output and no way to attribute it.
+There is no `stdin=subprocess.DEVNULL` either, so an interactive rclone prompt blocks
+forever rather than failing.
+
+**Fix**:
+
+```python
+# core/mirror.py — on the Mirror dataclass, beside `rclone_bin`
+    #: Per-call ceiling for one rclone invocation. A mirror we cannot reach must
+    #: fail as `MirrorUnreachableError`, not hang a sweep — the same distinction
+    #: `ABSENT_EXIT_CODES` draws, applied to the time axis.
+    timeout: float = 300.0
+
+# ... in _run_ok
+        kwargs: dict[str, object] = {
+            "capture_output": True,
+            "check": False,
+            "timeout": self.timeout,
+            "stdin": subprocess.DEVNULL,
+        }
+        try:
+            proc = self.run(self._cmd(*args), **kwargs)
+        except FileNotFoundError as exc:
+            raise RetrievalError(
+                "rclone not found on PATH — install it or unset the mirror"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise MirrorUnreachableError(
+                f"rclone {args[0]} on {self.remote!r} did not answer within "
+                f"{self.timeout:.0f}s — the mirror could not be reached, so "
+                "whether it holds this key is unknown",
+                returncode=-1,
+            ) from exc
+```
+
+`core/keys.py:393` wants `timeout=10` and `except subprocess.TimeoutExpired: return None`
+— the function already returns `None` for "git could not answer", so a timeout maps
+cleanly onto the existing contract.
+
+---
+
+### BE-6 — The key store is written world-readable, then chmod'd, and non-atomically
+
+`defendable-science/defendable_science/core/keys.py:198`
+```python
+    resolved = store_path(path)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(dict(sorted(mapping.items())), indent=2) + "\n"
+    resolved.write_text(payload, encoding="utf-8")
+    resolved.chmod(0o600)
+```
+
+Two problems in five lines:
+
+1. **Mode race.** `write_text` creates the file at `0666 & ~umask` — `0644` on a
+   default system. The secret is on disk and world-readable for the interval between
+   line 201 and line 202. On a shared host or a CI runner that is a real window.
+2. **Non-atomic full rewrite.** `set_key` (`keys.py:212`) and `unset_key`
+   (`keys.py:224`) both do load → mutate → `write_store`, i.e. every single-key
+   operation rewrites the whole store. An interruption during line 201 truncates the
+   file and loses **every** stored credential, not just the one being set. The module
+   docstring's honesty section (`keys.py:32`) discusses plaintext-at-rest but not this.
+
+**Fix** — create the temp file with the mode already correct, then rename:
+
+```python
+import os
+import tempfile
+
+
+def write_store(mapping: Mapping[str, str], path: str | Path | None = None) -> None:
+    """Write `mapping` to the store, creating it ``0600`` from the first byte.
+
+    The payload lands in a ``0600`` temp file in the store's own directory and is
+    then renamed over the target, so the secret is never momentarily world-readable
+    (the ``write`` then ``chmod`` order left a window) and an interrupted write can
+    never truncate the store and lose every other key.
+    """
+    resolved = store_path(path)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(dict(sorted(mapping.items())), indent=2) + "\n"
+    fd, tmp_name = tempfile.mkstemp(dir=resolved.parent, prefix=".keys-", suffix=".tmp")
+    tmp = Path(tmp_name)
+    try:
+        os.chmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+        tmp.replace(resolved)
+    except OSError:
+        tmp.unlink(missing_ok=True)
+        raise
+```
+
+(`tempfile.mkstemp` already creates at `0600`; the explicit `chmod` documents the
+intent and survives an exotic umask.)
+
+---
+
+### BE-7 — Per-item HTTP round-trips where OpenAlex offers a batch filter
+
+The N+1 analogue. Three sites, all in `literature/graph.py`, all one call per item
+against an API that accepts up to 50 ids in one `filter=openalex_id:W1|W2|…` query.
+
+`defendable-science/defendable_science/literature/graph.py:403`
+```python
+def _cocitation(openalex_id, citers, client, top):
+    counter: Counter[str] = Counter()
+    for citer in citers:
+        citer_id = citer["id"]["openalex"]
+        if citer_id:
+            for ref in refs(citer_id, client=client):     # 1 HTTP call per citer
+```
+
+`defendable-science/defendable_science/literature/graph.py:417`
+```python
+def _coupling(openalex_id, client, top, frontier):
+    counter: Counter[str] = Counter()
+    for ref in refs(openalex_id, client=client)[:frontier]:
+        for citer in cites(ref, client=client, max_results=frontier):  # ≥1 per ref
+```
+
+With the default `frontier = 50` (`graph.py:436`), `literature neighbors --kind both`
+issues roughly 100 sequential requests. `HttpClient.openalex_rps` defaults to 10.0
+(`core/http.py:149`), so the proactive throttle alone floors it at ~10 s of wall clock
+for one neighbour query — before any retry.
+
+`defendable-science/defendable_science/literature/graph.py:374`
+```python
+    for wid in openalex_ids:
+        record = enrich_work(_fetch_work(client, wid))    # 1 call per id
+```
+
+And the CLI doubles it — `enrich` resolves each identifier separately before enriching:
+
+`defendable-science/defendable_science/cli.py:962`
+```python
+        ids = [_openalex_id(client, ident) for ident in identifiers]
+        rows = graph_mod.enrich(ids, client=client, with_context=with_context)
+```
+
+So `literature enrich A B C` costs six round-trips where two would do. A single
+unresolvable identifier also aborts the whole batch (`_openalex_id` raises
+`typer.Exit(1)` at `cli.py:883`), discarding the work already done on the others.
+
+The on-disk response cache (`core/http.py:155`) blunts the *repeat* cost but not the
+first run, which is the one a researcher waits on.
+
+**Fix** — add one batch helper and route the three loops through it:
+
+```python
+# literature/graph.py
+#: OpenAlex accepts up to 50 ids in one `openalex_id:` OR-filter.
+BATCH = 50
+
+
+def fetch_works(openalex_ids: list[str], *, client: HttpClient) -> dict[str, dict[str, Any]]:
+    """Fetch many works in ``ceil(n/50)`` requests instead of ``n``.
+
+    :returns: work-id → work record, for every id the API returned. An id the
+        API did not return is **absent** from the mapping rather than mapped to
+        an empty dict: "OpenAlex has no such work" and "we did not ask" must not
+        collapse into the same value.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for start in range(0, len(openalex_ids), BATCH):
+        chunk = openalex_ids[start : start + BATCH]
+        page = client.get_json(
+            f"{OPENALEX}/works",
+            {"filter": "openalex_id:" + "|".join(chunk), "per-page": str(BATCH)},
+        )
+        if not isinstance(page, dict):
+            raise HttpError(f"{OPENALEX}/works: batch page is not a JSON object")
+        for work in page.get("results", []):
+            if isinstance(work, dict) and (wid := _short_id(work.get("id"))):
+                out[wid] = work
+    return out
+```
+
+`enrich` becomes a single `fetch_works` call plus a list comprehension; `_cocitation`
+becomes one `fetch_works(citer_ids)` followed by reading `referenced_works` off each
+returned record — which removes the `refs()` call entirely, since the batch response
+already carries that field. Expected reduction for `neighbors --kind both`: ~100
+requests → ~4.
+
+---
+
+### BE-8 — `check` walks and re-parses every artifact three times per run
+
+`run_checks` (`check/checks.py:2097`) composes seven families. Three of them
+independently glob the tree and re-read every staged document, and `Probe` has no
+memoisation:
+
+- `check_frontmatter` → `staged_documents(layout, probe)` at `check/checks.py:937`,
+  then `read_or_finding(path, …)` per document at `check/checks.py:828`
+- `check_cross_artifact` → `_check_dashboard_consistency` → `projected_ids` at
+  `check/checks.py:1746` → `collect()` → `staged_documents` at
+  `progress/collect.py:214` and `read_or_finding` at `progress/collect.py:242`
+- `check_cross_artifact` → `_check_artifact_rules` → `staged_documents` at
+  `check/checks.py:1806`, then `read_or_finding` at `check/checks.py:1820`
+
+`aims.md` is read a fourth time (`progress/collect.py:409` and
+`check/checks.py:1812`). `FsProbe.read_text` (`check/probe.py:62`) goes straight to
+the filesystem every time, and each read is followed by a fresh
+`scaffold.status.parse` / `yaml.safe_load`.
+
+Cost is `3 × (glob + read + YAML-parse)` per staged document. A portfolio of 8 papers
+with 4 hypotheses each is ~100 staged documents, so ~300 reads and ~300 YAML parses
+per `check` — and `check` is the command `research-init` tells users to run routinely.
+The same tree is walked again by `progress dashboard`.
+
+`run_checks` already deduplicates the *findings* this produces (`check/checks.py:2128`),
+which is the symptom being managed rather than the cause.
+
+**Fix** — a memoising probe decorator; no call site changes:
+
+```python
+# check/probe.py
+class CachingProbe:
+    """A `Probe` that reads each path once per run.
+
+    `run_checks` composes seven families over one immutable snapshot of the repo,
+    and three of them walk the same staged documents. Re-reading is not merely
+    slow: two families reading a file at different instants could disagree about
+    it, and a check report must describe one state of the tree.
+    """
+
+    def __init__(self, inner: Probe) -> None:
+        self._inner = inner
+        self._text: dict[Path, str | OSError] = {}
+        self._glob: dict[tuple[Path, str], list[Path]] = {}
+
+    def read_text(self, path: Path) -> str:
+        if path not in self._text:
+            try:
+                self._text[path] = self._inner.read_text(path)
+            except OSError as exc:
+                self._text[path] = exc
+        hit = self._text[path]
+        if isinstance(hit, OSError):
+            raise hit
+        return hit
+
+    def glob(self, root: Path, pattern: str) -> list[Path]:
+        key = (root, pattern)
+        if key not in self._glob:
+            self._glob[key] = self._inner.glob(root, pattern)
+        return list(self._glob[key])
+
+    # exists / is_dir / is_gitignored: delegate, memoised the same way
+```
+
+Then `cli.py:640` becomes `probe = CachingProbe(FsProbe())` and
+`cli.py:754` likewise. Caching the raised `OSError` matters: an unreadable file must
+stay unreadable for every family, or the dedup at `checks.py:2128` starts hiding a
+real inconsistency.
+
+---
+
+### BE-9 — External JSON/YAML is parsed by hand; wrong shapes crash or coerce silently
+
+Five untrusted-input surfaces. The guard quality is **not uniform**, and the split
+matters for what to fix:
+
+| Surface | Parser | Guard quality |
+|---|---|---|
+| OpenAlex work records — **`graph.py`** | `literature/graph.py:90`, `:232-274` | **unguarded** — BE-4 sites 1, 2, 4 |
+| OpenAlex work records — **`acquire.py`** | `literature/acquire.py:508-675` | good `isinstance` ladder per field; ~42 `dict[str, Any]` but every read is checked |
+| Semantic Scholar responses | `literature/graph.py:288-355` | envelope checked, **fields unguarded** — BE-4 site 3 |
+| Croissant JSON-LD | `dataset/manifest.py:534` | **assumes a top-level object** — BE-4 site 6 |
+| `datasets.yml` | `dataset/manifest.py:221-336` | structurally good, but coerces (below) |
+| Registry / triage / key store / point records / cells | `registry.py:290`, `keys.py:170`, `cli.py:1805`, `cli.py:2774`, `extraction.py:239` | **good — see Positive patterns item 7** |
+| Artifact YAML frontmatter | `scaffold/status.py`, `progress/collect.py:64-119` | deliberately tolerant, and correctly so |
+
+The two rows worth reading together are the first two: the *same* upstream record is
+parsed by two modules, and only `acquire.py` guards it. The rule exists in the codebase;
+`graph.py` predates its consistent application.
+
+Two distinct defects rather than one:
+
+**(i) Missing shape checks that become tracebacks or wrong values** — the six sites in
+BE-4.
+
+**(ii) Coercion where validation is meant.** `dataset/manifest.py:226`:
+
+```python
+    try:
+        path = str(raw["path"])
+        sha256 = str(raw["sha256"])
+    except KeyError as exc:
+        raise ManifestError(f"{where}: file missing required key {exc}") from exc
+```
+
+A manifest written `path: [a, b]` silently becomes the *string* `"['a', 'b']"`. Same
+at `manifest.py:268` for `id` and `manifest.py:240` for `retrieval.kind`. The
+subsequent `validate()` pass (`manifest.py:443`) checks the checksum *format*
+(`SHA256_RE`, `manifest.py:24`) so a mangled sha is caught, but a mangled `path` or
+`id` is not — it reaches `retrieval._resolve_file` (`dataset/retrieval.py:96`) as a
+path.
+
+**Fix — Pydantic v2 at the parsing boundary.** Now sanctioned for exactly this
+surface. Model the *wire shape*, keep the existing `dataclasses` as the internal
+value objects, and convert once at the seam:
+
+```python
+# dataset/manifest.py
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+
+class _FileRefIn(BaseModel):
+    """The wire shape of one ``files[]`` element in ``datasets.yml``.
+
+    ``strict`` is on deliberately: this manifest is the fixity spine, and a
+    ``path`` written as a list must be refused, not stringified into
+    ``"['a', 'b']"`` the way ``str(raw["path"])`` did.
+    """
+
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    path: str
+    sha256: str = Field(pattern=r"^(sha256:)?[0-9a-f]{64}$")
+    size: int | None = None
+
+
+class _CroissantIn(BaseModel):
+    """The subset of a Croissant / schema.org ``Dataset`` document we ingest."""
+
+    model_config = ConfigDict(extra="ignore")  # published Croissant carries much more
+
+    name: str
+    alternateName: str | None = None
+    version: str | None = None
+    license: str | None = None
+    description: str | None = None
+    identifier: str | None = None
+    citeAs: str | None = None
+    distribution: list[_DistributionIn] = []
+
+
+def entry_from_croissant(json_ld: object) -> DatasetEntry:
+    """Ingest a published Croissant document into a *draft* registry entry.
+
+    :param json_ld: The decoded document. Typed ``object`` rather than
+        ``dict[str, Any]``: the value comes from ``json.loads`` on a file the
+        tool did not write, and the old annotation let a JSON array reach
+        ``.get()`` and traceback (audit BE-4a).
+    :raises ManifestError: If the document is not a Croissant ``Dataset`` shape.
+    """
+    try:
+        doc = _CroissantIn.model_validate(json_ld)
+    except ValidationError as exc:
+        raise ManifestError(f"croissant: {_render(exc)}") from exc
+    ...
+```
+
+with one shared renderer so Pydantic's error text never leaks as-is:
+
+```python
+def _render(exc: ValidationError) -> str:
+    """Render a `ValidationError` as one actionable line per bad field.
+
+    Pydantic's own ``str(exc)`` carries a URL and a model class name that mean
+    nothing to a researcher editing YAML; this names the field path and the
+    problem, which is what the rest of this package's messages do.
+    """
+    return "; ".join(
+        f"{'.'.join(str(p) for p in e['loc']) or '<document>'}: {e['msg']}"
+        for e in exc.errors()
+    )
+```
+
+One `_WorkIn` model with `extra="ignore"` then covers **BE-4 sites 1–4 at once**, since
+`enrich_work`, `cites` and `candidate_from_work` all read the same record:
+
+```python
+class _S2Edge(BaseModel):
+    """One Semantic Scholar citation edge.
+
+    ``contexts``/``intents`` are lists in the documented schema. Typing them as
+    lists here is what stops a bare string being indexed to its first character
+    and recorded as the sentence a paper was cited in (audit BE-4 site 3).
+    """
+    model_config = ConfigDict(extra="ignore")
+
+    contexts: list[str] = []
+    intents: list[str] = []
+    isInfluential: bool | None = None
+
+
+class _WorkIn(BaseModel):
+    """The subset of an OpenAlex work this package reads.
+
+    ``extra="ignore"`` deliberately: a real work record carries 40+ fields we do
+    not use, and a new upstream field must not break a running install. But a
+    field we *do* read arriving with the wrong type is a fact about the upstream
+    response, not something to coerce — `publication_year: "n.d."` must become
+    ``None``, never the string.
+    """
+    model_config = ConfigDict(extra="ignore")
+
+    id: str | None = None
+    display_name: str | None = None
+    title: str | None = None
+    publication_year: int | None = None
+    cited_by_count: int | None = None
+    abstract_inverted_index: dict[str, list[int]] | None = None
+    authorships: list[_Authorship] = []
+    locations: list[_Location] = []
+    best_oa_location: _Location | None = None
+    primary_location: _Location | None = None
+    open_access: _OpenAccess | None = None
+    referenced_works: list[str] = []
+```
+
+with `model_validate` at the two entry points (`_fetch_work`, `graph.py:119`, and the
+pagination loop at `graph.py:256`) — after which the `isinstance` ladders in
+`acquire.py:508`, `:536`, `:562`, `:612`, `:651`, `:1320`, `:1344` become attribute
+reads. Apply the same to the quarantine sidecar (BE-4 site 5), where a model is strictly
+better than the five `cast()`s.
+
+**Where stdlib remains the better answer.** Do *not* convert:
+
+- `core/config.py:81` — the check is "is it a mapping", three lines, already correct.
+- `core/keys.py:170` — already validates object-ness and per-value string-ness with a
+  message naming the path and the key. A model would be equivalent, not better.
+- `literature/registry.py:290` and its `_decode_*` ladder — the tolerance there is
+  deliberate (unusable rows skipped, not fatal) and the error messages name the entry
+  *index*, which Pydantic's default `loc` rendering would not match without the custom
+  renderer above. Convert only if the renderer lands first.
+- `progress/collect.py:64` (`_strings`) — its tolerance is a *deliberate* documented
+  behaviour ("an author who typed `blockers: awaiting the rerun` meant exactly what
+  they wrote"). A strict model here would drop a blocker, which is the one thing the
+  dashboard exists to show.
+- `defend/record.point_record_from_mapping` (`record.py:87`) and
+  `extraction.cell_from_mapping` (`extraction.py:239`) — these already do exactly what
+  a model would, with better messages, and their `resolved: bool` strictness is
+  hand-tuned for a documented reason (`record.py:90`). A model would be equivalent,
+  not better. If they *are* converted for uniformity, they need
+  `ConfigDict(strict=True)` or Pydantic's lax mode will accept `"false"` for
+  `resolved` and reintroduce the bug the docstring describes.
+
+Dependency tradeoff for adding `pydantic>=2`: see the analysis at the end of
+`plugin-tech-debt.md` → *The Pydantic reversal*. Short version: the CLI is installed
+**isolated** from the consumer's environment (`resources/ensure-tooling.md`, "Notes →
+Isolation"), so the "Rust-binary conflict" half of `CLAUDE.md:64` does not apply; and
+the existing `pyyaml` dependency already ships a compiled C extension (`_yaml`,
+3.1 MB installed here — larger than `rich`), so the "light wheel" half is already
+breached.
+
+---
+
+### BE-10 — `dict[str, Any]` used as a de-facto schema
+
+Strict mypy passes, but the types carry no information about the most important data
+structure in the package. Counts by module (`grep -c "dict\[str, Any\]"`):
+
+```
+literature/acquire.py   42      cli.py                18      literature/graph.py     17
+literature/registry.py   9      digest/artifact.py     7      dataset/manifest.py      5
+check/checks.py          4      progress/collect.py    2      others                   4
+```
+
+The OpenAlex work record is threaded as an untyped `dict[str, Any]` through
+`acquire.py` — `candidate_from_work:536`, `_location_urls:562`, `_landing_locations:612`,
+`identity_candidates:651`, `sibling_candidates:686`, `venue_candidates:793`,
+`_resolve_work:1280`, `_all_landing_urls:1320`, `_access_from_work:1344`, `_ladder:1358`,
+`_accept:1650`, `_try_candidate:1693`, `_exhausted:1758`, `acquire_one:1819`. Every one
+of them re-derives the shape with `isinstance` checks; a typo in a key name is invisible
+to mypy and produces a silent `None` at runtime.
+
+Same for the sweep report, which is built as a bare dict and dispatched into by string:
+
+`defendable-science/defendable_science/literature/acquire.py:2120`
+```python
+    report: dict[str, Any] = {
+        "complete": True, "not_attempted": 0,
+        "fetched": [], "cached": [], "quarantined": [], "manual": [],
+        "committable": [], "errors": [],
+    }
+```
+`defendable-science/defendable_science/literature/acquire.py:2151`
+```python
+        report[outcome.bucket].append(outcome.as_json())
+```
+
+`report[outcome.bucket]` is a `KeyError` waiting on any bucket constant that is not
+also a report key. The `BUCKET_*` constants (`acquire.py:859-869`) keep it correct
+today, and the comment at `acquire.py:867` explains why `BUCKET_ERROR` is plural — a
+naming contortion that exists only to make this string dispatch line up.
+
+#### `cast()` as a substitute for validation — the whole-package sweep
+
+Run down as a pattern rather than as one site. There are **six `cast()` calls in the
+package**, and the split is clean:
+
+| Site | Call | Verdict |
+|---|---|---|
+| `literature/acquire.py:1940` | `cast("dict[str, Any]", data["candidate"])` | **validation substitute** |
+| `literature/acquire.py:1941` | `cast("dict[str, Any]", data["match"])` | **validation substitute** |
+| `literature/acquire.py:1942` | `cast("str", data["rung"])` | **validation substitute** |
+| `literature/acquire.py:1943` | `cast("str \| None", data["url"])` | **validation substitute** |
+| `literature/acquire.py:1944` | `cast("str \| None", candidate.get("license"))` | **validation substitute** |
+| `core/download.py:134` | `cast("StreamSession", requests.Session())` | **legitimate** |
+
+So five of six are the same four lines of `confirm_quarantined` (BE-4 site 5), and the
+sixth is a genuine structural-typing narrowing — `requests.Session` satisfies the
+`StreamSession` Protocol but mypy cannot infer it, which is the textbook use.
+
+The pattern is therefore **confined, not endemic** — but where it occurs it is the worst
+form of it. `data` is the result of `json.loads` on a file the tool wrote and a crash may
+have truncated; every one of the five casts asserts to mypy a fact that nothing checks
+at runtime, on the one code path whose job is to promote unverified bytes into the
+registry after human review. `cast()` here does not merely fail to help: it actively
+tells the type checker to stop asking, which is why strict mypy is clean over a function
+that raises `KeyError` on realistic input.
+
+**Fix**: the runtime guard in BE-4's site-5 snippet, after which all five casts delete —
+`isinstance` narrowing gives mypy the same information *and* checks it. If the sidecar
+gains a Pydantic model under BE-9 instead, `model_validate` subsumes both.
+
+Worth adopting as a standing rule, since the count is currently six: **a `cast()` over a
+value that came from `json.loads`, `yaml.safe_load`, or an HTTP response is a bug**;
+`cast()` is for narrowing a type the checker cannot see, not for asserting a shape the
+program has not verified. A grep for `cast(` in review would keep this at one
+legitimate site.
+
+**Fix** — a `TypedDict` for the report (no new dependency, no runtime cost), and the
+`_WorkIn` Pydantic model from BE-9 for the OpenAlex record:
+
+```python
+# literature/acquire.py
+from typing import TypedDict
+
+
+class FetchReport(TypedDict):
+    """The sweep report's shape — the `literature fetch` JSON contract.
+
+    A `TypedDict` rather than a dataclass because this *is* the emitted JSON and
+    is built incrementally by bucket; typing it makes ``report[outcome.bucket]``
+    checkable instead of a `KeyError` waiting on a constant nobody re-read.
+    """
+
+    complete: bool
+    not_attempted: int
+    fetched: list[dict[str, Any]]
+    cached: list[dict[str, Any]]
+    quarantined: list[dict[str, Any]]
+    manual: list[dict[str, Any]]
+    committable: list[dict[str, Any]]
+    errors: list[dict[str, Any]]
+```
+
+and make the dispatch total instead of dynamic:
+
+```python
+_BUCKET_KEY: dict[str, Literal["fetched", "cached", "quarantined", "manual", "errors"]] = {
+    BUCKET_FETCHED: "fetched", BUCKET_CACHED: "cached",
+    BUCKET_QUARANTINED: "quarantined", BUCKET_MANUAL: "manual",
+    BUCKET_ERROR: "errors",
+}
+```
+
+---
+
+### BE-11 — Injectable-callable fields typed `object`, forcing four `type: ignore[operator]`
+
+`defendable-science/defendable_science/core/http.py:144`
+```python
+    sleep: object = time.sleep
+    clock: object = time.monotonic
+```
+
+Every use then needs a suppression — `core/http.py:265`, `:270`, `:271`, `:361`:
+
+```python
+        now: float = self.clock()  # type: ignore[operator]
+```
+
+Four of the package's eight `# type: ignore` comments come from this one pair. The
+annotation is presumably a workaround for mypy treating a `Callable`-annotated class
+attribute with a function default as a method. The standard fix keeps full typing:
+
+```python
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+@dataclass
+class HttpClient:
+    ...
+    #: Sleep function for backoff and throttling (injectable for tests).
+    sleep: Callable[[float], None] = field(default=time.sleep)
+    #: Monotonic clock for the proactive throttle (injectable for tests).
+    clock: Callable[[], float] = field(default=time.monotonic)
+```
+
+`field(default=…)` on a dataclass stores the function in the instance `__dict__`, so it
+is never bound as a method, and mypy accepts the call sites with no suppression. The
+other two `type: ignore`s in `http.py`'s vicinity disappear with it.
+
+The remaining suppressions are: `cli.py:133`/`:154` (`Typer.command` override — genuine
+and unavoidable), `cli.py:2030` (below), and `cli.py:2526` (BE-13).
+
+`defendable-science/defendable_science/cli.py:2026`
+```python
+    if level not in ("hypothesis", "paper"):
+        typer.echo(f"--level must be 'hypothesis' or 'paper', got {level!r}", err=True)
+        raise typer.Exit(code=2)
+    resolved = path or _resolve_backlog(level)
+    return resolved, backlog_mod.Backlog.load(resolved, level)  # type: ignore[arg-type]
+```
+
+The validation is right there; mypy just cannot narrow `str` to `Level`. Use a
+`TypeGuard` and the ignore goes away:
+
+```python
+def _is_level(value: str) -> TypeGuard[backlog_mod.Level]:
+    """Narrow a raw ``--level`` to the two the backlog module accepts."""
+    return value in ("hypothesis", "paper")
+```
+
+Also note `warn_unused_ignores = false` (`pyproject.toml:94`) — see BE-16 — means a
+suppression that stops being necessary is never reported.
+
+---
+
+### BE-12 — Layout constants duplicated outside `scaffold/layout.py`
+
+`scaffold/layout.py:1` states it is "The single definition of the consumer content
+layout". It is not, for the accountability log:
+
+`defendable-science/defendable_science/defend/record.py:34`
+```python
+DEFAULT_LOG_DIR = Path("docs/research/defend-log")
+```
+
+`Layout` has no `defend_log` property, so all three CLI call sites reach into this
+constant and take *only its last component*, discarding the `docs/research` prefix that
+would contradict a configured `research_root`:
+
+`defendable-science/defendable_science/cli.py:1907`
+```python
+    log_root = (
+        Path(log_dir)
+        if log_dir is not None
+        else layout.research_root / record_mod.DEFAULT_LOG_DIR.name
+    )
+```
+
+Repeated verbatim at `cli.py:2908` and `cli.py:3311`, the latter two reading it through
+a re-export (`digest/artifact.py:39`) so the same constant is reachable by two names.
+The `.name` trick works only because the constant's first two components happen to equal
+`DEFAULT_RESEARCH_ROOT` (`layout.py:31`); change either and they silently disagree.
+
+**Fix** — one property, three call sites collapse:
+
+```python
+# scaffold/layout.py — on Layout
+    @property
+    def defend_log(self) -> Path:
+        """The append-only accountability log every examination writes into.
+
+        Under ``research_root``, not the repo root: it is research evidence, and
+        a repo that moved its research tree moves its evidence with it.
+        """
+        return self.research_root / "defend-log"
+```
+
+Then `record.DEFAULT_LOG_DIR` is deleted (the `record()` keyword already has no sane
+default outside a layout — make `log_dir` required), and each CLI site becomes
+`Path(log_dir) if log_dir is not None else layout.defend_log`.
+
+Second instance: the containment rule is written twice, and the second copy says so.
+
+`defendable-science/defendable_science/cli.py:357`
+```python
+    # Same containment rule as `_relative` in scaffold/layout.py: a relative
+    # value must stay inside the repository.
+    if resolved != repo_root and repo_root not in resolved.parents:
+```
+versus `defendable-science/defendable_science/scaffold/layout.py:242`
+```python
+    if resolved != repo_root and repo_root not in resolved.parents:
+```
+
+They differ in one respect that matters: `layout._relative` refuses an absolute path
+outright (`layout.py:238`), `cli._repo_relative` honours it (`cli.py:353`). That
+divergence is deliberate and documented (`cli.py:341`) — but it is the kind of
+divergence that only stays deliberate while both copies are read together. Extract the
+shared predicate to `core/`:
+
+```python
+# core/paths.py
+def within(repo_root: Path, resolved: Path) -> bool:
+    """Return whether `resolved` is `repo_root` or lies under it."""
+    return resolved == repo_root or repo_root in resolved.parents
+```
+
+Third instance: `dataset/manifest.py:301` and `:339` both default `path` to the string
+literal `"datasets.yml"`, which duplicates `layout.DEFAULT_DATASETS_MANIFEST`
+(`layout.py:32`). No caller uses the default, so it is latent rather than active.
+
+---
+
+## Low
+
+### BE-13 — `keys check` shadows the top-level `check` command at module scope
+
+`defendable-science/defendable_science/cli.py:599`
+```python
+@app.command()
+def check(
+```
+`defendable-science/defendable_science/cli.py:2526`
+```python
+@keys.command()  # type: ignore[no-redef]
+def check() -> None:  # noqa: F811
+```
+
+Both suppressions exist to silence the collision rather than to resolve it. Typer is
+unaffected (each is registered on a different group before the rebind), but
+`defendable_science.cli.check` at import time is the *keys* one, so any future
+programmatic reference, doc-generation walk, or test that imports the symbol gets the
+wrong command. `tools/build_docs_site.py` walks the Typer tree rather than the module
+namespace today, which is the only reason this has not bitten.
+
+**Fix** — name the function for what it is and keep the CLI name in the decorator:
+
+```python
+@keys.command("check")
+def keys_check() -> None:
+    """Report presence/absence and source of each key as JSON (never a value)."""
+```
+
+Both suppressions delete. Note that the sibling commands already follow this
+convention (`lit_fetch`, `lit_confirm`, `extract_axes`, `list_keys`, `set_`, `list_`),
+so this is one straggler, not a pattern.
+
+---
+
+### BE-14 — Unescaped title interpolated into an OpenAlex filter expression
+
+`defendable-science/defendable_science/literature/acquire.py:713`
+```python
+    page = client.get_json(
+        f"{OPENALEX}/works",
+        {"filter": f"title.search:{entry.title}", "per-page": str(SEARCH_LIMIT)},
+    )
+```
+
+`entry.title` comes from the human's `references.json`. OpenAlex's `filter` grammar
+uses `,` for AND and `|` for OR, so a title containing either — *extremely* common:
+"Deep Learning, Revisited", "A|B testing" — produces a filter expression the caller
+did not intend. The failure mode is not a crash: it is a **different query**, silently
+returning different siblings or none, which routes a paper to the `manual[]` worklist
+that rung 4 could have found.
+
+No test covers it — `grep -rn "title.search" tests/` returns nothing. This is the
+"legitimately empty vs. we asked the wrong question" distinction the module is
+otherwise scrupulous about (`acquire.py:1758` `_exhausted` exists for exactly that).
+
+**Fix** — strip the two delimiters before interpolating, and say why:
+
+```python
+#: OpenAlex's `filter` grammar reserves `,` (AND) and `|` (OR); a title carrying
+#: either would be parsed as two filters. `title.search` is a full-text match, so
+#: dropping them narrows nothing that matters — and the gate re-checks the title
+#: on the real record anyway.
+_FILTER_RESERVED = re.compile(r"[,|]")
+
+    search = _FILTER_RESERVED.sub(" ", entry.title)
+    page = client.get_json(
+        f"{OPENALEX}/works",
+        {"filter": f"title.search:{search}", "per-page": str(SEARCH_LIMIT)},
+    )
+```
+
+with a test asserting that a comma-bearing title still finds its sibling.
+
+Related, lower still: `venue_candidates` calls `template.format(**fields)` on a
+consumer-supplied template (`acquire.py:846`). The `except (KeyError, IndexError,
+ValueError)` at `:847` covers malformed templates, and `fields` holds only strings, so
+there is no attribute-traversal exposure. A pathological width spec
+(`{doi:>999999999}`) could allocate a large string; the template is the operator's own
+config, so this is noted for completeness rather than as a recommendation.
+
+---
+
+### BE-15 — God modules: quantified, and *not* the problem it looks like
+
+The three largest modules are big, but their *functions* are not:
+
+| Module | LOC | Top-level defs | Max McCabe |
+|---|---|---|---|
+| `cli.py` | 3,537 | 38 commands + 34 helpers | ≤ 10 |
+| `literature/acquire.py` | 2,350 | 46 | ≤ 10 |
+| `check/checks.py` | 2,136 | 40 | ≤ 10 |
+
+`uv run ruff check --select C901 --config 'lint.mccabe.max-complexity=10'` reports
+**zero** violations across the package; lowering the threshold to 6 surfaces 26. So
+the size is docstring-dense composition of small functions, not tangled logic. Roughly
+half of `cli.py`'s bulk is MyST docstrings, several of which are 40+ lines of genuine
+design rationale (`cli.py:2694-2730`, `cli.py:3240-3289`).
+
+The one structural cost that *is* real: `cli.py` mixes four unrelated
+responsibilities that would be independently testable if split —
+
+1. config/layout resolution helpers (`cli.py:261-458`, ~200 lines, 9 functions)
+2. output shaping (`_emit_row:2033`, `_emit_record_report:2798`, `_emit_sample_report:3145`)
+3. per-group command bodies
+4. the `DocstringTyper` help-text machinery (`cli.py:62-172`)
+
+**Proposed split boundaries** (no rewrite, pure code movement):
+
+- `cli/_config.py` ← `_load_config_or_exit`, `_explicit_root_or_exit`, `_layout_or_exit`,
+  `_repo_relative`, `_cache_root`, `_lit_block`, `_lit_str`, `_rps_from_config`,
+  `_lit_acquisition`, `_lit_mirror`, `_lit_registry_paths`, `CacheDirError`
+- `cli/_help.py` ← `_role_target`, `_strip_inline_roles`, `_prose_only`, `DocstringTyper`
+- `cli/_emit.py` ← the three report emitters and the envelope helper `api-tech-debt.md`
+  API-1 proposes
+- `cli/{literature,dataset,digest,backlog,keys}.py` ← one `DocstringTyper` sub-app each,
+  registered from `cli/__init__.py`
+
+That leaves `cli/__init__.py` at roughly 300 lines of composition. Do this **only if**
+the file becomes hard to navigate in practice; it is not currently causing defects, and
+the priority-ordered items above are worth more.
+
+`acquire.py` divides cleanly along its own section comments — `# --- rungs`,
+`# --- outcome buckets`, `# --- the sweep`, `# --- verify`, `# --- mirror` — into
+`acquire/ladder.py`, `acquire/gate.py`, `acquire/sweep.py`, `acquire/fixity.py`. Same
+caveat.
+
+**Import graph: no cycles.** The one near-cycle is acknowledged and correctly handled —
+`progress.collect` imports `check.checks` at module scope (`progress/collect.py:29`),
+and `check.checks._check_dashboard_consistency` imports `progress.collect` *inside the
+function* with a comment saying why (`check/checks.py:1732`). Everything else is a
+strict `cli → {front-ends} → core` layering.
+
+---
+
+### BE-16 — `warn_unused_ignores = false` + `ignore_missing_imports = true` weaken strict mypy
+
+`defendable-science/pyproject.toml:85`
+```toml
+ignore_missing_imports = true
+```
+`defendable-science/pyproject.toml:94`
+```toml
+warn_unused_ignores = false
+```
+`defendable-science/pyproject.toml:98`
+```toml
+disallow_any_unimported = false
+```
+
+`strict = true` (line 81) is set, and then three of its guarantees are individually
+switched back off. Concretely:
+
+- `pooch` is untyped, so `pooch.retrieve` (`dataset/retrieval.py:59`) returns `Any` and
+  `Path(got)` at `:65` is unchecked. That is the *only* real Tier-B fetch path and it
+  also carries `# pragma: no cover` (`retrieval.py:50`), so neither the type checker nor
+  the test suite constrains it. See `coverage.md`.
+- `warn_unused_ignores = false` means the eight `# type: ignore` comments are never
+  re-validated; several (BE-11) are already removable.
+
+**Fix** — narrow the escape hatches rather than dropping them:
+
+```toml
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+# pooch ships no type information. Scope the exemption to it instead of the
+# whole dependency graph, so a future untyped import is a decision, not a default.
+module = ["pooch.*"]
+ignore_missing_imports = true
+```
+
+and delete the global `ignore_missing_imports = true`. Expect a handful of new errors
+in `dataset/retrieval.py` on the first run; they are the point.
+
+---
+
+## Positive patterns to preserve
+
+These are load-bearing and should survive any refactor.
+
+1. **Failure honesty is implemented, not just stated.** The distinction between
+   "we could not ask" and "the answer is no" is a real, tested type distinction in three
+   independent layers: `MirrorUnreachableError` vs. a `False` return keyed on rclone's
+   exit code (`core/mirror.py:40`, `:160-172`); `DownloadError.hard_miss` keyed on
+   404/410 vs. everything else (`core/download.py:71`); `RateLimitError` as a distinct
+   subclass so a throttle can never be recorded as a miss (`core/http.py:52`). The
+   payoff is `_exhausted` (`literature/acquire.py:1758`), which buckets an exhausted
+   ladder as `manual` only when nothing was *blocked*, and `AuditReport.mirror_present:
+   dict[str, bool | None]` (`dataset/retrieval.py:250`), where `None` genuinely means
+   unknown. Almost nothing at this scale gets this right.
+
+2. **Explicit, injectable seams.** `Probe` (`check/probe.py:13`), `Session` /
+   `Response` (`core/http.py:61`, `:78`), `StreamSession` (`core/download.py:118`),
+   `Runner` (`core/mirror.py:83`), `GitRunner` (`core/keys.py:355`), `SearchClient` /
+   `MirrorClient` (`literature/acquire.py:53`, `:79`), `TierBFetcher`
+   (`dataset/retrieval.py:44`). All structural `Protocol`s, all narrow. CLAUDE.md's
+   claim that the kernels are injectable holds; the only residual coupling is
+   `Path.cwd()` reached via `find_repo_root` (`core/config.py:74`) and the `repo_root`
+   defaults at `dataset/retrieval.py:157` and `:212`, all of which the CLI overrides.
+
+3. **Surgical, comment-preserving writers.** `core/frontmatter.set_field`
+   (`frontmatter.py:102`) edits one key and refuses rather than destroying an
+   annotation it cannot round-trip (`frontmatter.py:158`). `registry.patch_triage`
+   (`registry.py:695`) refuses a sidecar carrying comments, non-mapping rows, or any
+   YAML anchor — with `_alias_groups` (`registry.py:651`) walking the *composed node
+   graph* rather than the constructed objects, precisely to avoid false-positiving on
+   interned scalars. That comment (`registry.py:657-663`) is the single best piece of
+   reasoning in the codebase.
+
+4. **Refusal over silent repair.** `_refuse_unvalidated` (`digest/artifact.py:451`),
+   `_check_verdict` (`digest/artifact.py:421`), refetch drift (`acquire.py:1532`),
+   `_write_quarantine` writing nothing to the registry (`acquire.py:1043`),
+   `scaffold_paper` refusing an existing root (`exploration/backlog.py:599`). The tool
+   consistently prefers an actionable stop to a plausible guess.
+
+5. **Every error message carries a remedy.** Not a single bare "invalid input" in the
+   package. `Finding.remedy` is a required field of the model (`check/model.py:36`),
+   and the free-text errors follow the same discipline —
+   `frontmatter.py:158`, `registry.py:770`, `acquire.py:1258`, `cli.py:1325`,
+   `core/config.py:52`.
+
+6. **Rate-limit politeness is proactive, not just reactive.** `_throttle`
+   (`core/http.py:244`) paces *before* sending, per host key, with independent caps for
+   OpenAlex / S2 / arXiv (`core/http.py:148-150`) sourced from each provider's published
+   guidance. Most clients only implement the reactive half.
+
+7. **Most external-input parsing is already honest — do not churn it.** BE-4's six
+   sites are the exception, and it is worth being precise about how much of the surface
+   is done well, because a blanket "add validation everywhere" would damage more than it
+   fixed. These five sites are the standard the six should be brought up to:
+
+   - `core/keys.py:170` — checks the JSON is an object *and* that every value is a
+     string, and raises a `ValueError` naming the resolved path and the offending key.
+     A missing store is `{}`; a malformed one is an error. Absent ≠ malformed.
+   - `literature/registry.py:290` — `_parse_items` distinguishes "invalid JSON" from
+     "not a JSON array" with two different messages, both naming the file
+     (`registry.py:301`, `:303`); `load_registry_text` then rejects a non-object entry
+     and an entry with no `id`, naming the *index* (`registry.py:334`, `:337`). The
+     `_decode_*` ladder beneath it (`registry.py:205-287`) is tolerant by design —
+     unusable rows are skipped rather than fatal — which is right for a spine the tool
+     wrote, and is documented as such.
+   - `cli.py:1805` — `_parse_points` checks valid JSON, then array, then per-item
+     object, then delegates to `point_record_from_mapping`
+     (`defend/record.py:87`), which type-checks every field with a phrasing table
+     (`record.py:77`). The comment at `record.py:90` explains why `resolved` must be
+     strictly `bool`: Python truthiness would read `"false"` as `True` and drop a gap
+     from the artifact's `unresolved` list. That is validation reasoned from the
+     consequence of getting it wrong.
+   - `cli.py:2383` — `_parse_json_object` returns `None` for both "not JSON" and "JSON
+     but not an object", and the caller treats that as "the stdin was a single value",
+     which is a deliberate and documented two-way branch rather than a swallowed error.
+   - `cli.py:2774` — `_parse_cells` refuses an empty array explicitly, because "a run
+     that recorded no cells and exited 0 would report a failed extraction as a completed
+     one" (`cli.py:2758`), and prefixes every per-item error with the item index.
+
+   `digest/extraction.py:239` (`cell_from_mapping`) belongs in this list too: it refuses
+   *unknown* keys rather than dropping them, because "silently ignoring a misspelled
+   `locater` would turn a typo into a cell with no locator at all, which rule 1 would
+   then blame on the wrong thing" (`extraction.py:242`).
+
+8. **Bandit is clean and the two `nosec` sites are justified.** `# nosec B404`
+   (`cli.py:18`, `core/mirror.py:21`, `core/keys.py:42`) and `# nosec B603`
+   (`cli.py:221`, `core/mirror.py:153`, `core/keys.py:393`) all annotate fixed-argument,
+   no-shell invocations. `# nosec B405/B314` on `xml.etree` (`acquire.py:745`, `:749`)
+   parses an arXiv Atom feed with `ParseError` caught at `:750`; the residual XXE
+   surface is worth a follow-up note but the annotation is honest about what it is.
+
+---
+
+*Cross-references: the CLI/JSON contract findings are in [`api-tech-debt.md`](api-tech-debt.md);
+the artifact-layer and atomicity consequences in [`data-tech-debt.md`](data-tech-debt.md);
+assertion strength and the untested surfaces in [`coverage.md`](coverage.md).*

--- a/.codebase_audit/coverage.md
+++ b/.codebase_audit/coverage.md
@@ -1,0 +1,518 @@
+# Coverage
+
+## The measured result
+
+```
+$ cd defendable-science && uv run pytest -q
+1562 passed, 14 skipped in 16.36s
+
+TOTAL   4976 stmts   0 miss   1498 branch   0 partial   100%
+Required test coverage of 100.0% reached. Total coverage: 100.00%
+```
+
+100.00 % statement **and** branch, across all 41 modules, no exceptions and no `omit`.
+`fail_under = 100` (`defendable-science/pyproject.toml:113`) with `--cov-branch`
+(`:106`). Also clean: `uv run mypy` (79 files, `strict = true`), `uv run ruff check`,
+`uv run bandit -r defendable_science/` (2 Low, both correct uses of `random`).
+
+Corrections to the baseline metrics I was given: source is **17,081 LOC across 41 files**
+(not 15,930/29 — the earlier count appears to exclude `__init__.py` files and predates
+`cli.py` reaching 3,537 and `checks.py` reaching 2,136); tests are **21,833 LOC across
+36 files** (not 20,285/29); `check/checks.py` is 2,136 (not 1,511),
+`tests/test_check.py` is 2,528 (not 1,698), and there is a
+`tests/test_digest_cli.py` at 1,338 that the baseline list omits. There are 42 files in
+`decisions/` — 41 ADRs plus the index. Skills total 2,955 markdown lines, not 2,881.
+
+## Why this document is not a table of percentages
+
+Grouping modules by coverage would print `100%` forty-one times. The gate makes line
+and branch coverage true by construction, so the only useful question is **what a 100 %
+branch gate structurally cannot catch**, and whether the assertions behind those covered
+lines are load-bearing.
+
+Short answer, evidenced below: **this is not coverage theatre.** A hand-built mutation
+spot-check killed 7/7 non-equivalent mutants. Fakes are conformance-pinned against their
+real counterparts. Error branches routinely assert message *text*, not just an exception
+type. The real gaps are concentrated in five places — adversarial parser input,
+external-service contract realism, cross-process concurrency, test-suite structure, and
+the plugin.
+
+---
+
+## 1. Strongly tested
+
+No material gap found in: `core/fixity.py`, `core/download.py`, `core/mirror.py`,
+`literature/registry.py`, `dataset/manifest.py` (shape errors), `check/model.py`,
+`check/checks.py`, `check/probe.py`, all four `digest/` modules, all three `progress/`
+modules, all four `scaffold/` modules, `exploration/backlog.py`.
+
+Three things deserve specific credit because they are rare at any scale:
+
+- **`tests/test_check.py:251` — `test_the_fake_probe_models_the_real_one`.** Pins
+  `FakeProbe` against the real `FsProbe` on a real filesystem across `glob`, `exists`,
+  `is_dir` and empty directories. This converts "we tested against a fake" from an
+  assumption into a *checked* claim, and roughly 150 downstream check/progress tests
+  inherit the guarantee. Almost no codebase does this.
+- **`tests/test_sampling.py:79` — `test_select_sample_is_stable_across_processes`.**
+  Spawns two interpreters with different `PYTHONHASHSEED` and compares the draws. The
+  determinism of `select_sample` is what stops a researcher re-rolling until an easy
+  sample comes up (`cli.py:3243`), and a same-process test cannot establish it.
+- **`tests/test_digest_cli.py:1294`.** An AST-level assertion that `write_extraction`
+  has exactly one call site, inside `validate`'s loop — testing a structural invariant
+  ("validation and writing are one action", `cli.py:2869`) rather than a behaviour.
+
+The atomic-write testing is also genuinely strong, and recent (`0489114`, #144): both
+failure modes of `patch_asset`/`patch_triage` are tested with an orphan-`.tmp` assertion
+*and* a byte-identical-original assertion at `tests/test_lit_registry.py:341`, `:483`,
+`:502`, `:518`, `:559`, `:625`, `:712`. Mid-stream body death with a real
+`requests.exceptions.ChunkedEncodingError`, asserting the partial file was removed:
+`tests/test_download.py:225`; disk-full at `:251`. Partial-scaffold recovery:
+`tests/test_cli_commands.py:928` and `tests/test_backlog.py:806`.
+
+---
+
+## 2. Weakly tested — code executed, weakly asserted
+
+| Module / site | Gap |
+|---|---|
+| `core/http.py:345` | The `except requests.RequestException` retry branch is `# pragma: no cover - network`. `grep RequestException tests/` → **zero hits**. The session is a constructor parameter and `FakeSession` (`tests/test_literature.py:41`) could reach it in three lines. This is the most operationally common HTTP failure (DNS, reset, read timeout) and the branch where a transport failure must set `rate_limited = False` and still consume a retry — i.e. exactly where a connection reset could be mistyped as a throttle. |
+| `dataset/retrieval.py:111` | `mirror.get(...) and verified(blob, ref.sha256)` — no test covers *the mirror returns True but the bytes fail SHA-256*. `MirrorHit` (`tests/test_retrieval.py:290`) always writes a correct payload. Branch coverage cannot see it because both conditions share one arc. The **literature** front-end has this exact test (`tests/test_acquire.py:1208`); the dataset one does not. |
+| `defend/record.py:293-311` | The write-ordering hazard (BE-3 / DATA-1) is untested in both directions: no test makes `_append_log` fail after the artifact is patched, and no test passes a nonexistent artifact path to `record()`. |
+| `digest/artifact.py:548` | Same shape, same absence. |
+| `exploration/backlog.py:601-618` | `tests/test_backlog.py:143` and `:128` test each half of `scaffold_paper`; nothing composes them, so the non-retryable partial scaffold (DATA-1c) is uncovered. |
+| `cli.py:1791` | `_parse_acks` silently accepts an item with no `::`, producing `{"gap": "<whole string>", "by": ""}` → outcome `acknowledged-per-gap` with **nobody named**, in a code path whose purpose is naming the human who waved a gap through. Only well-formed input is tested (`tests/test_record.py:568`). |
+| `literature/graph.py:459` | `neighbors`' `capped` flag is only ever asserted `False` (`tests/test_literature.py:460`). No hermetic test drives `len(citers) >= frontier` to assert `capped is True` — and `capped` exists specifically so truncation is never silent. Single assignment expression, so branch coverage cannot see it. |
+
+**Pattern (a): exit-code-only assertions.** Present but inconsistent rather than
+systemic — peers in the same files do assert messages. Notable instances:
+`tests/test_cli_commands.py:63`, `:70`, `:154`, `:161`, `:251`;
+`tests/test_acquire_cli.py:872`, `:884`, `:904`, `:919`;
+`tests/test_literature.py:340`, `:489`, `:742`;
+`tests/test_cache_config.py:50`, `:82`, `:129`.
+
+The four `test_acquire_cli.py` config-validation tests are the ones that matter: those
+messages *are* the actionability guarantee the CLI advertises ("the message names the
+offending key"), and none of the four checks that the key is named.
+`tests/test_check_cli.py:300` asserts `>= 1` on counts, so it cannot fail if
+deduplication over-collapses by one.
+
+**Pattern (b): mock-argument assertions.** Mostly *correct* uses, not smells.
+`tests/test_mirror.py:46`/`:65` assert rclone's argv — for a subprocess wrapper the argv
+**is** the observable output. `tests/test_cli_commands.py:91`/`:385` use spies that
+delegate to the real function. One genuinely decorative pair:
+`tests/test_check.py:2121` and `:2140` supply a `.gitignore` line that
+`FakeProbe(gitignore={...})` overrides, so they would pass with any line — and the file
+comments say so and point at `test_gitignore.py`.
+
+**Pattern (c): over-mocking.** Essentially absent. Only five `monkeypatch.setattr` sites
+across the whole check/digest/cli/progress/scaffold slice, each either wrapping the real
+callee or forcing a real `OSError`.
+
+---
+
+## 3. Effectively untested
+
+- **`dataset/retrieval._pooch_fetch`** (`dataset/retrieval.py:50`) — the only real
+  Tier-B fetcher, `# pragma: no cover`, and `pooch` is untyped so
+  `ignore_missing_imports = true` (`pyproject.toml:85`) makes its return `Any`. Neither
+  the type checker nor the hermetic suite constrains it. The live suite does.
+- **`core/gitignore.literal_covers`** (`core/gitignore.py:84`) — no direct test;
+  exercised only incidentally as a helper inside `tests/test_check.py:226`.
+- **`core/frontmatter.py`** — no dedicated test file. Covered indirectly through
+  `tests/test_record.py:292-320` and `tests/test_digest_artifact.py:596-770`, which are
+  good on unterminated fences and the comment round-trip refusal, but the module is a
+  hand-rolled parser used by two front-ends and has no suite of its own.
+
+---
+
+## 4. All six `# pragma: no cover` sites, and the coverage config
+
+Every one carries a reason comment. That is already better than most.
+
+| Site | Code | Verdict |
+|---|---|---|
+| `defendable_science/__init__.py:14` | `except PackageNotFoundError:` | **Legitimate** — cannot fire when installed. |
+| `defendable_science/cli.py:3536` | `if __name__ == "__main__":` | **Legitimate**; also matched by `exclude_also`, so doubly excluded. |
+| `defendable_science/literature/registry.py:687` | `if not isinstance(root, yaml.MappingNode):` | **Legitimate** — `triage_mapping` already narrowed the shape, and the comment says so. |
+| `defendable_science/dataset/retrieval.py:50` | `def _pooch_fetch(...)` | **Legitimate but consequential** — an injectable seam, and the live suite exercises the real one. See §5. |
+| `defendable_science/cli.py:228` | `except (OSError, subprocess.SubprocessError):` in `_tool_report` | **Borderline escape hatch.** Trivially testable by monkeypatching `subprocess.run`. Low severity — diagnostic output only. |
+| `defendable_science/core/http.py:345` | `except requests.RequestException as exc:` | **Escape hatch hiding a reachable branch.** The stated reason ("network") no longer holds: `session` is a constructor parameter and `FakeSession` already exists. |
+
+**Coverage config** (`defendable-science/pyproject.toml:112-120`):
+
+```toml
+[tool.coverage.report]
+fail_under = 100
+show_missing = true
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "\\.\\.\\.",
+    "if __name__ == .__main__.:",
+    "pragma: no cover",
+]
+```
+
+There is **no `omit` and no `exclude_lines`** — the whole package is measured. Judging
+each pattern: `if TYPE_CHECKING:` and `if __name__ == .__main__.:` are standard and
+correct. `pragma: no cover` is redundant (coverage.py excludes it by default) and
+harmless. `"\\.\\.\\."` is the one worth naming: it is a regex on the *line*, intended
+for `Protocol` stubs, and would equally excuse a real `...` body in shipped code.
+Nothing currently abuses it. **No pattern silently excludes real code today.**
+
+---
+
+## 5. Live-marked tests
+
+Two files, gated by `pytestmark` at `tests/test_live_retrieval.py:39` and
+`tests/test_live_literature.py:24`. These are the 14 skipped.
+
+**Exercised only under `DEFENDABLE_SCIENCE_LIVE=1`:**
+
+*OpenAlex / Semantic Scholar* (`tests/test_live_literature.py`) — real `graph.resolve`
+on an OpenAlex id (`:49`), an arXiv id with `vN` suffix stripping (`:56`), non-empty
+`graph.refs` (`:64`), real **cursor pagination** with a cap (`:70`), `graph.neighbors`
+co-citation (`:77`), keyless-S2 graceful degradation (`:83`, `:91`), and S2-keyed
+enrichment plus the CorpusId→externalIds→OpenAlex resolution chain (`:101`, `:110`,
+additionally gated on `S2_API_KEY`).
+
+*pooch / rclone* (`tests/test_live_retrieval.py`) — real `pooch.retrieve` over a
+localhost HTTP server (`:100`) including wrong-hash rejection (`:107`); the real
+`rclone` binary against a local-filesystem alias remote: `copyto`/`lsf` round-trip
+(`:116`), mirror-hit-instead-of-redownload (`:129`), audit mirror presence (`:149`). All
+rclone tests skip if the binary is absent (`:47`).
+
+**What that means for confidence — better than "skipped by default" suggests, with one
+hole:**
+
+- These are **not** developer-only. `.github/workflows/live-validation.yml:12` runs them
+  on a **weekly cron (Mon 06:00 UTC)** plus `workflow_dispatch`, on ubuntu-latest with
+  rclone installed and `S2_API_KEY` from secrets. Upstream drift is caught within ≤7
+  days.
+- They are **not a PR gate** (`ci.yml:81` requires only `pre-commit`, `test`,
+  `plugin-validate`), which is correct — a PR must not fail because OpenAlex is down.
+  But the workflow has **no notification or issue-filing step**, so a scheduled failure
+  is a red mark on a tab nobody opens.
+- **The hole: `literature/acquire.py` — 2,350 LOC, the largest literature module — has
+  zero live coverage.** The live suite touches only `graph.py`. Acquire's PDF-acquisition
+  ladder, its OA-location parsing, and its content-type/magic-byte logic are validated
+  exclusively against three trimmed fixtures. Drift in `best_oa_location` or
+  `locations[].pdf_url` would be caught by *neither* suite.
+
+---
+
+## 6. Integration coverage for external services
+
+**Fixtures are real-but-trimmed, and there are only three.**
+`tests/fixtures/openalex/{sill1997,monokan_journal,monokan_arxiv}.json`, 895–1,288 bytes
+each. They carry genuine upstream markers (`W2293093810`, a real MAG id, a real
+`papers.nips.cc` URL, `"best_oa_location": null`), so they are recorded responses
+hand-reduced to the fields the code reads — a real OpenAlex work is 20–50 KB. Loaded at
+`tests/test_acquire.py:368-375`, used nowhere else.
+
+**`graph.py` — the actual OpenAlex + S2 client — has zero recorded fixtures.** It is
+tested exclusively against hand-written idealised dicts: 83 `_client(...)` /
+`FakeSession(...)` constructions in `tests/test_literature.py`, with inline payloads like
+`{"display_name": "A Title", "publication_year": 2023, ...}`
+(`tests/test_literature.py:205-211`, `:374`, `:431`, `:567`, `:588`, `:599`, `:612`,
+`:634`).
+
+Fake transports: `tests/test_literature.py:20` `FakeResponse` / `:41` `FakeSession`
+(routing dict → response, records `calls`); `tests/test_download.py:16`/`:41`;
+`tests/test_acquire_cli.py:39`/`:55`; `tests/test_acquire.py:575` `FakeClient`;
+`tests/test_retrieval.py:42`/`:53` and `tests/test_mirror.py:16`/`:26` for rclone.
+
+**Is upstream contract drift detectable by the hermetic suite? Structurally, no.**
+`FakeSession.get` returns whatever the test registered for a URL. It validates nothing
+about the outbound query and cannot know what the real endpoint returns. Nothing
+re-fetches the three fixtures and diffs them against upstream, and nothing asserts the
+hand-written dicts resemble a real payload. **Hand-written fixtures that can never fail
+is a real finding here**, mitigated — but only for `graph.py` — by the weekly live job.
+
+**Fix**: a `tests/fixtures/openalex/` refresh script run by the live job, which
+re-fetches each recorded work and fails if a field the code reads has disappeared; plus
+at least one `acquire.py` live test driving the ladder against a known open-access DOI.
+
+---
+
+## 7. Concurrency and robustness coverage
+
+Replaces "missing async test coverage" — there is no async anywhere (`grep -rn
+"async def\|await \|asyncio" defendable_science/` → 0; ruff's `ASYNC` rules are enabled
+at `pyproject.toml:142` and clean).
+
+**What exists** — the atomic-write and partial-write tests listed in §1, and they are
+good.
+
+**What does not:**
+
+- **Zero cross-process concurrency tests.** No test runs two CLI invocations against one
+  cache directory, one `triage.yml`, or one registry.
+- **No locking exists to test.** `grep -rn
+  "fcntl\|filelock\|LOCK_EX\|threading.Lock\|multiprocessing" defendable_science/` → 0
+  hits. Safety rests entirely on rename atomicity, which is sufficient for the two
+  content-addressed stores and **not** for the four read-modify-write files (DATA-6).
+- **`literature/acquire.py:1068` and `:1099`** use a bare `src.replace(dest)` with no
+  `.tmp`-cleanup wrapper and no failure test, unlike `registry.py`.
+- **No `fsync` before `replace`** anywhere, so a power-loss window remains. Defensible,
+  but undocumented.
+- **The write-then-log ordering hazard** (BE-3, DATA-1) — three instances, none tested
+  in the failing direction.
+
+A two-process test is cheap and would pin the constraint whichever way it is resolved:
+
+```python
+def test_two_concurrent_triage_patches_do_not_lose_an_update(tmp_path):
+    """`patch_triage` is read-modify-write; without a lock the second run's
+    rewrite discards the first's row. Whether that is fixed or documented as a
+    single-writer constraint, it should not be discovered by a researcher."""
+```
+
+---
+
+## 8. Missing edge cases
+
+**Property-based / fuzz testing: definitively none.** No `hypothesis` (the library) in
+`pyproject.toml:47-62` or `uv.lock`, no `@given`, no `atheris`, no fuzz corpus. Every
+"hypothesis" hit in the repo is the domain term. The suite is 100 %-branch-covered and
+**entirely example-based**. That combination is exactly where the two verified bugs
+below live.
+
+**`core/mdtable.py`** — fence and ambiguity handling are exceptionally covered
+(`tests/test_mdtable.py:200-227` fence variants, `:234-267` duplicate headings,
+`:93-123` ragged rows and separators). But **a verified round-trip bug survives**:
+`render_table` escapes row cells and joins the header raw
+(`core/mdtable.py:446` vs `:450`), so `| a \| b | c |` parses to a 2-column header,
+re-emits as `| a | b | c |`, and the next parse raises `TableError: ragged t row: 2
+cells, header has 3`. Reproduced. A lossless-round-trip API silently corrupts the host
+document. See DATA-5. Also untested: duplicate header columns, CRLF, empty input.
+
+**`dataset/manifest.py`** — verified: `id: null` becomes the literal string `'None'`;
+`license: [a, b]` becomes `"['a', 'b']"` via `_opt_str`'s `str(value)`
+(`dataset/manifest.py:187`) and then **passes** the `if not entry.license` required-check
+at `:366`; `path: ../../etc/passwd` loads with **zero validation errors**
+(`_validate_files`, `:386`, checks only non-empty plus checksum shape). For a fixity
+tool, unvalidated paths in a manifest is the notable one. Also untested: duplicate YAML
+keys (last wins, silently), YAML anchors (no guard at all here, unlike `triage.yml`),
+whitespace-only input, thousands of entries.
+
+**`literature/registry.py`** — anchor/alias handling is the strongest thing in the
+suite: whole-row (`tests/test_lit_registry.py:609`), nested (`:692`), in-list (`:715`),
+merge key (`:762`), scalar reuse (`:785`), cyclic self-reference (`:738`). But three
+gaps: duplicate top-level citekeys in `triage.yml` silently lose a row on rewrite
+(untested, unguarded — the one round-trip shape with no guard); a duplicate `id` in
+`references.json` silently takes the first; and **verified**, `load_triage` raises an
+uncaught `RecursionError` on deeply nested YAML because `registry.py:506` catches only
+`yaml.YAMLError`:
+
+```
+$ triage_mapping(Path("x.yml"), "a: " + "["*600 + "]"*600)
+RecursionError: maximum recursion depth exceeded
+```
+
+A raw traceback from a parsed file — the failure-honesty rule's exact prohibition.
+`dataset/manifest.py:312` has the identical gap. (No BibTeX parser exists; the registry
+is CSL-JSON only, per ADR-0020.)
+
+**`digest/extraction.py`** — best-covered parser in the set: wrong-typed and unknown
+fields, blank locators, duplicate columns, malformed regex config
+(`tests/test_extraction.py:413-458`, `:241-270`). Untested: an explicit `null` field;
+unicode/NBSP in axis names, where matching is exact string equality
+(`digest/extraction.py:390`); and ReDoS in user-supplied `locator_patterns` — that each
+pattern compiles is validated (`extraction.py:314`), match time is not.
+
+**`core/frontmatter.py`** — untested: empty input; **CRLF**, where `rebuild()` joins with
+`"\n"` (`core/frontmatter.py:48`) and silently rewrites the whole file LF-only in a
+module whose contract is "leave every other byte alone" (DATA-13); duplicate `status:`
+blocks, where `set_field` patches the first and `yaml.safe_load` reads the last, so a
+successful write changes nothing a reader sees.
+
+**`core/gitignore.py`** — `check_ignore` is well covered including real `git init` trees
+(`tests/test_gitignore.py:66-97`). `literal_covers` has no direct test. Untested:
+negation lines; trailing whitespace (git treats it as significant, `.strip()` here does
+not); Windows separators against the `startswith(line + "/")` test at
+`core/gitignore.py:113`.
+
+**Systematically absent across all six parsers:** CRLF and Windows paths · duplicate
+keys (four independent silent-loss doors — DATA-11) · very large payloads · unicode
+beyond a single Latin-1 accent (no emoji, RTL, or combining characters anywhere) · path
+traversal in parsed content · recursion limits.
+
+Adding `hypothesis` for these six would be the highest-leverage single change to the
+suite. A round-trip property would have caught the `mdtable` bug on the first run:
+
+```python
+@given(st.lists(st.text(min_size=1), min_size=1, unique=True), ...)
+def test_table_round_trips(header, rows):
+    """`parse(render(x)) == x` — the invariant every table writer depends on."""
+```
+
+---
+
+## 9. Test-suite maintainability
+
+21,833 test LOC against 17,081 source LOC (1.28:1). The *tests* are excellent; the
+*scaffolding* around them is copy-paste-grown.
+
+`tests/conftest.py` is **34 lines and provides exactly one thing**: an autouse fixture
+(`tests/conftest.py:17`) pointing `HOME`/`XDG_CONFIG_HOME` at a throwaway directory and
+clearing `DEFENDABLE_SCIENCE_KEYS_PATH`. Well-documented and correct. It provides **no
+shared builders, no `CliRunner`, no tmp-repo factory, no fakes.**
+
+Measured consequences:
+
+- **15 test files each construct their own `CliRunner()`** — `test_acquire_cli`,
+  `test_backlog`, `test_check_cli`, `test_cli`, `test_cli_commands`, `test_cli_help`,
+  `test_digest_cli`, `test_digest_render`, `test_init_repo`, `test_keys`,
+  `test_literature`, `test_manifest`, `test_progress_cli`, `test_record`,
+  `test_sampling`.
+- **`_unstyled` — the identical `re.sub(r"\x1b\[[0-9;]*m", "", text)` — is defined three
+  times**: `tests/test_cli_help.py:38`, `tests/test_progress_cli.py:228`,
+  `tests/test_cli_commands.py:733`.
+- **`_write` is defined six times with six different signatures**:
+  `tests/test_digest_render.py:64`, `tests/test_manifest.py:53`,
+  `tests/test_extraction.py:32`, `tests/test_lit_registry.py:14`,
+  `tests/test_digest_artifact.py:53`, `tests/test_retrieval.py:15`.
+- **`_scaffolded()` is near-duplicated** at `tests/test_check.py:233` and
+  `tests/test_progress.py:342` — the same seven renderer calls, the progress copy just
+  omitting the `.gitignore` line.
+- **`_repo` ×3** (`tests/test_digest_render.py:286`, `tests/test_digest_cli.py:72`,
+  `tests/test_sampling.py:154`), `_init` ×3, plus ×2 duplicates of `_write_triage`,
+  `_write_config`, `_spine`, `_seed_blob`, `_run`, `_registry`, `_raising_run`,
+  `_quarantine`, `_item`, `_fake_run`, `_entry`, `_cells`, `_artifact`.
+- **Only 3 of 36 test files use `@pytest.fixture` at all.** Four `class` definitions
+  across the 2,933 lines of `test_acquire.py`; one across the 2,528 of `test_check.py`.
+  `parametrize` is used but sparsely (8 in `test_acquire.py`, 3 in `test_check.py`).
+  The two largest suites are flat modules of 167 and 163 top-level functions.
+- One cross-file import stands in for a conftest: `tests/test_progress.py:10`,
+  `from test_check import FakeProbe, _doc  # the shared filesystem fake (#121)`. It
+  works only because pytest inserts `tests/` on `sys.path` — fragile, and an explicit
+  admission that a shared-fixture home is missing.
+
+This is a maintainability finding, not a correctness one. But `conftest.py` is doing
+roughly 1 % of the job it could, and the duplication tax lands on every new test.
+
+---
+
+## 10. The untested half of the repo — the plugin
+
+The plugin is the primary deliverable and is invisible to every tool above.
+
+**`tools/validate-plugin.sh` validates two JSON files.** If `claude` is on PATH it defers
+to `claude plugin validate .` (this *is* what runs locally — verified: "Validating
+marketplace manifest … ✔ Validation passed"). Otherwise the inline Python fallback
+(`tools/validate-plugin.sh:15-58`) checks that `.claude-plugin/plugin.json` parses, is a
+dict, and has non-empty `name`/`version`/`description`; and that
+`.claude-plugin/marketplace.json` parses, is a dict, has a non-empty `name`, and a
+non-empty `plugins` list whose entries each have `name` and a non-null `source`.
+**That is the entire check. It never opens `skills/`.**
+
+**`tests/test_plugin_content.py` (99 lines) asserts exactly three things**: (1)
+`tests/test_plugin_content.py:52` — parametrised over all `skills/*/SKILL.md`, no line
+in *prose* contains the literal `docs/research/` unless it sits inside a fence or matches
+an allow-list regex (`:19`); (2) `:65` — the glob matched ≥ 8 skills, so the guard is not
+vacuous; (3) `:70` — a self-test of the fence-tracking helper. It checks **one
+hard-coded string**, and it deliberately **skips fenced code blocks**, which is where
+every CLI invocation lives.
+
+**Three more plugin-content guards do exist**, and they are good ones:
+
+- `tests/test_status.py:121` — parametrised drift guard: all nine shipped
+  `resources/templates/**.md` status blocks must byte-match `scaffold/status.render()`;
+  `:179`/`:192` guard `templates/README.md`; `:204` pins that no machine-read field
+  carries a placeholder.
+- `tests/test_render.py:147` — `resources/templates/thesis/milestones.yml` must match the
+  renderer.
+- `tests/test_layout.py:326` — asserts `AUTHORITATIVE_DOCUMENTS["thesis"] == "kappa.md"`
+  is consistent with what `kappa.md` and `aims.md` actually say.
+
+**What can still break silently:**
+
+- All 11 `skills/*/SKILL.md` — 2,955 lines. No frontmatter validation, no link checking,
+  and **no check that a `defendable-science <group> <cmd>` named in a skill still exists
+  in the Typer tree**. Four such breaks are shipping right now (API-2).
+- 14 of 26 `resources/` files entirely unguarded: `contracts/*.md`, all eight
+  `references/*.md`, `rigor/rigor-kit.md`, `substrate/asset-registry.md`,
+  `commit-attribution.md`, and `ensure-tooling.md`.
+- **`resources/ensure-tooling.md:26` is the concrete demonstration**: it pins the
+  bootstrap to `defendable-science>=0.3.0,<0.4.0`. The in-tree package is `0.2.2`
+  (`defendable-science/pyproject.toml:7`), `plugin.json` is `0.2.2`, the newest tag is
+  `v0.2.2`, and `CHANGELOG.md:12` still has 0.3.0's content under `## [Unreleased]`. The
+  bootstrap instruction every skill executes names a version that does not exist. Nothing
+  — not `validate-plugin.sh`, not the suite, not CI — checks that pin against reality.
+
+The two tests that close most of this are in
+[`api-tech-debt.md`](api-tech-debt.md) API-3 (invocation-resolves) and API-6
+(pin-is-satisfiable). Both are short, both belong in the existing `test` job.
+
+---
+
+## 11. Mutation spot-check — `core/fixity.py`
+
+No mutation tool is installed (`mutmut`/`cosmic-ray` absent from PATH and `uv.lock`), so
+this was hand-built: `defendable_science/` and `tests/` copied to `/tmp`, mutants applied
+there, suite run via the existing venv. **The repository was never modified; the scratch
+copy is deleted.** Four repo-root-coupled template guards fail in a `/tmp` copy, so
+`test_status.py`/`test_layout.py`/`test_plugin_content.py` were excluded and
+`test_render.py::test_rendered_milestones_matches_the_shipped_template` was held as a
+constant 1-failure baseline — a mutant counts as SURVIVED at exactly 1 failure.
+
+| Mutant | Result |
+|---|---|
+| M1 `bare_sha256`: drop `.lower()` | KILLED (4 tests) |
+| M2 `bare_sha256`: drop `.strip()` | KILLED (2) |
+| M3 `bare_sha256`: `[-1]` → `[0]` | KILLED (30) |
+| M4 `blob_path`: drop the `sha256/` shard segment | KILLED (29) |
+| M5 `verified`: `is_file()` → `exists()` | SURVIVED — **equivalent mutant** (a directory yields `IsADirectoryError`, an `OSError` subclass caught at `core/fixity.py:65` → the same `False`) |
+| M6 `verified`: `==` → `!=` (sanity check) | KILLED (21) |
+| M7 `verified`: unreadable file → `True` | KILLED (3) |
+| M8 `sha256_file`: chunk 1 MiB → 1 byte | SURVIVED — **equivalent mutant, as predicted** (validates the harness is not producing false kills) |
+| M9 `sha256_file`: `sha256` → `sha512` | KILLED (36) |
+
+**Mutation score: 7/7 non-equivalent mutants killed (100 %)**, with both equivalent
+mutants correctly surviving. Empirical evidence that in the fixity core — the module the
+whole integrity story rests on — the 100 % line coverage is backed by real assertion
+strength rather than execution alone.
+
+---
+
+## Key gaps to address
+
+Ranked by impact on **research integrity** and on a consumer's ability to trust an
+artifact this tool produced.
+
+1. **Nothing tests the skill↔CLI contract, and four invocations are broken today**
+   (API-2, API-3). A skill that names a flag the CLI dropped fails in front of a
+   researcher mid-workflow. One parametrised test closes it.
+2. **Nothing tests that the compat pin is satisfiable** (API-6). The shipped bootstrap
+   names an unreleased version; ~15 lines of test prevent a recurrence.
+3. **The write-then-log ordering hazard is untested in the failing direction** — three
+   instances (`defend/record.py:293`, `digest/artifact.py:548`,
+   `exploration/backlog.py:601`). This is the failure where an artifact claims verified
+   understanding with no evidence behind it, which is categorically the worst thing this
+   tool can do. Two `monkeypatch` tests.
+4. **`core/mdtable.render_table` silently corrupts a host document** (DATA-5) —
+   verified, and the class of bug a single round-trip property test eliminates.
+5. **Unvalidated paths and coerced scalars in `datasets.yml`** (DATA-3, DATA-12) —
+   verified: `path: ../../etc/passwd` produces zero validation errors in a fixity tool.
+6. **`RecursionError` from deeply nested YAML** in `literature/registry.py:506` and
+   `dataset/manifest.py:312` — verified raw traceback, against the repo's own rule.
+7. **`core/http.py:345`'s pragma hides the most common HTTP failure.** Drop it and test
+   the branch through the existing `FakeSession`; this is where a connection reset must
+   not be mistyped as a throttle.
+8. **`literature/acquire.py` has no live coverage at all** (§5) — 2,350 LOC of upstream
+   parsing validated against three hand-trimmed fixtures.
+9. **Zero concurrency tests, and no locking to test** (§7, DATA-6). Either add the lock
+   or document the single-writer constraint — but discovering it as a lost `triage.yml`
+   row is the wrong way for a researcher to learn it.
+10. **No property-based testing on six hand-rolled parsers of untrusted input** (§8).
+    Adding `hypothesis` to the dev group would have caught items 4 and 5 mechanically.
+11. **`conftest.py` provides one fixture** (§9). Moving `_unstyled`, `CliRunner`,
+    `_scaffolded` and `FakeProbe` into it removes ~40 duplicated definitions and the
+    `sys.path`-dependent cross-file import at `tests/test_progress.py:10`.
+
+---
+
+*Cross-references: [`be-tech-debt.md`](be-tech-debt.md) for the implementation side of
+items 3, 6 and 7; [`data-tech-debt.md`](data-tech-debt.md) for 4, 5 and 9;
+[`api-tech-debt.md`](api-tech-debt.md) for 1 and 2;
+[`plugin-tech-debt.md`](plugin-tech-debt.md) for §10.*

--- a/.codebase_audit/data-tech-debt.md
+++ b/.codebase_audit/data-tech-debt.md
@@ -1,0 +1,930 @@
+# The git-native artifact / data layer
+
+**Framing.** There is no database. Persistence is **files in a git repository**:
+markdown with YAML frontmatter, a CSL-JSON bibliography, a YAML triage sidecar, a
+Croissant-interop dataset manifest, an on-disk HTTP response cache, a content-addressed
+blob store, an out-of-repo JSON key store, and an append-only accountability log. Git
+is the transaction log and the audit trail (ADR-0018).
+
+Every category below is the original template's, mapped onto that substrate.
+
+---
+
+## Alembic: not applicable — and the real analogue is a genuine gap
+
+`alembic history` / `alembic current` do not run: there is no database, no ORM, no
+`alembic.ini`, and no migration directory anywhere in the repository. Recording that
+plainly rather than skipping it, because the *analogue* is real and, in this repo, more
+consequential than a DB migration would be. See **DATA-4**.
+
+---
+
+## Priority index
+
+| # | Finding | Severity |
+|---|---|---|
+| DATA-1 | Multi-file writes are non-atomic and un-rolled-back; the claim lands before the evidence | **High** |
+| DATA-2 | No single authoritative schema per artifact; the shape is re-implemented in four places | **High** |
+| DATA-3 | Externally-derived strings flow into filesystem paths unchecked | **High** |
+| DATA-4 | No artifact schema version and no migration path for already-initialised repos | **High** |
+| DATA-5 | `render_table` corrupts a host document on round-trip | **High** |
+| DATA-6 | Read-modify-write with no locking; two concurrent invocations silently lose one update | **Medium** |
+| DATA-7 | Full-file re-read and re-write per item: O(n²) I/O on registry sweeps | **Medium** |
+| DATA-8 | Every lookup is a linear scan or a full tree walk; no index | **Medium** |
+| DATA-9 | The HTTP cache never expires and has no negative-caching policy | **Medium** |
+| DATA-10 | Destructive overwrite of recorded evidence; git alone is the undo | **Medium** |
+| DATA-11 | Four silent-data-loss doors from duplicate keys | **Medium** |
+| DATA-12 | Manifest values are coerced, not validated | **Low** |
+| DATA-13 | Frontmatter round-trip is not byte-preserving on CRLF | **Low** |
+
+---
+
+## High
+
+### DATA-1 — Multi-file writes are non-atomic and un-rolled-back
+
+Three commands write several files, or a file plus a registry update, with no
+transaction. In each the *claim* is durable before the *evidence* is.
+
+**(a) `defend record`.** `defend/record.py:288`:
+```python
+    artifact_path = Path(artifact)
+    if record_understanding:
+        patched = patch_understanding(...)
+        artifact_path.write_text(patched, encoding="utf-8")     # 1. the claim
+    transcript_path: Path | None = None
+    if transcript is not None:
+        transcript_path = artifact_path.with_name(f"defend-{date}.md")
+        transcript_path.write_text(transcript, encoding="utf-8")  # 2.
+    ...
+    log_entry_path = _append_log(Path(log_dir), entry)            # 3. the evidence
+```
+A failure at step 3 leaves the artifact reading
+`status.understanding: {"status": "ok", "unresolved": []}` with **no accountability-log
+entry**. `progress` and `check` both read the frontmatter, not the log, so the false
+claim reaches the dashboard. For a tool whose stated purpose is defensible claims, this
+is the worst orientation the two writes could have.
+
+**(b) `digest extract record`.** Identical shape at `digest/artifact.py:548`, plus a
+second stage: `cli.py:2966` then patches `triage.yml`. That second stage *is* handled
+correctly — the cells are written first deliberately, and a triage refusal is reported
+under a separate `triage_not_updated[]` bucket with a `kind` discriminator
+(`cli.py:2982`), reasoned out at `cli.py:2961`. Good design applied to the second
+boundary and not the first.
+
+**(c) `backlog promote --scaffold`.** `exploration/backlog.py:598`:
+```python
+    root = layout.paper_dir(paper_id)
+    if root.exists():
+        raise BacklogError(f"{root} already exists — refusing to overwrite")
+    layout.hypotheses_dir(paper_id).mkdir(parents=True)
+    docs_dir = layout.paper_docs_dir(paper_id)
+    docs_dir.mkdir(parents=True)
+    layout.backlog(paper_id).write_text(...)
+    (docs_dir / "pitch.md").write_text(...)
+    append_papers_registry(layout.papers_registry, paper_id, ..., backend)
+```
+If `append_papers_registry` raises — a `papers.md` missing a required column
+(`exploration/backlog.py:533`), a duplicate `paper-id` (`:538`), a ragged table
+(`:527`) — the paper tree with its two files is already on disk and unregistered.
+
+`cli.py:2334` catches the `BacklogError` and exits 1 without saving the backlog, so the
+row correctly stays `ranked`. But **the operation is not retryable**: the next attempt
+hits `root.exists()` at `exploration/backlog.py:599` and refuses. The command's own
+docstring claims otherwise:
+
+`defendable-science/defendable_science/cli.py:2296`
+```
+    Scaffolding runs *before* the backlog is written, so a refused scaffold (the
+    artifact already exists) leaves the row ``ranked`` and the operation
+    retryable, never ``promoted`` with nothing on disk.
+```
+That holds for the `root.exists()` refusal it names, and not for the registry refusal.
+The user must delete a directory by hand, with no message telling them so.
+
+**Rollback story: there is none.** No command unwinds a partial write. The implicit
+answer is `git checkout`, which fails for the common case — a repo mid-session with
+other uncommitted work — and does nothing for the cache and key store, which are
+gitignored.
+
+**Fix** — order the writes so the durable-first item is the one that is safe to orphan,
+and make the multi-file case reversible:
+
+```python
+# exploration/backlog.py — scaffold_paper
+    root = layout.paper_dir(paper_id)
+    if root.exists():
+        raise BacklogError(f"{root} already exists — refusing to overwrite")
+    # Reserve the registry row first. A row with no tree is a visible, fixable
+    # inconsistency the author can see in `papers.md`; a tree with no row is
+    # invisible to `progress` and `check`, and blocks its own retry at the
+    # `root.exists()` guard above.
+    append_papers_registry(layout.papers_registry, paper_id, registry_root(layout, root), backend)
+    try:
+        layout.hypotheses_dir(paper_id).mkdir(parents=True)
+        docs_dir = layout.paper_docs_dir(paper_id)
+        docs_dir.mkdir(parents=True)
+        write_atomic(layout.backlog(paper_id), Backlog(...).dumps())
+        write_atomic(docs_dir / "pitch.md", _PAPER_TEMPLATE.format(...))
+    except OSError:
+        shutil.rmtree(root, ignore_errors=True)   # nothing else wrote here yet
+        remove_papers_registry_row(layout.papers_registry, paper_id)
+        raise
+    return root
+```
+
+For `defend record` and `write_extraction`, see BE-3 in
+[`be-tech-debt.md`](be-tech-debt.md): write the log entry first, then the artifact.
+
+**Single-file atomicity is a separate, broader gap** — 15 of 18 write sites use a plain
+`write_text` on the destination with no temp-and-rename, including
+`positioning.md`'s full rewrite (`cli.py:3509`), the key store (`core/keys.py:201`) and
+every backlog table. Full inventory and the shared `write_atomic` helper are in BE-2.
+
+---
+
+### DATA-2 — No single authoritative schema per artifact
+
+Each artifact type's shape is defined **four times**, in four languages, with nothing
+tying them together.
+
+Take the paper `decision.md` status block:
+
+| Where | What defines the shape | File |
+|---|---|---|
+| **Writer** | `status.render("paper", …)` emits the field set | `defendable-science/defendable_science/scaffold/status.py:94` |
+| **Template** | the literal YAML a human sees and edits | `resources/templates/paper/decision.md` |
+| **Reader** | `_artifact()` reads `id`, `verdict`, `readiness`, `signed-off-by`, `load-bearing`, `covers`, `blockers`, `last-updated`, `understanding` | `defendable-science/defendable_science/progress/collect.py:310-328` |
+| **Validator** | `_check_frontmatter_document` re-derives required/known fields and enums | `defendable-science/defendable_science/check/checks.py:821`, `:756`, `:796` |
+
+Four places that must agree, and there is **no shared constant**. `_check_unknown_fields`
+(`check/checks.py:756`) and `_check_enum_field` (`:796`) encode the permitted keys and
+values inside the checker; `progress/collect.py` reads by string literal; the template
+is hand-written markdown.
+
+Two guards exist and they are good, but they cover only one edge of the square:
+
+- `tests/test_status.py:121` parametrises over all nine shipped
+  `resources/templates/**.md` and asserts each status block byte-matches
+  `scaffold/status.render()` — **template ↔ writer**.
+- `tests/test_status.py:179` pins `resources/templates/README.md`'s documented field
+  set and order — **docs ↔ writer**.
+
+Nothing pins **reader ↔ writer** or **validator ↔ writer**. Adding a field to
+`status.py` and to the templates leaves `progress/collect.py` silently ignoring it and
+`check/checks.py` reporting it as unknown. The `AUTHORITATIVE_DOCUMENTS` /
+`STAGED_DOCUMENTS` pair (`scaffold/layout.py:36`, `:65`) is the counter-example done
+right: one dict, read by `init`, `check` and `progress`, with a comment explaining why
+it is written out rather than derived.
+
+There is a fifth definition off to one side:
+`skills/progress/SKILL.md:80-98` ships a 19-line copy of the status frontmatter,
+byte-identical today to `resources/templates/README.md:82-100`. The README copy is
+guarded by `tests/test_status.py:179`; **the skill copy is not**, so it drifts on the
+next schema change.
+
+The same four-way split applies to the registry spine — `Asset`/`AssetFile`/`License`
+dataclasses (`literature/registry.py:95-118`), `asset_to_json` (`:366`), the
+`_decode_*` ladder (`:205-287`), and `_check_references` (`check/checks.py:1352`) — and
+to the dataset manifest.
+
+**Fix — one Pydantic model per artifact type at the parse boundary, and generate the
+rest from it.** Now sanctioned for exactly this surface:
+
+```python
+# scaffold/schema.py  (new)
+from typing import Literal
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Understanding(BaseModel):
+    """The block `defend record` writes and `progress` surfaces."""
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok", "gaps"]
+    unresolved: list[str] = []
+
+
+class PaperStatus(BaseModel):
+    """The `status:` block of a paper-level staged document.
+
+    One definition, four consumers: `status.render` emits it, `check` validates
+    against it, `progress` reads it, and the shipped template is generated from
+    it. Before this model those four were four independent transcriptions of the
+    same field table, with test guards on only one of the six pairings.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    schema_version: int = Field(default=1, alias="schema-version")
+    id: str | None = None
+    verdict: Literal["confirmed", "refuted", "inconclusive", "n/a"] | None = None
+    readiness: Literal["draft", "submittable", "publish", "no-go"] | None = None
+    signed_off_by: str | None = Field(default=None, alias="signed-off-by")
+    load_bearing: bool = Field(default=False, alias="load-bearing")
+    covers: list[str] = []
+    blockers: list[str] = []
+    last_updated: str | None = Field(default=None, alias="last-updated")
+    understanding: Understanding | None = None
+```
+
+Then:
+
+- `status.render()` emits `PaperStatus.model_json_schema()`'s field order — the template
+  is generated, not transcribed.
+- `check_frontmatter` replaces `_check_unknown_fields` / `_check_enum_field` with
+  `PaperStatus.model_validate(block)` and maps each `ValidationError` entry onto a
+  `Finding`, keeping the existing severity model (`check/model.py:26`) and the remedy
+  text — which is the part worth preserving.
+- `progress/collect.py` reads typed attributes instead of `status.get("verdict")`.
+
+**Important caveat.** `progress/collect.py`'s tolerance is *deliberate* and must
+survive: `_strings` (`progress/collect.py:64`) accepts `blockers: awaiting the rerun`
+as a one-element list because "dropping it because the YAML type was not the expected
+one would hide a blocker, which is the one thing the dashboard exists to show". Use
+`model_validate` in `check` (strict, reports the problem) and keep the tolerant reader
+in `progress` (never drops data). Two readers with two jobs, one schema — not one
+strict reader that silently discards.
+
+Tracking: this reverses `CLAUDE.md:64`; the reconciliation is filed as **#169** (see
+[`plugin-tech-debt.md`](plugin-tech-debt.md)).
+
+---
+
+### DATA-3 — Externally-derived strings flow into filesystem paths unchecked
+
+Cross-reference: **BE-1** in [`be-tech-debt.md`](be-tech-debt.md) has the full analysis
+and the reproduction. Summarised here because it is a property of the *storage layer*,
+not just of one function.
+
+`Layout` derives every artifact path by interpolating an identifier with no validation
+— `digest()` (`scaffold/layout.py:144`), `paper_dir()` (`:179`), `backlog()` (`:183`),
+`positioning()` (`:195`), `hypothesis_dir()` (`:199`) — and
+`append_log_entry` does the same for the log filename (`defend/record.py:343`). The
+identifiers come from a CSL-JSON `id`, a `--cells` JSON payload, or `backlog --id`.
+
+**Reproduced**: a cell whose citekey is `../../../../../../tmp/dsaudit/PWNED` caused
+`digest extract record` to create `/tmp/tmp/dsaudit/PWNED.md` outside the work tree,
+creating intermediate directories on the way.
+
+The same repository already enforces this rule in three other places —
+`acquire._safe_name` (`literature/acquire.py:1019`), `layout._relative`
+(`scaffold/layout.py:241`), `cli._repo_relative` (`cli.py:359`) — which is why this is
+an inconsistency finding rather than an oversight.
+
+**Related, unfixed in the dataset layer**: `_validate_files`
+(`dataset/manifest.py:386`) checks that `path` is non-empty and that the checksum
+matches `SHA256_RE`, and nothing else. A Tier-A entry with `path: ../../etc/passwd`
+loads with **zero validation errors**, and `retrieval._resolve_file`
+(`dataset/retrieval.py:96`) then joins it to `repo_root`:
+
+```python
+    if entry.tier == "A":
+        repo_path = Path(ref.path)
+        if not repo_path.is_absolute():
+            repo_path = repo_root / repo_path
+        if verified(repo_path, ref.sha256):
+            return repo_path
+```
+
+The checksum gate makes this read-only and mostly harmless in practice — you can only
+"fetch" a file whose SHA-256 you already knew. But `dataset verify` will then report
+that out-of-tree path as `verified`, and the manifest is a file a collaborator sends
+you. Add the containment check to `_validate_files`, where the other manifest rules
+live.
+
+**Unsafe deserialisation: none.** Every YAML load is `yaml.safe_load` —
+`core/config.py:92`, `literature/registry.py:506`, `dataset/manifest.py:312`,
+`progress/collect.py:456`, `digest/artifact.py:329` — plus `yaml.compose(...,
+Loader=yaml.SafeLoader)` at `registry.py:684`. `yaml.load` appears nowhere. All dumps
+are `yaml.safe_dump`. There is no zip/tar extraction anywhere in the package, so
+zip-slip does not apply. rclone is invoked with a fixed argv list and no shell
+(`core/mirror.py:132`), so argument injection does not apply. The one XML parse
+(`literature/acquire.py:745`) uses `xml.etree` with `# nosec B405/B314` on a feed from
+a known host and catches `ParseError`; hardening it against entity expansion with
+`defusedxml` is a reasonable follow-up but not a live exposure at Atom-feed scale.
+
+---
+
+### DATA-4 — No artifact schema version, and no migration path
+
+Alembic is not applicable. The analogue is: **what happens to a researcher's existing
+artifacts when the schema moves?**
+
+**There is no schema-version field on any artifact.** Grep confirms: no
+`schema-version`, `schema_version` or `apiVersion` in `resources/templates/**` or in
+`scaffold/status.py`. The one exception proves the point — the registry spine *does*
+carry one:
+
+`defendable-science/defendable_science/literature/registry.py:26`
+```python
+#: Spine schema version, so a future migration need not guess.
+SCHEMA = 1
+```
+written at `registry.py:376`, read at `:277`. Nothing consumes it: no code branches on
+`asset.schema`, and there is no migration to guess for. So the mechanism exists in
+exactly one place, is unused, and is absent from the artifacts that actually matter
+(the frontmatter of every hypothesis, paper and thesis document).
+
+**There is no migration or upgrade command.** The CLI has no `migrate`, no `upgrade`,
+no `--fix`. `init` explicitly refuses to touch existing files:
+
+`defendable-science/defendable_science/cli.py:516`
+```
+    **Existing files are never overwritten** — a file already there is reported
+    ``exists`` and left exactly as the author wrote it, which is why there is no
+    ``--force``: re-running only fills the gaps.
+```
+That is the right default. It also means `init` is not, and cannot become, the upgrade
+path: re-running against a repo scaffolded by an older version fills gaps and leaves
+every stale field in place.
+
+**What `research-init adopt` does with pre-existing files**: `adopt` is a *skill* mode
+(`skills/research-init/SKILL.md:36`), not a CLI command — the tree has no `adopt`
+(confirmed against the live Typer tree). It resolves to the same
+`defendable-science init` plus human judgement about where things go, so the same
+gap-filling semantics apply.
+
+**What `check` does with an artifact written by an older package version.** This is the
+concrete failure. `_check_unknown_fields` (`check/checks.py:756`) reports any field it
+does not recognise. So:
+
+- a field **removed** in a new version → every existing artifact reports `invalid`, and
+  `check` exits 1, on a repo the researcher has not touched;
+- a field **added** → `_required` reports it missing on every existing artifact;
+- a field whose **semantics changed** → nothing at all is reported. The old value is
+  read as if it meant the new thing. For a field like `readiness` or `signed-off-by`
+  this silently changes what a dashboard and a defensibility gate assert.
+
+The third is the dangerous one, and it is precisely the failure the repo's own
+failure-honesty rule exists to prevent — applied to time rather than to network errors.
+
+**This has already happened once.** `CHANGELOG.md`'s `[Unreleased]` section records
+that `progress dashboard` grew `scaffold.status.SIGNED_READINESS` and that "`check`
+grew the matching rule, which its `verdict: n/a` exemption had been hiding". A
+sign-off rule changed meaning. There is no note about what that does to a thesis
+artifact written the week before, and no version on the artifact to tell them apart.
+
+**Fix** — add the field now, while there is one schema version to declare:
+
+```python
+# scaffold/status.py
+#: The artifact frontmatter schema version. Bumped when a field is removed or
+#: given new semantics — never for a purely additive change, which an older
+#: reader ignores harmlessly. Written into every scaffolded artifact so a future
+#: `migrate` has something to branch on rather than a guess, and so `check` can
+#: say "written by an older version" instead of "invalid".
+SCHEMA_VERSION = 1
+```
+
+emitted by `status.render()` into every template, with three consequences:
+
+1. `check` distinguishes three cases instead of one — *current and invalid*
+   (`invalid`, exit 1), *older schema* (a new `outdated` severity, exit 0, remedy
+   "run `defendable-science migrate`"), *newer schema* (`unreadable`, exit 1: this CLI
+   cannot know what the fields mean, and guessing is the one thing it must not do).
+2. `_check_unknown_fields` stops firing on old artifacts.
+3. A `migrate` command becomes writable, with the same posture as the rest of the tool:
+   `--dry-run` by default, per-file report, never touching a file it cannot parse, and
+   atomic writes (BE-2).
+
+Until then the honest interim is a documented statement in
+`resources/templates/README.md` that artifact schemas are unversioned and that a
+package upgrade may require hand-editing — which is at least true, and is not currently
+said anywhere.
+
+---
+
+### DATA-5 — `render_table` corrupts a host document on round-trip
+
+Every markdown table this tool writes — the two backlogs, `papers.md`, the concept
+matrix in `positioning.md` — goes through one renderer, and it escapes data cells but
+not header cells.
+
+`defendable-science/defendable_science/core/mdtable.py:443`
+```python
+def render_table(header: list[str], rows: list[Row]) -> str:
+    """Render `rows` as a GFM table in `header`'s column order."""
+    lines = [
+        "| " + " | ".join(header) + " |",              # <-- raw
+        "|" + "|".join("---" for _ in header) + "|",
+    ]
+    lines.extend(
+        "| " + " | ".join(escape_cell(row.get(c, "")) for c in header) + " |"
+        for row in rows                                 # <-- escaped
+    )
+```
+
+`escape_cell` (`core/mdtable.py:117`) exists and is correct; line 446 does not call it.
+`split_cells` un-escapes on the way in, so a header cell containing an escaped pipe is
+parsed correctly and then re-emitted unescaped.
+
+**Reproduced:**
+
+```
+input:            | a \| b | c |
+                  |---|---|
+                  | 1 | 2 |
+
+parsed header:    ['a | b', 'c']            # 2 columns, correct
+round-tripped:    | a | b | c |             # 3 columns — escape dropped
+re-parse:         TableError: ragged t row: 2 cells, header has 3 (['1', '2'])
+```
+
+So `backlog add` on a table whose header contains a pipe writes a file that the very
+next `backlog list` cannot read. The document is corrupted in place, silently, by a
+successful command. `Backlog.save` (`exploration/backlog.py:242`) is a plain
+`write_text`, so there is no `.tmp` and no prior copy — see DATA-1.
+
+A pipe in a header is unusual but not exotic: `| metric (a\|b) |`, `| P(y\|x) |`.
+
+**Fix** — one call:
+
+```python
+    lines = [
+        "| " + " | ".join(escape_cell(c) for c in header) + " |",
+        ...
+```
+
+and a round-trip property test, which is the class of test that would have caught it:
+
+```python
+@pytest.mark.parametrize("cell", ["a | b", "a\\b", "a\nb", "|", ""])
+def test_table_round_trips_pathological_headers(cell):
+    """`parse(render(x)) == x` — the invariant every writer here depends on."""
+    src = splice("", "", [cell, "c"], [{cell: "1", "c": "2"}])
+    doc = parse_document(src, row_label="t")
+    assert doc.header == [cell, "c"]
+```
+
+---
+
+## Medium
+
+### DATA-6 — Read-modify-write with no locking
+
+`grep -rn "fcntl\|filelock\|LOCK_EX\|threading.Lock\|multiprocessing" defendable_science/`
+returns **zero hits**. There is no locking anywhere; concurrency safety rests entirely
+on `Path.replace` being atomic.
+
+That is sufficient for the two content-addressed stores — the HTTP cache
+(`core/http.py:169`) and the blob store (`literature/acquire.py:1086`) — where the
+destination is derived from the bytes, so a racing writer writes identical content.
+`_store_blob`'s comment says exactly this (`literature/acquire.py:1089`).
+
+It is **not** sufficient for the four read-modify-write files:
+
+| File | Writer | Race |
+|---|---|---|
+| `references.json` | `patch_asset` (`literature/registry.py:432`) | reads all items, mutates one spine, rewrites all. Two concurrent `literature fetch` runs → the second's rewrite discards the first's spine. |
+| `triage.yml` | `patch_triage` (`literature/registry.py:695`) | same shape. Called in a loop by `digest extract record` (`cli.py:2968`). |
+| the key store | `set_key`/`unset_key` (`core/keys.py:205`, `:217`) | load → mutate → full rewrite (`core/keys.py:212`). Concurrent `keys set` loses one key. Also non-atomic — see BE-6. |
+| any backlog table | `Backlog.load` … `save` (`exploration/backlog.py:225`, `:240`) | the CLI loads, mutates, saves across a whole command. |
+
+There is also a scratch-file collision: `_land_bytes` writes every download to a
+per-citekey path (`literature/acquire.py:1456`):
+```python
+    dest = ctx.cache_dir / "incoming" / f"{_safe_name(entry.citekey)}.part"
+```
+Two `literature fetch` runs on the same citekey — a rerun after a hang, say — write the
+same `.part` concurrently, and whichever finishes second gets hashed.
+
+Finally, `append_log_entry`'s `while target.exists(): … write_text`
+(`defend/record.py:345`) is a check-then-write race **on the append-only audit log**;
+see BE-3 for the `open("x")` fix.
+
+Nothing documents a single-writer constraint, and no test runs two invocations against
+one repo.
+
+**Fix** — a small advisory lock around the four RMW writers is proportionate and needs
+no new dependency:
+
+```python
+# core/lockfile.py
+import fcntl
+from contextlib import contextmanager
+from pathlib import Path
+
+
+@contextmanager
+def exclusive(target: Path, *, timeout: float = 30.0):
+    """Hold an advisory lock on a sibling ``.lock`` while `target` is rewritten.
+
+    Only the read-modify-write files need this — `references.json`, `triage.yml`,
+    a backlog table, the key store — where a second process's rewrite would
+    discard the first's update. The content-addressed stores do not: their
+    destination is derived from the bytes, so a racing writer writes the same
+    thing.
+    """
+    lock = target.with_name(target.name + ".lock")
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    with lock.open("a+") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)   # add a timeout via signal or a poll loop
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+```
+
+`fcntl` is POSIX-only. If Windows support is intended (the classifiers say 3.11–3.14
+but name no OS), an `os.open(..., O_CREAT | O_EXCL)` sentinel with a stale-lock timeout
+is the portable alternative. Either way, the honest minimum is to **document the
+single-writer constraint** in `resources/ensure-tooling.md` and have the skills not
+parallelise these commands.
+
+---
+
+### DATA-7 — Full-file re-read and re-write per item
+
+`patch_asset` re-reads and re-parses the **entire** `references.json`, then re-serialises
+and rewrites all of it, for every single entry:
+
+`defendable-science/defendable_science/literature/registry.py:456`
+```python
+    target = Path(path)
+    items = _read_items(target)          # full read + json.loads
+    index = _locate(items, citekey)      # linear scan
+    ...
+    tmp.write_text(json.dumps(items, indent=2, ensure_ascii=False) + "\n", …)
+    tmp.replace(target)
+```
+
+It is called once per bound entry from `_bind` (`literature/acquire.py:1621`), which
+`fetch_all` drives over the whole registry (`literature/acquire.py:2140`). So a
+`literature fetch --all` over an *n*-entry registry performs **n full parses and n full
+rewrites** of an *n*-entry file — O(n²) bytes. For 400 papers with a populated spine
+(~2 KB/entry, so ~800 KB) that is ~320 MB of I/O churn, and 400 opportunities for the
+race in DATA-6.
+
+`patch_triage` is the same shape (`literature/registry.py:766-814`) and additionally
+runs `_alias_groups` — a full `yaml.compose` plus a graph walk (`registry.py:651`) —
+on every call. `cli.py:2966` calls it once per recorded paper.
+
+**Fix** — a batch writer beside the single one, used by the sweep:
+
+```python
+def patch_assets(path: str | Path, assets: Mapping[str, Asset]) -> None:
+    """Replace many entries' spines in one read-modify-write.
+
+    `patch_asset` is right for a single human-driven acquisition; a sweep over an
+    n-entry registry calling it n times re-parses and rewrites the whole file n
+    times, which is O(n²) and gives a concurrent writer n chances to interleave.
+    """
+    target = Path(path)
+    items = _read_items(target)
+    by_id = {_opt_str(i.get("id")): n for n, i in enumerate(items) if isinstance(i, dict)}
+    for citekey, asset in assets.items():
+        index = by_id.get(citekey)
+        if index is None:
+            raise RegistryError(f"no entry {citekey!r} in the registry")
+        ...
+    write_atomic(target, json.dumps(items, indent=2, ensure_ascii=False) + "\n")
+```
+
+`fetch_all` accumulates `{citekey: asset}` and flushes once. That does change one
+property worth naming: today a sweep interrupted at entry 200 has 200 spines on disk;
+with a single flush it has none. Flush per batch of ~25 rather than once, so an
+interruption loses at most a batch and the bytes are still cached (`_bind`'s error path
+already says "the bytes are in the cache, so re-run", `literature/acquire.py:1631`).
+
+---
+
+### DATA-8 — Every lookup is a linear scan or a full tree walk
+
+There is no index of any kind. Nothing is memoised across a command.
+
+| Lookup | Implementation | Cost |
+|---|---|---|
+| citekey → entry | `Registry.get` — linear scan (`literature/registry.py:159`) | O(n); called per key inside `_select`'s loop (`literature/acquire.py:2071`) → **O(n²)** for `--all` |
+| citekey → item index | `_locate` — two linear scans (`literature/registry.py:420`, `:423`) | O(n) per `patch_asset` |
+| dataset id → entry | `_entry_or_exit` — linear scan (`cli.py:1631`) | O(n), once per command |
+| dataset id → entry | `emit` — a second, separate scan (`cli.py:1594`) | O(n) |
+| all staged documents | `staged_documents` — glob per document name (`check/checks.py:723`) | full tree walk, **×3 per `check`** (BE-8) |
+| extraction batch | `layout.digests_dir.glob("*.md")` + read + parse each (`cli.py:3026`) | full read of every digest, per `sample`/`render` |
+| backlog row → row | `Backlog.get` — linear scan (`exploration/backlog.py:249`) | O(n) |
+
+**Growth to a realistic consumer.** A three-year PhD portfolio is plausibly 8 papers ×
+4 hypotheses ≈ 100 staged documents, a 400-entry bibliography, and 200 digest
+artifacts. Then:
+
+- `defendable-science check` — 3 tree walks, ~300 file reads, ~300 YAML parses.
+- `literature fetch --all` — 400 `Registry.get` scans over 400 entries (160,000
+  comparisons, cheap) plus DATA-7's 400 full parses and rewrites (not cheap).
+- `digest extract sample --all` — reads and parses all 200 digests to determine
+  membership (`cli.py:3026`), then reads the drawn ones **again** (`cli.py:3073`).
+- `digest extract render` — the same 200 reads a third time (`cli.py:3411`).
+
+None of this is fatal; all of it is avoidable with per-run memoisation rather than a
+persistent index.
+
+**Fix — memoise within a run, do not build an index file.** A cache file is the wrong
+answer here: it would be a second source of truth for data whose whole point is that
+git is the source of truth, and a stale index in an integrity tool is worse than a slow
+scan.
+
+```python
+# literature/registry.py — on Registry
+    def __post_init__(self) -> None:
+        self._by_citekey = {e.citekey: e for e in self.entries}
+
+    def get(self, citekey: str) -> Entry | None:
+        """Return the entry with this citekey, or ``None``.
+
+        Indexed at load: `_select` calls this once per key over the whole
+        registry, so the linear scan it replaced was quadratic on a sweep.
+        """
+        return self._by_citekey.get(citekey)
+```
+
+plus `CachingProbe` for the `check`/`progress` walks (BE-8), and a single
+`read_cells` pass in `digest extract sample`/`render` whose result is threaded through
+rather than re-read.
+
+---
+
+### DATA-9 — The HTTP cache never expires and has no negative-caching policy
+
+`defendable-science/defendable_science/core/http.py:155`
+```python
+    def _cached(self, key: str) -> JsonValue | None:
+        if self.cache_dir is None:
+            return None
+        path = self.cache_dir / f"{key}.json"
+        if path.is_file():
+            try:
+                data: JsonValue = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                return None
+            return data
+        return None
+```
+
+Assessed against the template's categories:
+
+- **TTL / expiry: none.** No mtime check, no max-age, no `--refresh` flag on any
+  command. An OpenAlex record cached today is served unchanged in a year. The module
+  docstring frames this as intentional — "the provenance root — never silently
+  refreshed within a run" (`core/http.py:4`) — and *within a run* that is exactly
+  right. Across runs it is unbounded, and nothing says so to the user. There is no
+  documented way to invalidate one entry; the only lever is deleting the whole
+  `<cache_dir>/http` directory, which nothing tells you to do.
+- **Cache-key collisions: no.** `_cache_key` (`core/http.py:92`) is
+  `sha256(url + "?" + urlencode(sorted(params)))`. Sorted params make it canonical.
+  One real subtlety, correctly handled: `mailto` is added to `query` *before* the key is
+  computed (`core/http.py:202`, key at `:208`), so a polite-pool and an anonymous
+  request are different entries. Correct — they can return different bodies.
+  `get_text` is deliberately uncached (`core/http.py:223`).
+- **Error responses are never cached: correct.** `_store` is only reached after
+  `_fetch` returns (`core/http.py:212`), and every non-200 raises. So a 404 or a 429 is
+  never poisoned into the cache. This is the single most important property of the
+  three and it is right.
+- **Concurrency: safe.** Temp-then-rename at `core/http.py:176`, content-addressed key,
+  so a racing writer writes identical bytes. The one gap is the orphan `.tmp` on a
+  failed write (BE-2), which is benign here.
+- **Unbounded growth.** No size cap and no eviction. A literature sweep with
+  `neighbors` caches ~100 work records per anchor at 20–50 KB each.
+
+**Fix** — keep the within-run immutability and add the two missing levers:
+
+```python
+    #: How long a cached response stays authoritative. `None` means forever, which
+    #: is the current behaviour and is right for a provenance root *within* a run —
+    #: but a record cached a year ago is not evidence about the paper today, and
+    #: there is presently no way to say so.
+    max_age: float | None = None
+
+    def _cached(self, key: str) -> JsonValue | None:
+        ...
+        if self.max_age is not None and time.time() - path.stat().st_mtime > self.max_age:
+            return None
+```
+
+driven by `literature.cache_max_age` in `config.yml` (defaulting to `None`, so nothing
+changes for anyone who does not set it), plus a `defendable-science literature refresh
+[<identifier>]` that evicts one key or the group. Document the growth characteristic in
+`skills/literature/SKILL.md` beside the existing cache note.
+
+---
+
+### DATA-10 — Destructive overwrite of recorded evidence
+
+The audit trail is genuinely append-only in one place and not in the others.
+
+**Append-only, correctly:**
+- The accountability log — `append_log_entry` (`defend/record.py:320`) never reuses a
+  filename, suffixing `-2`, `-3` (`defend/record.py:344`). Written by both `defend
+  record` and `digest extract record`/`sample`, one trail
+  (`digest/artifact.py:549`, `:667`). The docstring calls it "append-only evidence"
+  (`defend/record.py:337`). Weakened only by the TOCTOU race in DATA-6 / BE-3.
+- `backlog drop` records a reason and never deletes a row (`cli.py:2351`, "file-drawer
+  discipline"). Exactly right.
+- Quarantine — nothing reaches the registry without an explicit human `confirm`
+  (`literature/acquire.py:1043`), and there is "deliberately no 'promote whatever is in
+  quarantine' convenience".
+- Refetch drift refuses rather than rebinding (`literature/acquire.py:1532`).
+
+**Destructively overwritten:**
+
+1. **`status.understanding`** — `set_field` (`core/frontmatter.py:166`) replaces the
+   value in place. A second `defend record` on the same artifact overwrites the first
+   verdict. The *log* keeps both, so the evidence survives; but the artifact — the thing
+   `progress` and `check` read — shows only the latest. A gap resolved and later
+   re-opened leaves no trace in the artifact.
+2. **`status.extraction`** — `_set_extraction_key` (`digest/artifact.py:554`) and
+   `write_extraction` (`digest/artifact.py:546`) replace the cells block wholesale. Re-extracting
+   a paper discards the previous cells. `write_extraction`'s `in_sample=False` reset is
+   deliberate and documented (`digest/artifact.py:511`, "the flag can never outlive the
+   cells it certified") — good — but the superseded cells themselves are simply gone.
+3. **`dashboard.md`** — rewritten wholesale by design (`cli.py:729`, "a pure
+   projection … a hand-edit is (correctly) discarded"). Correct, and not a finding.
+4. **`positioning.md`'s matrix** — `render_matrix` re-emits the table
+   (`cli.py:3507`). The command is careful about *deletion* ("Nothing is ever deleted",
+   `cli.py:3441`) but a changed cell overwrites the prior value with no record. Combined
+   with DATA-5 and the non-atomic write, this is the riskiest writer in the tool.
+
+**Is git the undo?** Partly, and the reliance is undocumented. It works for the four
+artifacts above, which are tracked. It does **not** cover the cache, the blob store or
+the key store, all gitignored — so `confirm_quarantined`'s
+`sidecar.unlink(missing_ok=True)` (`literature/acquire.py:1959`) permanently destroys
+the match record for a promoted candidate, and nothing else holds it. And it only works
+if the researcher commits between examinations, which nothing enforces and no skill
+requires.
+
+**Fix** — for the two evidentiary blocks, keep a bounded history in the artifact rather
+than a single value:
+
+```yaml
+status:
+  understanding:
+    status: gaps
+    unresolved: ["the identifiability argument"]
+    superseded:                      # newest first, capped at N
+      - {date: 2026-08-14, status: ok, unresolved: []}
+```
+
+`set_field` already refuses to destroy an annotation it cannot round-trip
+(`core/frontmatter.py:158`), which is the same instinct — this extends it from comments
+to prior values. Cheaper interim: have `defend record` refuse to overwrite a *resolved*
+understanding block with a different verdict unless `--supersede` is given, naming the
+log entry that recorded the first one.
+
+For the quarantine sidecar, move it to `<cache>/quarantine/<citekey>/confirmed/` rather
+than unlinking it.
+
+---
+
+### DATA-11 — Four silent-data-loss doors from duplicate keys
+
+Each of the four persisted formats loses data on a duplicate key, silently, in a
+different way:
+
+1. **`triage.yml` duplicate citekeys.** `yaml.safe_load` keeps the last
+   (`literature/registry.py:506`); `patch_triage` then rewrites from the parsed dict
+   (`registry.py:805`), so the earlier row and its PRISMA rationale vanish. This is the
+   one round-trip shape with **no guard**, in a module that otherwise refuses comments
+   (`registry.py:769`), non-mapping rows (`:778`) and every anchor shape (`:785`)
+   precisely to avoid this class of loss.
+2. **`references.json` duplicate `id`.** `_locate` returns the first
+   (`literature/registry.py:421`); `load_registry_text` appends both
+   (`registry.py:338`), so `Registry.get` and `_locate` can disagree about which entry
+   a citekey means.
+3. **Markdown table duplicate header columns.** `_checked_axes` catches this for the
+   concept matrix, with an excellent comment about why the whole header must be checked
+   and not just the axes (`digest/extraction.py:166-178`). `Backlog.loads`
+   (`exploration/backlog.py:195`) and `append_papers_registry`
+   (`exploration/backlog.py:522`) have **no** such check, and a row is a dict keyed by
+   header (`core/mdtable.py`), so `| id | id |` silently collapses two cells into one.
+4. **Duplicate `status:` blocks in frontmatter.** `set_field` patches the first
+   (`core/frontmatter.py:126`); `yaml.safe_load` reading the same file takes the last
+   (`digest/artifact.py:329`, `scaffold/status.py`). So a successful write changes
+   nothing a reader sees. `set_field` already guards against a *duplicate child key*
+   for exactly this reason — "a duplicate key silently shadows the value just written"
+   (`core/frontmatter.py:144`) — and not against a duplicate parent block.
+
+**Fix** — the check already written for the concept matrix, applied to the other three:
+
+```python
+# literature/registry.py — in triage_mapping, before returning
+    seen: set[str] = set()
+    dupes = sorted({str(k) for k in _duplicate_keys(text)})
+    if dupes:
+        raise RegistryError(
+            f"{target}: citekeys {dupes} appear more than once — YAML keeps only "
+            "the last, so a rewrite would delete the others' rationale. Merge "
+            "them by hand, then re-run."
+        )
+```
+(implemented over the composed node graph, the way `_alias_groups` already is at
+`registry.py:684`, so it sees what `safe_load` collapses); the same test in
+`Backlog.loads` and `append_papers_registry` against the header; and a
+duplicate-`status:` check in `split_frontmatter`.
+
+---
+
+## Low
+
+### DATA-12 — Manifest values are coerced, not validated
+
+`dataset/manifest.py:226`:
+```python
+        path = str(raw["path"])
+        sha256 = str(raw["sha256"])
+```
+and `_opt_str` (`manifest.py:185`) does `str(value)` on anything truthy. So:
+
+- `id: null` → the literal string `'None'` (verified);
+- `license: [a, b]` → `"['a', 'b']"` (verified), which then **passes**
+  `_validate_required`'s `if not entry.license` check at `manifest.py:366`;
+- `path: 12345` → `"12345"`.
+
+The checksum is the one field with a real format check (`SHA256_RE`, `manifest.py:24`,
+applied at `:386`). Everything else is stringified into something that looks valid.
+
+Fix: covered by DATA-2's Pydantic model with `ConfigDict(strict=True)` — a `path` given
+as a list is refused, not stringified. This is the clearest single case for the
+sanctioned Pydantic scope: the manifest is the fixity spine, and the current parser's
+tolerance is not a feature.
+
+---
+
+### DATA-13 — Frontmatter round-trip is not byte-preserving on CRLF
+
+`core/frontmatter.py`'s contract is that it changes one key and leaves "every other byte
+alone" (`core/frontmatter.py:4`). `split_frontmatter` uses `text.splitlines()`
+(`core/frontmatter.py:32`), which consumes `\r\n`, and `rebuild` rejoins with `"\n"`
+(`core/frontmatter.py:48`):
+
+```python
+    parts = ["---", *fm_lines, "---", *body_lines]
+    return "\n".join(parts) + "\n"
+```
+
+So `defend record` on a CRLF artifact — a Windows collaborator, or a repo without
+`core.autocrlf` — rewrites the entire file to LF. The diff shows every line changed, and
+the one-key edit becomes unreviewable. The same applies to `core/mdtable.splice`.
+
+Fix: detect the dominant terminator in `split_frontmatter` and thread it through
+`rebuild`, or document that artifacts are LF-only and add a `.gitattributes` line to the
+`init` scaffold (`scaffold/render.py`), which is the cheaper and probably better answer.
+
+---
+
+## Positive patterns to preserve
+
+1. **Content-addressed storage with the checksum as the identity.** `blob_path`
+   (`core/fixity.py`), `sha256:`-prefixed refs, `_store_blob`'s unconditional overwrite
+   because "the destination is derived from the bytes, so anything already there is the
+   same bytes" (`literature/acquire.py:1089`). This makes the cache and the mirror
+   idempotent and concurrency-safe for free, and it is why DATA-6 is bounded to four
+   files rather than everything.
+
+2. **Verify-at-every-hop.** `_resolve_file` (`dataset/retrieval.py:68`) checks the
+   SHA-256 after the cache read, after the mirror pull, and after the Tier-B fetch, and
+   treats a mismatch as *absent* so the chain continues. `_resolve_recorded`
+   (`literature/acquire.py:1183`) goes further and **deletes** a blob that failed
+   verification, because "leaving a known-bad blob at the content-addressed path would
+   have every later run re-read the same bad bytes" (`acquire.py:1196`).
+
+3. **Surgical writers that refuse rather than round-trip.** `patch_asset` mutates one
+   namespaced object and preserves unknown top-level keys, unknown `custom` sub-keys and
+   key order (`literature/registry.py:433`) — so a Zotero namespace survives.
+   `patch_triage` refuses a file with comments, non-mapping rows, or any anchor
+   (`registry.py:769`, `:778`, `:785`) rather than silently reshaping a human's file.
+   The `_alias_groups` node-graph walk (`registry.py:651`) is the most careful piece of
+   parsing in the repository.
+
+4. **Namespaced extension of a standard format.** The substrate spine lives under
+   CSL-JSON's schema-designated `custom` field (`literature/registry.py:3`), so
+   `references.json` stays valid CSL-JSON and round-trips through Zotero and pandoc. The
+   file remains the researcher's, not the tool's.
+
+5. **`unknown` is a first-class value.** `AuditReport.mirror_present: dict[str, bool |
+   None]` (`dataset/retrieval.py:250`) — `None` means the mirror could not be reached,
+   distinct from `False`. `Milestones(unknown=True)` (`progress/collect.py:422`) — the
+   gate list is unknown, never an empty one. `VerifyReport.ok` returns `False` for an
+   entry with nothing recorded, because "`verify --all` on a fresh registry must say
+   'nothing is verified', not 'everything checks out'" (`literature/acquire.py:2198`).
+
+6. **The layout is resolved from one module and confined to the repo.**
+   `scaffold/layout.py` derives every path, `_relative` refuses a `layout:` value that
+   escapes the work tree (`layout.py:241`), and `recorded_layout` (`layout.py:336`) is a
+   true inverse of the resolver so a written block round-trips. `layout_from_overrides`
+   (`layout.py:315`) deliberately routes `init`'s CLI options through the *same*
+   validation as a config block "rather than a second copy of the rule that could drift
+   from it". DATA-3 is a gap in the per-artifact derivation, not in this.
+
+7. **Determinism where it is load-bearing.** The dashboard has no timestamp in the file
+   and a total sort order (`cli.py:733`) specifically so `check`'s stale-dashboard
+   comparison is meaningful, and both sides of that comparison come from `progress`
+   (`check/checks.py:1707`). `select_sample` is stable across processes and is tested
+   with two interpreters at different `PYTHONHASHSEED`
+   (`tests/test_sampling.py:79`) — so nobody can re-roll a sample until an easy one
+   comes up.
+
+---
+
+*Cross-references: the write-site inventory and the `write_atomic` helper are BE-2, the
+traversal reproduction is BE-1, and the repeated-parse costs are BE-8, all in
+[`be-tech-debt.md`](be-tech-debt.md). The JSON-shape half of DATA-2 is API-1 in
+[`api-tech-debt.md`](api-tech-debt.md). Test-side gaps are in
+[`coverage.md`](coverage.md).*

--- a/.codebase_audit/executive-summary.md
+++ b/.codebase_audit/executive-summary.md
@@ -372,6 +372,12 @@ which is precisely what an ADR set exists to make possible.
 | [`coverage.md`](coverage.md) | The measured result, then coverage *quality*: weak/strong per module, all six pragmas, the live suite, fixture realism, edge cases, and a mutation spot-check |
 | [`plugin-tech-debt.md`](plugin-tech-debt.md) | The markdown deliverable — 11 findings: the bootstrap, domain-neutrality, ADR hygiene, doc staleness, packaging, skill structure |
 
+Plus [`AUDIT-PROMPT.md`](AUDIT-PROMPT.md) — the spec that produced these reports,
+kept so the audit can be **re-run after fixes** and the results compared. It
+carries the stack remapping, the calibration rules, the known-good sites not to
+churn, the sanctioned decisions, and a re-run mode that classifies every prior
+finding as fixed / persisting / new.
+
 ---
 
 ## Closing assessment

--- a/.codebase_audit/executive-summary.md
+++ b/.codebase_audit/executive-summary.md
@@ -1,0 +1,395 @@
+# Executive summary — `defendable-science` codebase audit
+
+Audited 2026-08-29 against `0489114` on `literature/patch-triage-tmp-cleanup`.
+Documentation-only: no source file was modified. Every finding carries a verified
+`file:line`; the notable ones were reproduced.
+
+**Headline rating: 6.5 / 10** — genuinely strong engineering discipline in the
+places most projects neglect, with the debt concentrated in one area that matters
+disproportionately here: the CLI/JSON contract the plugin's skills depend on.
+
+---
+
+## Quality rating
+
+| Factor | Weight | Score | Justification |
+|---|---:|---:|---|
+| Architecture & plugin↔package boundary | 11 % | **8** | ADR-0026 is respected *in the automation*, not just the comments — `tools/bump_version.py:28` touches only the package's pyproject and no workflow references `plugin.json`. `scaffold/layout.py` is a real single definition; Protocol seams throughout; **no circular imports** and **zero functions over McCabe 10** across 17,081 LOC. Deductions: `cli.py` at 3,537 lines mixing four responsibilities (BE-15), `DEFAULT_LOG_DIR` duplicated outside `layout.py` (BE-12). |
+| Test-suite quality | 12 % | **7** | A hand-built mutation check killed **7/7 non-equivalent mutants** on `core/fixity.py`; `FakeProbe` is conformance-pinned against the real `FsProbe` (`tests/test_check.py:251`); sample determinism is tested across two interpreters (`tests/test_sampling.py:79`). Deductions: **zero property-based testing** on six hand-rolled parsers of untrusted input — and two verified bugs live exactly there; no concurrency tests; `graph.py` has only hand-written idealised fixtures. ([`coverage.md`](coverage.md)) |
+| Code duplication | 6 % | **6** | Source duplication is low and usually *acknowledged* (`cli.py:357` names the rule it duplicates). Test duplication is not: `_write` defined 6×, `_unstyled` 3×, 15 separate `CliRunner()`s, ~40 duplicated helpers against a 34-line `conftest.py`. One skill duplicate has already drifted (PL-8). |
+| CLI & JSON-contract design | 13 % | **5** | The weakest area, and the one with the widest blast radius: **38 commands, 7 incompatible output shapes** (API-1); four commands change shape based on a flag (API-4); the exit-code taxonomy is documented on one command and applied on that one only (API-5); no version field and no stated change policy (API-9). Offset by genuinely good help-text machinery (`cli.py:120`) and the `digest extract` family, which is a model envelope. |
+| Artifact / data-model quality | 12 % | **6** | Strong substrate: a namespaced spine inside valid CSL-JSON (`registry.py:24`), content-addressed storage, `unknown` as a first-class value (`retrieval.py:250`). Deductions: **no schema version on any artifact**, the shape re-implemented in four places with only one of six pairings guarded (DATA-2), no migration path (DATA-4), and a verified round-trip corruption in `render_table` (DATA-5). |
+| Failure honesty & degradation | 15 % | **7** | The *design* here is a 9 — three independent type-level distinctions between "we could not ask" and "the answer is no" (`mirror.py:43`, `download.py:71`, `http.py:52`), paying off in `_exhausted` (`acquire.py:1758`). The *application* has six verified holes at the JSON boundary, including one **silent wrong value** where a malformed S2 field is recorded as a single character (BE-4 site 3), plus a bootstrap that silently keeps a stale CLI (PL-2). Highest weight because it is this repo's own stated core principle and the axis on which research integrity turns. |
+| Dependency management & supply chain | 7 % | **7** | Exact-pinned dev/lint tools, a committed `uv.lock`, Dependabot (ADR-0036), OIDC Trusted Publishing (ADR-0027), a tag↔version guard (`publish.yml:34`), bandit + detect-secrets in pre-commit. Deductions: runtime deps are **floors only, no upper bounds** — `typer>=0.12` is a pre-1.0 library tested at 0.27.1; plus a global `ignore_missing_imports` and `warn_unused_ignores = false` (BE-16). |
+| Git / DevOps / release discipline | 9 % | **7** | 4-Python CI matrix with an alls-green gate, pinned action SHAs, a separate weekly live-validation cron, a docs pipeline that 404-checks the live site after publishing. Deductions: `bump-version.yml:74` prints release instructions that **publish nothing** (PL-6); no plugin↔package compat gate — which is exactly how PL-1 shipped; `CHANGELOG.md` missing two released versions. |
+| Bus factor & contributor scaling | 7 % | **4** | Effectively bus-factor 1. **8 of 99 merged PRs carry any review record**; the other 91 are self-merged. Three git identities for one person, no `.mailmap`. The ADR set is a real compensating control — but it documents decisions, it does not catch defects, and the four broken doc invocations (API-2) are what a second reviewer would have caught. |
+| Documentation & ADR discipline | 8 % | **7** | 41 ADRs, complete index, a `Status`/`Date`/`Deciders` line on every one, and real *rejected alternatives* sections. Docstrings are explanatory rather than decorative. Deductions: six material decisions with **no** ADR — all CLI-contract ones (PL-5d); a **dangling citation to an ADR that does not exist** (PL-5c); `STATUS.md` still advertises the former project name; `docs/design/proposals/tooling-package.md:17` contradicts ADR-0026 inside a doc marked `implemented`. |
+| **Weighted total** | **100 %** | **6.5** | |
+
+---
+
+## Team & contribution
+
+| Contributor | Commits (all branches) | First | Last | Tenure | Inferred role |
+|---|---:|---|---|---|---|
+| Davor Runje `<davor@synthpop.ai>` | 298 | 2026-07-17 | 2026-08-29 | 43 d | Author, maintainer, sole reviewer |
+| Davor Runje `<zlikowski@gmail.com>` | 64 | 2026-07-18 | 2026-08-26 | 39 d | **Same person**, second machine/identity |
+| Davor Runje `<davor.runje@fer.hr>` | 34 | 2026-08-27 | 2026-08-29 | 3 d | **Same person**, institutional identity |
+| `dependabot[bot]` | 7 | — | — | — | Automated dependency bumps (ADR-0036) |
+| `copilot-swe-agent[bot]` | 1 | — | — | — | One-off automated contribution |
+
+**Review process, measured.** 99 merged PRs; 92 authored by `davorrunje`, 7 by
+Dependabot. **Only 8 carry any review record at all.** 92 merge commits on `main`, with
+a consistent `Merge pull request #N from davorrunje/<topic>` shape and disciplined
+branch prefixes (`fix/`, `feat/`, `docs/`, `literature/`, `core/`, `design/`,
+`release/`). The mechanics are exemplary; the *second pair of eyes is absent*.
+
+What that implies, stated plainly: this is a single-maintainer repository with bot
+contributors and self-merged PRs. **The ADR set is the compensating control**, and it is
+an unusually good one — 41 records with drivers, options and rejected alternatives means
+a future maintainer can reconstruct *why*, which is the thing that normally dies with the
+author. But ADRs document decisions; they do not catch defects. The four documented CLI
+invocations that do not run (API-2), the compat pin naming an unreleased version (PL-1),
+and the `bump-version` instructions that publish nothing (PL-6) are all things a reviewer
+would plausibly have caught, and all three are user-facing. The structural answer is not
+"find a reviewer" — it is **to convert the review that is missing into tests**, which is
+why API-3 and API-6 are the top two recommendations below.
+
+**Three git identities for one person** is a concrete hygiene issue: `git shortlog -sn`
+reports three contributors, `git log --author` misses two-thirds of the history, and any
+future contribution-graph or CITATION tooling will double-count. There is no `.mailmap`.
+One file fixes it permanently:
+
+```
+# .mailmap
+Davor Runje <davor@synthpop.ai> <zlikowski@gmail.com>
+Davor Runje <davor@synthpop.ai> <davor.runje@fer.hr>
+```
+
+---
+
+## Project metrics
+
+| Metric | Value |
+|---|---|
+| Source | **17,081 LOC** across **41** `.py` files |
+| Tests | **21,833 LOC** across **36** files |
+| Test : source ratio | **1.28 : 1** |
+| Coverage | **100.00 %** statement **and** branch (`fail_under = 100`, `--cov-branch`) |
+| Test run | **1562 passed, 14 skipped** in 16.4 s |
+| mypy | clean, 79 files, `strict = true` |
+| ruff | clean; **0** functions over McCabe 10 |
+| bandit | 2 Low (both correct uses of `random`) |
+| Largest modules | `cli.py` 3,537 · `literature/acquire.py` 2,350 · `check/checks.py` 2,136 |
+| Largest suites | `test_acquire.py` 2,933 · `test_check.py` 2,528 · `test_digest_cli.py` 1,338 |
+| Commits on `main` | **374** |
+| Commits, all branches | **404** |
+| Merge commits on `main` | **92** |
+| PRs (all states / merged) | **101 / 99** |
+| Merged PRs with any review | **8 of 99** |
+| Open issues | **11** |
+| Skills | **11**, **2,955** markdown lines |
+| ADRs | **41** (+ index) |
+| `# pragma: no cover` | **6** |
+| Project age | 2026-07-17 → 2026-08-29 (**43 days**) |
+| Avg commits/week (main) | **≈ 61** |
+
+*Corrections to the baseline I was given: source is 17,081/41 not 15,930/29 (the earlier
+count omits `__init__.py` files and predates recent growth); tests 21,833/36 not
+20,285/29; `check/checks.py` is 2,136 not 1,511; merge commits 92 not 94; PRs 101 not 99;
+skills 2,955 lines not 2,881.*
+
+---
+
+## What works
+
+1. **Failure honesty is implemented as types, not as a convention.** The distinction
+   between "we could not ask" and "the answer is no" is a real, tested type distinction
+   in three independent layers: `MirrorUnreachableError` vs. a `False` return keyed on
+   rclone's exit code (`core/mirror.py:40`, `:160`); `DownloadError.hard_miss` keyed on
+   404/410 (`core/download.py:71`); `RateLimitError` as a distinct subclass so a throttle
+   can never be recorded as a miss (`core/http.py:52`). It pays off in `_exhausted`
+   (`literature/acquire.py:1758`), which buckets an exhausted ladder as `manual` **only**
+   when nothing was blocked, and in `AuditReport.mirror_present: dict[str, bool | None]`
+   (`dataset/retrieval.py:250`), where `None` genuinely means unknown. Almost nothing at
+   this scale gets this right.
+
+2. **The ADR set.** 41 records, complete index (`decisions/README.md:15`), a
+   `Status`/`Date`/`Deciders` line on every one, and genuine rejected-alternatives
+   sections — `0026:51` on why locked versions were rejected, `0038:74` on why
+   PDF-text verification was rejected as disproportionate. For a single-maintainer repo
+   this is the difference between a codebase that can be inherited and one that cannot.
+
+3. **Explicit, narrow injection seams.** `Probe` (`check/probe.py:13`), `Session` /
+   `Response` (`core/http.py:61`), `StreamSession` (`core/download.py:118`), `Runner`
+   (`core/mirror.py:83`), `GitRunner` (`core/keys.py:355`), `SearchClient` /
+   `MirrorClient` (`literature/acquire.py:53`), `TierBFetcher`
+   (`dataset/retrieval.py:44`). All structural Protocols. CLAUDE.md's claim that the
+   kernels are injectable holds, and `tests/test_check.py:251` *pins the fake against the
+   real one* — converting "we tested a fake" from an assumption into a checked claim.
+
+4. **Refusal over silent repair, everywhere.** `patch_triage` refuses a sidecar carrying
+   comments, non-mapping rows, or any YAML anchor (`literature/registry.py:769`, `:778`,
+   `:785`) rather than reshaping a human's file — with `_alias_groups`
+   (`registry.py:651`) walking the *composed node graph* to avoid false-positiving on
+   interned scalars, which is the single best piece of reasoning in the repository.
+   `set_field` refuses to overwrite a comment it cannot round-trip
+   (`core/frontmatter.py:158`). Refetch drift refuses rather than rebinding
+   (`acquire.py:1532`).
+
+5. **Every error message carries a remedy.** Not one bare "invalid input" in the package.
+   `Finding.remedy` is a *required* field of the model (`check/model.py:36`), and the
+   free-text errors follow the same discipline (`frontmatter.py:158`,
+   `registry.py:770`, `acquire.py:1258`, `core/config.py:52`).
+
+6. **The agency principle is enforced in code, not just described.** Gaps cannot be waved
+   through without a named human (`defend/record.py:285`); an unsigned refutation blocks
+   nothing (`progress/collect.py:350`); `digest extract record` writes two factual
+   scalars and *never* `disposition`, because "a machine advancing it would be exactly
+   the agency violation this tool exists to prevent" (`cli.py:2961`); scaffolds seed
+   structure but never prose (`exploration/backlog.py:580`).
+
+---
+
+## Critical gaps
+
+### 1. The skill↔CLI contract is unenforced, and four invocations are broken today
+*(High — [`api-tech-debt.md`](api-tech-debt.md) API-2, API-3)*
+
+| Location | Break | Effect |
+|---|---|---|
+| `docs/USER-GUIDE.md:182` | `--EIG` (the flag is `--eig`, `cli.py:2119`) | `No such option`, exit 2 |
+| `docs/guides/dataset.md:32` | `dataset verify` with no required positional | `Missing argument`, exit 2 — in the block that *defines* the guide's "shell blocks are verbatim" convention |
+| `docs/guides/dataset.md:139` | same, and the prose asks for a whole-manifest sweep (`dataset audit`) | wrong command *and* broken |
+| `skills/hypothesis-exploration/SKILL.md:56` | documents the column `one-line hypothesis`; the CLI requires `one-line` (`exploration/backlog.py:303`) | a table built to spec is **permanently unwritable** |
+
+`tests/test_plugin_content.py` is the only test that opens a `SKILL.md`; it asserts one
+hard-coded string and **deliberately skips fenced code blocks** (`:70`) — where every
+invocation lives. One parametrised test closes the whole class.
+
+### 2. The shipped bootstrap names a package version that does not exist
+*(High — [`plugin-tech-debt.md`](plugin-tech-debt.md) PL-1, PL-2)*
+
+- `resources/ensure-tooling.md:26` pins `defendable-science>=0.3.0,<0.4.0`.
+- `defendable-science/pyproject.toml:7` is `0.2.2`; newest tag `v0.2.2`. **0.3.0 was never released.**
+- The pin is **never passed to any install command** — `:28`, `:30`, `:32` are all bare.
+- There is **no upgrade path**: a mismatch falls through to a bare `uv tool install`, a
+  no-op against an existing older install. ADR-0026:35 promises "installs/**upgrades**".
+  A stale CLI is kept silently — a failure-honesty violation in the one file whose job
+  is honest bootstrapping.
+
+### 3. Six unvalidated JSON boundaries — four tracebacks and one *silently wrong value*
+*(High — [`be-tech-debt.md`](be-tech-debt.md) BE-4; tracked in #169)*
+
+All six reproduced. The worst is not a crash:
+
+```python
+_aggregate_s2_edges([{"contexts": "the whole sentence", "intents": "background"}], out)
+# out["context_snippet"] == 't'      # literature/graph.py:349
+# out["intent"]          == 'b'      # literature/graph.py:351
+```
+
+If Semantic Scholar returns a bare string where the docs promise a list, the tool records
+the letter `t` as the sentence in which a paper was cited, emits it as a legitimate value
+with no `degraded` marker, and a researcher may quote it in a related-work section.
+Four of the six are in `literature/graph.py`; the *same* upstream record is parsed
+correctly by `acquire.py:549`, so the rule exists and was applied to one of two readers.
+Also reproduced: `dataset ingest` on a JSON array → raw `AttributeError` traceback
+(`cli.py:1549`).
+
+### 4. Writes are non-atomic, and the claim lands before the evidence
+*(High — [`be-tech-debt.md`](be-tech-debt.md) BE-2/BE-3, [`data-tech-debt.md`](data-tech-debt.md) DATA-1)*
+
+**3 of 18 write sites** use the temp-then-rename idiom that commit `0489114` just
+hardened. The 15 that do not include `defend record`'s artifact patch, the accountability
+log, the digest artifact, the key store, every backlog table, and `positioning.md`'s full
+rewrite (`cli.py:3509`) — whose docstring promises "**Nothing is ever deleted**".
+
+Worse than the atomicity is the **ordering**. `defend/record.py:288` patches the
+artifact's `status.understanding` and *then* writes the accountability-log entry. If the
+log write fails, the artifact claims verified understanding **with no evidence behind
+it** — and `progress` and `check` read the frontmatter, not the log. For a tool whose
+entire purpose is defensible claims, this is the single worst on-disk state it can
+produce. Same shape at `digest/artifact.py:548`.
+
+### 5. Externally-derived identifiers reach the filesystem unchecked
+*(High — [`be-tech-debt.md`](be-tech-debt.md) BE-1)*
+
+**Reproduced**: a `--cells` entry whose citekey is `../../../../../../tmp/dsaudit/PWNED`
+caused `digest extract record` to write `/tmp/tmp/dsaudit/PWNED.md` **outside the work
+tree**, creating intermediate directories on the way. `Layout.digest`
+(`scaffold/layout.py:144`), `paper_dir` (`:179`), `backlog` (`:183`), `positioning`
+(`:195`) and `append_log_entry` (`defend/record.py:343`) all interpolate an untrusted
+identifier with no validation — while the same repository enforces exactly this rule in
+three other places (`acquire.py:1019`, `layout.py:241`, `cli.py:359`). It is an
+inconsistency, not an oversight.
+
+### 6. No artifact schema version, and no migration path
+*(High — [`data-tech-debt.md`](data-tech-debt.md) DATA-2, DATA-4)*
+
+No `schema-version` on any artifact. The registry spine has one (`registry.py:26`,
+"so a future migration need not guess") and nothing reads it. There is no `migrate`
+command, and `init` explicitly never overwrites (`cli.py:516`) so it cannot become one.
+When a field's *semantics* change, `check` reports nothing at all — the old value is read
+as if it meant the new thing. **This has already happened once**: `CHANGELOG.md`'s
+`[Unreleased]` records that a sign-off rule changed and "`check` grew the matching rule,
+which its `verdict: n/a` exemption had been hiding", with no note about existing
+artifacts. Compounding it, each artifact's shape is defined in four places — writer,
+template, reader, validator — and only **one of the six pairings** is guarded by a test
+(`tests/test_status.py:121`).
+
+---
+
+## Risk assessment
+
+Weighted by impact on **research integrity**. A silent wrong answer is categorically
+worse than a crash: a crash is re-run, a wrong citation context ends up in a manuscript.
+
+| Risk | Severity | Likelihood | Blast radius |
+|---|---|---|---|
+| A recorded claim of verified understanding with no evidence behind it (gap 4) | **Critical** | Low | One artifact, permanently, invisibly — the exact failure the tool exists to prevent |
+| A malformed upstream field emitted as a plausible value (gap 3, BE-4 site 3) | **Critical** | Low–Med | Any `literature enrich --context` output; may reach a related-work section |
+| A skill fails mid-workflow on a documented invocation (gap 1) | High | **Certain** — 4 live | Every consumer following `USER-GUIDE` or `guides/dataset`; erodes trust in the tool |
+| Bootstrap resolves nothing on a fresh install (gap 2) | High | **Certain** | Every new consumer taking the documented PyPI path |
+| Silently stale CLI after a bootstrap (gap 2, PL-2) | High | Medium | Skills calling verbs the installed CLI lacks; symptom appears three steps later |
+| Artifact written outside the work tree (gap 5) | High | Low | Filesystem beyond the repo; data loss if it lands on an existing file |
+| Partial write corrupts `positioning.md` (gap 4, DATA-5) | High | Low | The author's taxonomy prose and PRISMA log, unrecoverable outside git |
+| `render_table` corrupts a table on round-trip (DATA-5) | High | Low | Any table with a pipe in a header; the next read fails |
+| Existing artifacts break or silently change meaning on upgrade (gap 6) | High | Medium | A researcher's whole thesis tree; no version to branch on |
+| Concurrent invocations lose a `triage.yml` row (DATA-6) | Medium | Low | PRISMA rationale, silently |
+| Contract drift with OpenAlex/S2 undetected by the hermetic suite | Medium | Medium | Bounded to ≤7 days by the weekly live job — but that job has **no failure notification**, and `acquire.py` has no live coverage at all |
+| `typer` major bump breaks an isolated install (no upper bound) | Medium | Low | Every fresh `uvx` install |
+| Bus factor 1 (§Team) | Medium | — | The whole project; mitigated by the ADR set |
+
+---
+
+## Recommendations
+
+### Immediate (week 1–2)
+
+1. **Fix the four broken invocations** and add the guard test — API-2, API-3. One-token
+   edits plus ~40 lines of parametrised test. Resolves gap 1.
+2. **Fix the compat pin**: release 0.3.0 or lower the floor to `>=0.2.2`, put the
+   constraint in all three install commands, define the mismatch action — PL-1, PL-2,
+   plus the `test_the_compat_pin_is_satisfiable` guard in API-6. Resolves gap 2.
+3. **Guard the six JSON boundaries** — BE-4. The `isinstance` checks already exist at
+   `acquire.py:549`; apply them in `graph.py`. Fix **site 3 first**: it is the only
+   silent-wrong-value in the set. Resolves gap 3.
+4. **Reorder `defend record` and `write_extraction`**: log entry first, artifact second —
+   BE-3, DATA-1. Twenty lines, and it removes the Critical-severity risk row.
+5. **Escape the header in `render_table`** (`core/mdtable.py:446`) — one call to a
+   function that already exists — plus a round-trip property test. DATA-5.
+6. **Add `.mailmap`** — three lines, permanent fix for the identity split.
+
+### Short-term (month 1)
+
+7. **Extract `write_atomic` to `core/` and route all 18 write sites through it** — BE-2.
+   Mechanical; no behavioural change on the success path. Completes gap 4.
+8. **Validate identifiers at the `Layout` boundary** — BE-1's `_safe_id`. Resolves gap 5.
+9. **Adopt Pydantic v2 at the parsing boundary** — BE-9, DATA-2, DATA-12, and #169. This
+   is now sanctioned (see the note below). One `_WorkIn` model closes BE-4 sites 1–4 at
+   once; a strict `_FileRefIn` closes the manifest coercion. Do **not** convert the
+   internal dataclasses, and do **not** convert `progress/collect.py:64`, whose tolerance
+   is deliberate and documented.
+10. **Add a `schema-version` field now**, while there is one version to declare — DATA-4.
+    It costs one line today and is unrecoverable later. Resolves the forward-compat half
+    of gap 6.
+11. **Fix `bump-version.yml:74`/`:95`** to use `gh release create` — PL-6 — and add
+    `CHANGELOG` entries for 0.2.1/0.2.2 plus the `CITATION.cff` bump.
+12. **Rewrite `STATUS.md`'s "Released" section** — it advertises the former project name
+    and a `uv tool install honest-scholar` that installs the wrong thing. PL-4.
+13. **Add failure notification to `live-validation.yml`** — the weekly job is the only
+    upstream-drift detector and a red run on a cron tab is easy to miss.
+
+### Medium-term (month 2–3)
+
+14. **Adopt the JSON envelope across the tree** — API-1, API-7, API-9. Breaking, so it
+    belongs with an `api_version: 1` field, an ADR recording the contract and its change
+    policy, and golden-output tests. This is the single largest quality lever in the
+    repository.
+15. **Unify the exit-code taxonomy** — API-5. `literature resolve`'s docstring already
+    specifies it correctly; apply it in `_http_guard`.
+16. **Write the six missing ADRs** — PL-5d. The JSON envelope and the `check` severity
+    model first: skills depend on both, and API-1 shows five conventions accreted in the
+    envelope's absence.
+17. **Consolidate `conftest.py`** — `coverage.md` §9. Moving `_unstyled`, `CliRunner`,
+    `_scaffolded` and `FakeProbe` removes ~40 duplicated definitions and the
+    `sys.path`-dependent cross-file import at `tests/test_progress.py:10`.
+18. **Add `hypothesis` for the six hand-rolled parsers** — `coverage.md` §8. A round-trip
+    property would have caught DATA-5 on the first run, and the `RecursionError` at
+    `registry.py:506` shortly after.
+19. **Batch the OpenAlex round-trips** — BE-7. `neighbors --kind both` currently issues
+    ~100 sequential requests where ~4 would do.
+20. **Resolve the concurrency question** — DATA-6. Either add the advisory lock or
+    document the single-writer constraint; discovering it as a lost `triage.yml` row is
+    the wrong way for a researcher to learn it.
+21. **Domain-neutrality pass** — PL-3, starting with `skills/digest/SKILL.md:257` and
+    `skills/hypothesis-testing/SKILL.md:70`, the two examples a new user hits first.
+
+---
+
+## A note on the Pydantic recommendations
+
+The repo owner has **lifted the blanket Pydantic prohibition for the external-input
+parsing boundary only** — API responses, Croissant, CSL-JSON, user YAML and config.
+Stdlib `dataclasses` remain the norm for internal value objects, and no recommendation
+here proposes changing that. The reconciliation of `CLAUDE.md:64` is **tracked in
+#169** and has not landed, so this audit reports the repository as it stands.
+
+Two things verified rather than assumed:
+
+- **The "no Rust-binary conflicts" rationale does not apply.** The CLI is installed
+  *isolated* from the consumer's environment — `resources/ensure-tooling.md:56`: "never
+  the consumer repo's project env. This is what lets `defendable-science` depend freely
+  on `typer` / `requests` / `pyyaml` / `pooch` without touching anyone's torch/jax
+  install."
+- **The "keep the wheel light" rationale is already breached by an existing dependency.**
+  `pyyaml` ships a compiled C extension (`_yaml`; `yaml.CSafeLoader` present) at **3.1 MB
+  installed — larger than `rich` at 2.7 MB**. And the four "exactly" runtime dependencies
+  resolve to fourteen packages via `typer → rich → markdown-it-py`, `pooch →
+  platformdirs`, and so on.
+
+The **finding** that stands regardless of the decision is a governance one, reported in
+[`plugin-tech-debt.md`](plugin-tech-debt.md) PL-5c: the prohibition is restated in
+**fourteen places** — `CLAUDE.md:64`, three ADRs, one design proposal (twice), three
+source docstrings, and five superpowers plans — and **no ADR ever established it**.
+`decisions/0031-config-driven-cache-dir.md:32` cites "(ADR rejecting it stands)", a
+**dangling reference to an ADR that does not exist**. A governing constraint that lives
+only in contributor guidance, is cited secondhand as a decision record, and has no
+context/drivers/rejected-alternatives write-up cannot be revisited on the evidence —
+which is precisely what an ADR set exists to make possible.
+
+---
+
+## The other six reports
+
+| File | Contents |
+|---|---|
+| [`project-brief.md`](project-brief.md) | The research-methodology domain, the actors and agency/access-control model, every core entity and state machine, the trigger→effect automation tables, and a domain glossary |
+| [`be-tech-debt.md`](be-tech-debt.md) | Package internals — 16 findings: traversal, atomicity, subprocess timeouts, key-store modes, N+1 HTTP, repeated parses, validation gaps, `cast()` misuse, type weaknesses |
+| [`api-tech-debt.md`](api-tech-debt.md) | The CLI + JSON contract — 12 findings: response shapes, skill drift, exit codes, pagination, versioning, error models |
+| [`data-tech-debt.md`](data-tech-debt.md) | The git-native artifact layer — 13 findings: transaction boundaries, schema authority, migration, indexes, cache policy, append-only evidence |
+| [`coverage.md`](coverage.md) | The measured result, then coverage *quality*: weak/strong per module, all six pragmas, the live suite, fixture realism, edge cases, and a mutation spot-check |
+| [`plugin-tech-debt.md`](plugin-tech-debt.md) | The markdown deliverable — 11 findings: the bootstrap, domain-neutrality, ADR hygiene, doc staleness, packaging, skill structure |
+
+---
+
+## Closing assessment
+
+This repository is **six weeks old** and already has a 100 %-branch coverage gate that is
+not theatre, a strict-mypy-clean 17 kLOC package, 41 ADRs with rejected alternatives, and
+a failure-honesty model I would hold up as a reference implementation. That is a genuinely
+unusual standard, and the audit should not be read as saying otherwise.
+
+The debt has one clear shape. **The package's internal discipline outran the discipline
+applied to its public surfaces.** Six months of careful reasoning went into whether an
+unreachable mirror is the same as an absent file — and none into whether every command
+answers "did this succeed?" the same way. Six invariants are enforced by tests inside
+`defendable_science/`, and zero across the boundary to the eleven markdown clients that
+consume it. That is why four documented invocations are broken, why the bootstrap names a
+version that does not exist, and why five JSON conventions accreted without anyone having
+to decide whether that was allowed.
+
+The fix is not more discipline. It is **pointing the existing discipline at the
+boundary**: the two tests in recommendations 1 and 2 would have caught the two
+certain-likelihood risks in the table above, and cost roughly an afternoon.

--- a/.codebase_audit/plugin-tech-debt.md
+++ b/.codebase_audit/plugin-tech-debt.md
@@ -1,0 +1,625 @@
+# The plugin — technical debt
+
+The plugin is the **primary deliverable** and is invisible to every tool in the package's
+CI: ruff, mypy, bandit and pytest never open it, and `tools/validate-plugin.sh` reads
+only two JSON manifests. 11 skills (2,955 markdown lines), 26 `resources/` files, a
+design record, 41 ADRs, and two `.claude-plugin/` manifests.
+
+**Headline.** The prose discipline is genuinely strong — the exploration→resolution
+firewall holds in all 11 skills, failure honesty is enforced explicitly and repeatedly,
+and all 41 ADRs are indexed with a `Status` line. Almost every finding below is **drift
+between the markdown and reality**, and one of them ships broken today.
+
+---
+
+## Priority index
+
+| # | Finding | Severity |
+|---|---|---|
+| PL-1 | The bootstrap pins a package version that has never been released | **High** |
+| PL-2 | The pin is never passed to any install command, and there is no upgrade path | **High** |
+| PL-3 | Domain-neutrality violations: the author's own research domain ships as the canonical example | **Medium** |
+| PL-4 | `STATUS.md` advertises the former project name and a two-release-old version | **Medium** |
+| PL-5 | ADR hygiene: a dangling reference to an ADR that does not exist, and six unrecorded material decisions | **Medium** |
+| PL-6 | `bump-version.yml` prints release instructions that publish nothing | **Medium** |
+| PL-7 | Design record contradicts shipped decisions and lists resolved open items | **Medium** |
+| PL-8 | Duplication across skills, with one copy already drifted | **Low** |
+| PL-9 | Skill structure is inconsistent in five specific ways | **Low** |
+| PL-10 | `CHANGELOG.md` is missing two released versions; `CITATION.cff` has drifted | **Low** |
+
+Skill↔CLI drift is reported from the CLI side in
+[`api-tech-debt.md`](api-tech-debt.md) API-2/API-3; the plugin-side view is PL-11 at the
+end.
+
+---
+
+## High
+
+### PL-1 — The bootstrap pins a package version that has never been released
+
+`resources/ensure-tooling.md:26` pins the install to:
+
+```
+`defendable-science>=0.3.0,<0.4.0` — the minimum package version this plugin
+release requires, up to the next incompatible boundary
+```
+
+But `defendable-science/pyproject.toml:7` reads `version = "0.2.2"`, the newest git tag
+is `v0.2.2` (`git tag --list` → `v0.0.0a0, v0.1.0, v0.2.0, v0.2.1, v0.2.1rc0,
+v0.2.1rc1, v0.2.2`), and `.claude-plugin/plugin.json:3` is `0.2.2`. **0.3.0 does not
+exist on PyPI.**
+
+The file knows. `resources/ensure-tooling.md:73` calls it "that same **unreleased**
+`0.3.0` line". `RELEASING.md:87` says to raise the floor when a skill starts calling a
+CLI capability an earlier release did not have — which is correct policy, and was
+followed ahead of the release rather than with it.
+
+The consequence is not theoretical: a consumer who installs the plugin today and lets a
+skill run the documented bootstrap gets a PyPI resolution failure on step 3. The
+git-subdirectory fallback (`resources/ensure-tooling.md:37`) would rescue it, but only
+if the agent reads past the failure to find it, and the fallback is framed as being for
+"an unreleased `<ref>`, or PyPI unreachable" rather than for this.
+
+**Nothing checks it.** Not `tools/validate-plugin.sh` (JSON manifests only), not the
+test suite, not any workflow. The pin is a string in a markdown file that no code reads.
+
+**Fix** — release 0.3.0, or lower the floor to `>=0.2.2,<0.3.0` until it lands; then add
+the guard. The test is in [`api-tech-debt.md`](api-tech-debt.md) API-6 and is ~15 lines.
+
+Related: the pin's own explanation enumerates
+`digest extract axes | record | sample | render`
+(`resources/ensure-tooling.md:72`) and omits `cells`, which
+`skills/defend/SKILL.md:134` and `skills/digest/SKILL.md:512` now depend on.
+
+---
+
+### PL-2 — The pin is never applied, and there is no upgrade path
+
+Two defects in the same file, both arguably worse than the version number.
+
+**The constraint never reaches a command.** Every literal install line is bare:
+
+`resources/ensure-tooling.md:28`
+```
+   - `uv tool install defendable-science` — installs Python + deps in an isolated tool
+     env; or run ad hoc with `uvx defendable-science …` (no persistent install).
+   - else `pipx install defendable-science`.
+   - else `python3 -m venv "$XDG_STATE_HOME/defendable-science/venv-<ref>"` (fallback:
+     `~/.local/state/defendable-science/…`) then that venv's `pip install defendable-science`.
+```
+
+The version constraint exists only in the surrounding prose at `:26`. An agent executing
+the procedure literally installs **whatever is latest**, which is precisely what the
+compat pin exists to prevent. Every one of those three lines should read
+`'defendable-science>=0.3.0,<0.4.0'`.
+
+**There is no upgrade path.** Step 1 says:
+
+`resources/ensure-tooling.md:16`
+```
+1. **Fast path.** If a recorded invocation exists (`.defendable-science/config.yml →
+   tooling.cli`) or `defendable-science` is on `PATH`, run `defendable-science --version`. If it matches
+   the pinned version → **done**.
+```
+
+The pin is a *range*, so "matches" has no defined rule. And there is no stated action on
+a mismatch — the procedure simply falls through to step 3's bare `uv tool install`,
+which is a **no-op** against an already-installed older version (`uv` needs
+`--force`, or `uv tool upgrade`). So a consumer with 0.2.0 installed runs the bootstrap,
+gets no error, and continues with a CLI that lacks the verbs the skill is about to call.
+
+ADR-0026 line 35 promises the bootstrap "installs/**upgrades**". `ensure-tooling.md`
+never upgrades. This is a **failure-honesty violation in the one document whose entire
+job is honest bootstrapping** — the stale CLI is kept silently, and the first symptom is
+an unrelated-looking "no such command" three steps later.
+
+**Fix** — define the comparison and the action:
+
+```markdown
+1. **Fast path.** Run `defendable-science --version`. If the version **satisfies the
+   pinned range** below → done. If it is **below the floor**, go to step 3 and install
+   with `--force` (`uv tool install --force`, `pipx install --force`,
+   `pip install --upgrade`) — a bare install is a no-op on an existing tool env and
+   would silently leave the old CLI in place. If it is **at or above the ceiling**,
+   stop and say so: this plugin release does not know that CLI's output contract, and
+   guessing is the one thing it must not do.
+```
+
+**Credit where due** — the other failure modes in this file are handled well and should
+not be touched: no network / no toolchain → "**Honest stop.** … Never fake tooling
+output" (`resources/ensure-tooling.md:50`); environment mutation requires consent and
+forbids a silent `curl … | sh` (`:45`); PyPI unreachable → the git-subdirectory fallback
+(`:37`); and isolation from the consumer's ML environment is stated and reasoned
+(`:56`).
+
+---
+
+## Medium
+
+### PL-3 — Domain-neutrality violations
+
+`CLAUDE.md:66` forbids ML-, monotonic-network- and consumer-repo-specific assumptions in
+plugin content. All of the following are in shipped `skills/` or `resources/`.
+
+**The author's own domain (monotonic networks) as the canonical example:**
+
+- `skills/digest/SKILL.md:257` — the worked extraction example is
+  `"citekey": "sill1997monotonic"`, `"value": "architectural — monotone by
+  construction"`, axis `"partial monotonicity"`, justification `"scoped to
+  fully-monotone inputs"`. A consumer in clinical research or economics reads their
+  tool's reference example as a monotonic-network survey.
+- `skills/progress/SKILL.md:83` — `id: 2026-07-17-monotone-depth`, duplicated verbatim
+  at `resources/templates/README.md:85`.
+- `skills/paper-exploration/SKILL.md:78` — "The construction that gave monotonicity in
+  domain A — does it transfer to domain B?"
+- `skills/literature/SKILL.md:82` — "anchor = the group's ICML'23 paper → … snippet
+  reads *'unlike [anchor], our method needs no lattice'*". Both `ICML` and `lattice` are
+  the author's exact context.
+- `skills/research-init/SKILL.md:170` and `:227` — "a monotonic-network repo is only one
+  example consumer" and "*(Example: in a monotonic-network repo, the foundational paper
+  is the anchor…)*". Self-aware hedging, but it still ships the domain as *the*
+  illustration.
+- `skills/paper-exploration/SKILL.md:185` — the guardrail itself reads "No
+  **monotonic-network** or ML assumptions live here", naming the author's domain inside
+  the rule forbidding it. Should read "no domain-specific assumptions".
+
+**ML jargon used as if universal:**
+
+- `skills/hypothesis-testing/SKILL.md:70` — the single worked strategy example is
+  "pruning to 50% sparsity doesn't hurt accuracy … pruned vs. dense test accuracy". A
+  clinical or economics user has no anchor for the shape of a strategy.
+- `skills/paper-synthesis/SKILL.md:103` ("on tabular benchmarks") and `:132` ("the two
+  in-distribution benchmarks tested, not out-of-distribution"), mirrored into
+  `resources/templates/paper/ledger.md:34` and `:57` — so the *template* a consumer
+  fills in carries it.
+- `resources/contracts/experiment-backend.md:66` and `:68` — "GPU fan-out", "a `doit` +
+  GPU-pool executor". Contract-level, so every consumer reads it.
+- `skills/dataset/SKILL.md:45` and `:60` — "a venue (e.g. NeurIPS D&B)" as the only
+  venue named.
+
+**Personal identifiers:** `skills/progress/SKILL.md:90` and
+`resources/templates/README.md:92` both ship `signed-off-by: "D. Runje"` as the example
+value. (No hardcoded filesystem paths or emails elsewhere in `skills/`/`resources/`;
+`marketplace.json`'s owner email is a legitimate manifest field.)
+
+**Maintainer convention leaking into consumer skills:**
+`skills/hypothesis-testing/SKILL.md:179` and `skills/paper-synthesis/SKILL.md:185` both
+instruct **"Follow-ups become issues, not TODOs — … captured as a self-contained GitHub
+issue"**. That is `CLAUDE.md`'s house standard for *this* repository; it assumes the
+consumer uses GitHub Issues, and it appears in only 2 of the 11 skills.
+
+**Fix** — a domain-neutrality pass replacing each example with a neutral one (the
+`digest` and `hypothesis-testing` examples are the two a new user hits first), plus a
+grep guard in the same test file as API-3:
+
+```python
+_LEAKED = re.compile(r"\b(monoton\w*|ICML|NeurIPS|lattice|GPU|sparsity|D\. Runje)\b", re.I)
+
+
+@pytest.mark.parametrize("doc", [*ROOT.glob("skills/*/SKILL.md"), *ROOT.glob("resources/**/*.md")])
+def test_plugin_content_is_domain_neutral(doc):
+    """CLAUDE.md forbids the author's own domain in shipped plugin content.
+
+    `test_plugin_content.py` guards one hard-coded path this way already; the
+    domain-neutrality rule is the other half of the same promise.
+    """
+```
+with an allow-list for the places that legitimately name a domain to disclaim it.
+
+---
+
+### PL-4 — `STATUS.md` advertises the former project name and a two-release-old version
+
+`README.md:42` sends readers to `STATUS.md` for "the current ledger". Its entire
+"Released" section is pre-rename:
+
+`STATUS.md:39`
+```markdown
+- **`v0.1.0` — first final** (2026-07-19). The plugin (10 skills) and the
+  `honest-scholar` CLI are published: the package is on **PyPI**
+  (`uv tool install honest-scholar`), the `v0.1.0` tag doubles as the plugin's
+  marketplace pin, and the docs are live at
+  [honest-scholar.science](https://honest-scholar.science/).
+```
+
+The project was renamed by ADR-0035; the current release is `v0.2.2`; the docs are at
+`defendable.science`. A reader following that `uv tool install honest-scholar` installs
+the wrong package or nothing.
+
+The same file contradicts itself on the skill count: `STATUS.md:15` says "**All 11
+skills**", `STATUS.md:39` says "(10 skills)".
+
+`STATUS.md:22` also under-reports the CLI — it lists `literature`, `dataset`,
+`defend record`, `backlog` and `doctor`, omitting `init`, `check`, `progress dashboard`,
+`keys` and the whole `digest` group, all of which ship.
+
+---
+
+### PL-5 — ADR hygiene
+
+**(a) The index is complete and the status discipline is real.** All 41 ADRs (0001–0041)
+are indexed in `decisions/README.md:15-55` with no gaps and no orphan files, and every
+ADR carries `- Status: accepted · Date: … · Deciders: …` on line 3. This is the
+strongest single artifact in the repository and is genuinely unusual.
+
+**(b) No ADR is superseded-in-fact but unmarked.** ADR-0035 renamed the project, and the
+old name survives only inside ADR-0035 itself and two `docs/superpowers/` design records
+— a correct historical record. `decisions/0019-public-plugin-visibility.md:1` already
+reads "named `defendable-science`". The one soft issue:
+`decisions/0001-separate-plugin-repo.md:1` still titles itself "not in-mononet",
+accurate as history but the only ADR title carrying a consumer repo name.
+
+**(c) A dangling reference to an ADR that does not exist.** `decisions/0031` cites a
+Pydantic-rejecting ADR as an authority:
+
+`decisions/0031-config-driven-cache-dir.md:31`
+```markdown
+- No new dependency (stdlib + the existing `pyyaml`-backed `load_config`); no
+  Pydantic (ADR rejecting it stands).
+```
+
+**There is no such ADR.** Grepping the full set returns no ADR whose subject is
+Pydantic, dependencies, or the light-wheel posture. The prohibition lives in exactly one
+place — `CLAUDE.md:64` — and is a *contributor-guidance* file that `CLAUDE.md:14`
+itself says "is **not** a shipped artifact". Three ADRs and two design proposals cite it
+secondhand as though it were a decision record:
+
+| Location | Text |
+|---|---|
+| `CLAUDE.md:64` | "**Pydantic is deliberately rejected** (keep the wheel light, no Rust-binary conflicts) — do not reintroduce it" |
+| `decisions/0031-config-driven-cache-dir.md:32` | "no Pydantic (**ADR rejecting it stands**)" ← the dangling reference |
+| `decisions/0029-api-key-handling.md:84` | "Implementation stays light-dep (stdlib JSON + a small loader); no Pydantic, no dotenv dependency." |
+| `decisions/0038-venue-resolvers-trusted-not-gated.md:76` | "a new dependency (the package deliberately stays light: `requests`, `pooch`, `pyyaml`, no Pydantic)" |
+| `docs/design/proposals/dataset-manifest-tooling.md:46` | "No new heavy deps (no `jsonschema`, no `pydantic`, no `datasets`); validation is hand-rolled" |
+| `docs/design/proposals/dataset-manifest-tooling.md:129` | "**Deps:** `pyyaml` + stdlib `json` only. No `jsonschema`, no `pydantic`" |
+| `defendable-science/defendable_science/check/model.py:18` | "Stdlib only — ``dataclasses``, not ``pydantic``." |
+| `defendable-science/defendable_science/progress/model.py:13` | "Stdlib only — ``dataclasses``, not ``pydantic``." |
+| `defendable-science/defendable_science/core/gitignore.py:20` | "CLAUDE.md's light-wheel constraint is about not adding new *runtime dependencies* (**that is why Pydantic was rejected**)" |
+
+Plus five `docs/superpowers/plans/*.md` restatements — `2026-07-27-digest-skill-plan.md:14`,
+`2026-07-28-defendable-science-rename.md:17`, `2026-08-27-literature-asset-acquisition.md:19`,
+`2026-08-27-scaffold-check-layout.md:18`, `2026-08-28-digest-extraction-mode.md:19`.
+
+**Fourteen restatements of a rule that no ADR ever established** — and CLAUDE.md's own
+convention (`CLAUDE.md:62`) is that
+"material design decisions → a MADR ADR". A dependency-posture rule cited by three ADRs
+is material by any reading.
+
+**This is the finding, and it is independent of whether the rule is right.** A governing
+constraint that lives only in contributor guidance, is cited secondhand as an ADR, and
+has no context/drivers/options/rejected-alternatives record, cannot be revisited on the
+evidence — which is exactly what an ADR set exists to make possible. The repo owner has
+now sanctioned Pydantic at the external-input parsing boundary; the reconciliation of
+`CLAUDE.md:64` and the eight in-repo restatements is **tracked in #169** and has not
+landed, so every citation above is reported as found on `main`.
+
+For the record, the two halves of the original rationale, verified against this repo:
+
+- *"No Rust-binary conflicts"* — **does not apply.** The CLI is installed **isolated**
+  from the consumer's environment: `resources/ensure-tooling.md:56` — "the install lives
+  in a `uv`/`pipx` tool env or a per-user state venv — never the consumer repo's project
+  env. This is what lets `defendable-science` depend freely on `typer` / `requests` /
+  `pyyaml` / `pooch` without touching anyone's torch/jax install." A `pydantic-core`
+  wheel in an isolated tool env cannot conflict with anything.
+- *"Keep the wheel light"* — **already breached by an existing dependency.** `pyyaml`
+  ships a compiled C extension (`_yaml`, confirmed: `yaml.CSafeLoader` is present and
+  `_yaml` resolves to a built module in this venv) at **3.1 MB installed** — larger than
+  `rich` at 2.7 MB. And `typer` 0.27 pulls `rich` → `markdown-it-py` → `mdurl` +
+  `pygments`, plus `shellingham` and `annotated-doc`; `pooch` pulls `platformdirs`,
+  `packaging` and `requests`. The four "exactly" runtime dependencies resolve to
+  fourteen packages. Pydantic v2 adds `pydantic-core` (~1.8 MB per platform wheel) and
+  `annotated-types`. The real tradeoff is **one more compiled wheel and a wider
+  build/platform matrix, against deleting six hand-rolled parsers of untrusted input
+  that currently produce four tracebacks and one silently wrong value** (BE-4). On this
+  evidence the tradeoff favours adopting it at the parsing boundary, which is what the
+  owner decided.
+
+**(d) The "every material decision gets an ADR" claim does not hold.** Six material,
+cross-cutting decisions with no ADR:
+
+| Decision | Where it lives | ADR |
+|---|---|---|
+| The JSON envelope + exit-code taxonomy | `cli.py:895` (the only written statement), `skills/digest/SKILL.md:207` | **none** — ADR-0024 mentions neither JSON nor exit codes |
+| The `check` severity model (`invalid`/`unreadable`/`gap`, exit keyed to severity not count) | `check/model.py:3`, skill-facing at `skills/research-init/SKILL.md:158` | **none** |
+| The atomic write-temp-then-rename idiom | `literature/registry.py:740`, `:817`, `core/http.py:173` | **none** — and it recently produced a bug (`0489114`) |
+| Proactive per-host rate limiting, and `RateLimitError` distinct from a 404 | `core/http.py:5`, `:53`, `:244` | **none** |
+| The `DocstringTyper` help-text convention | `cli.py:120`, guarded by `tests/test_cli_help.py` | **none** |
+| `--root` discovery vs. explicit root | `core/config.py:17`, `:61` | **partial** — ADR-0039 covers the `layout:` block but contains no `--root` reference |
+
+*Has an ADR, correctly:* the `max(3, 10%)` sampling rule
+(`decisions/0040-digest-extraction-mode.md:150`), including its "convention rather than
+a statistical guarantee" caveat.
+
+The pattern is clean: **methodology decisions get ADRs; CLI-contract decisions do not.**
+Every gap is package-side. The first two are the ones the skills actually depend on and
+would most reward writing up — the JSON envelope in particular, because
+[`api-tech-debt.md`](api-tech-debt.md) API-1 shows five incompatible conventions
+accreted in its absence, with nothing forcing a decision about whether changing an older
+one was allowed.
+
+---
+
+### PL-6 — `bump-version.yml` prints release instructions that publish nothing
+
+`.github/workflows/bump-version.yml:74` (in the PR body it opens) and `:95` (in the job
+summary) both tell the maintainer:
+
+```
+git tag v${version} && git push origin v${version}   # → publish.yml → PyPI
+```
+
+`publish.yml:10` triggers on `release: [published]` and `workflow_dispatch` — **not** on
+a tag push. `RELEASING.md:72` says so explicitly: *"Don't push a bare `v*` tag — the
+trigger is the **Release**, not the tag."*
+
+So the release automation's own output contradicts the release runbook, and following it
+silently publishes nothing — the failure is an absence, which is the hardest kind to
+notice.
+
+**Fix**: replace both strings with the `gh release create` invocation from
+`RELEASING.md:60`.
+
+---
+
+### PL-7 — Design record contradicts shipped decisions and lists resolved open items
+
+**`docs/design/00-meta-spec.md`** — the file `CLAUDE.md:18` says to read first:
+
+- `:455` — the plugin/consumer table says "**the 7 skills**". There are 11, and the tree
+  66 lines above at `:378` correctly lists all 11. Internally contradictory.
+- `:348` — open item "*whether the thesis defensibility gate is made blocking*".
+  **Resolved by ADR-0021** (non-blocking, per-gap sign-off), which
+  `docs/design/01-lifecycle.md:212` correctly marks resolved.
+- `:558` — open item "`.defendable-science/` vs existing conventions — confirm the config
+  directory name". Settled by ADR-0035 and shipped everywhere.
+- `:560` — open item "Thesis milestone schema … resolve in sub-spec 1".
+  `resources/templates/thesis/milestones.yml` ships, and is guarded by
+  `tests/test_render.py:147`.
+- `:498` — "four sub-specs (each date-prefixed under `docs/superpowers/specs/`)". They
+  live at `docs/design/01-04`.
+- `:432` — the paper tree omits `pitch.md` and `plan.md`, both present at
+  `skills/research-init/SKILL.md:106`.
+- `:371` — "Working name `defendable-science`". Not a working name since ADR-0035.
+
+**`docs/design/01-lifecycle.md`** — header `:5` correctly reads "Status: Implemented",
+but `## 10. Open items` (`:210-221`) lists three items that shipped: the design/plan
+delegation seam (ADR-0023 + `resources/contracts/engineering.md`), the Toulmin ledger
+format (`resources/templates/paper/ledger.md` + `skills/paper-synthesis/SKILL.md:90`),
+and the status-frontmatter schema (`skills/progress/SKILL.md:80`). Only the ADR-0021
+item is marked resolved. Sub-specs 02/03/04 are correctly headed.
+
+**`docs/design/proposals/`** — 7 of 9 correctly marked `Status: implemented`. Two
+problems, one of which is a direct contradiction:
+
+- `docs/design/proposals/tooling-package.md:17` and `:104` describe the package as "a
+  monorepo, **co-versioned** with the plugin". That is precisely what **ADR-0026
+  rejected** (`decisions/0026-independent-versioning-compat-pin.md:51`, "Locked versions
+  — forces no-op bumps"). The proposal predates the ADR by one day and was never
+  corrected — in a document headed `Status: implemented`. Since plugin and package are
+  *numerically identical* at `0.2.2` today, a reader has no external signal that the
+  proposal is wrong.
+- `docs/design/proposals/docs-site.md:3` — `Status: designed 2026-07-19`, but ADR-0030
+  is accepted, `.github/workflows/docs-publish.yml` exists, and the site is live.
+- Stale interim paragraphs survive inside implemented proposals:
+  `docs/design/proposals/defend-record-helper.md:8` still says "the skill … marks it
+  unimplemented. **Interim (until the module is implemented):**"; same at
+  `docs/design/proposals/exploration-backlog-helper.md:8`.
+
+The nine invocation-level staleness items in these same proposals are in
+[`api-tech-debt.md`](api-tech-debt.md) API-12.
+
+---
+
+## Low
+
+### PL-8 — Duplication across skills and `resources/`
+
+| Duplicated block | Locations | Drifted? |
+|---|---|---|
+| Status-frontmatter YAML (19 lines) | `skills/progress/SKILL.md:80-98` ⇄ `resources/templates/README.md:82-100` | **No — byte-identical.** But only one copy is guarded: `tests/test_status.py:179` pins the README copy. The skill copy is unguarded and will drift on the next schema change. |
+| Concept-matrix shape rules | `skills/literature/SKILL.md:120-139` ⇄ `skills/digest/SKILL.md:225-240` | **Yes.** `literature` lists 5 rules; `digest`'s refusal list at `:236` adds "a missing `\|---\|` separator", "ragged rows" and "an unnamed column". A matrix author reading only `literature` does not know all the refusals — and `_checked_axes` (`digest/extraction.py:132`) enforces the longer list. |
+| `check` reporting paragraph | `skills/research-init/SKILL.md:156-162` ⇄ `:254-260` | No — verbatim, within one file, 100 lines apart. |
+| `defend`↔`digest` cross-reference essay | `skills/defend/SKILL.md:161-182` ⇄ `skills/digest/SKILL.md:508-521` ⇄ ADR-0040 | Partially — three copies of one rationale. |
+| Commit-attribution ritual (7 lines) | all 11 skills (`hypothesis-exploration:190` … `digest:585`) | No — identical modulo the skill name, and each already links `resources/commit-attribution.md`. |
+| "Follow-ups become issues" guardrail | `hypothesis-testing:179` ⇄ `paper-synthesis:185` | No — identical, but in only 2 of 11 (and see PL-3). |
+
+**Should become `resources/` includes:** the status-frontmatter block (one canonical
+copy, with `tests/test_status.py`'s guard extended to it); the concept-matrix shape
+rules (two copies already disagree); and the `check` paragraph deduped within
+`research-init`.
+
+**Done well, and worth naming:** `ensure-tooling` is **never** inlined. All eight call
+sites are links — `hypothesis-exploration:69`, `paper-exploration:57`, `defend:75` and
+`:135`, `digest:193`, `literature:279`, `dataset:112` and `:165`, `research-init:52`.
+That is exactly right. **One gap:** `skills/progress/SKILL.md:46` tells the agent to run
+`defendable-science check` and `progress dashboard` but never references
+`ensure-tooling` — the only CLI-invoking skill without a bootstrap link. (`thesis`
+invokes no CLI, so its omission is correct.)
+
+---
+
+### PL-9 — Skill structure is inconsistent
+
+All 11 SKILL.md files use exactly `name` + `description` frontmatter, and every `name`
+matches its directory. That part is clean. Five inconsistencies:
+
+| Skill | H1 | Verb-surface section | Guardrails | Composition |
+|---|---|---|---|---|
+| hypothesis-exploration | ✗ | `## Verbs` :33 | :167 | :145 |
+| hypothesis-testing | ✓ :6 | `## Staged documents` :41 | :162 | :145 |
+| paper-exploration | ✗ | `## Verbs` :39 | :164 | :148 |
+| paper-synthesis | ✗ | `## Staged documents` :28 | :159 | :139 |
+| thesis | ✗ | `## Modes` :37 | :147 | :130 |
+| progress | ✗ | `## Verbs` :42 | :212 | **✗** |
+| defend | ✗ | `## Targets` :110 | **`## Hard constraints` :256** | **✗** |
+| digest | ✗ | `## Two modes…` :22 | :550 | :523 |
+| literature | ✗ | `## Modes` :39 | :252 | :234 |
+| dataset | ✓ :11 | `## Verbs` :50 | :193 | :178 |
+| research-init | ✓ :6 | `## Modes` :36 | :282 | :262 |
+
+1. **H1 in only 3 of 11**, and `skills/dataset/SKILL.md:11` is lowercase `# dataset`
+   while the other two are Title Case.
+2. **`defend` alone names its guardrail section `## Hard constraints`**
+   (`skills/defend/SKILL.md:256`) — same content, different heading, on the one section
+   a reader most needs to find by name.
+3. **`progress` and `defend` have no `## Composition`**, despite being the two most
+   cross-cutting skills.
+4. **The verb surface is named four ways** — `Verbs` ×4, `Modes` ×4, `Staged documents`
+   ×2, `Targets` ×1 — and only `skills/defend/SKILL.md:193` has an `## Invocation`
+   section; the other ten fold it into When-to-use.
+5. **The tooling callout alternates form**: a blockquote in
+   `hypothesis-exploration:67`, `paper-exploration:54`, `defend:74`, `dataset:110`; a
+   real `## Tooling` heading in `literature:275`.
+
+**On `digest` at 593 lines vs `thesis` at 177**: mostly justified — ~340 lines
+(`skills/digest/SKILL.md:186-521`) are extraction mode, four CLI verbs with a report and
+refusal taxonomy each. Two chunks are genuine bloat: `:225-240` re-specifies matrix
+rules `skills/literature/SKILL.md:120` already owns (PL-8), and `:161-182` is ADR
+reasoning duplicated from ADR-0040. `thesis` at 177 is correctly short — it is a partial
+mirror (`skills/thesis/SKILL.md:13`) with less machinery. The gap is a complexity gap,
+not a quality gap.
+
+**The firewall itself is not a finding — it holds.** Checked across all six named
+skills. `skills/hypothesis-exploration/SKILL.md` does rank (`:116`), the closest thing
+to adjudication, and fences it three times: "advisory inputs to the human's ordering,
+not an automatic gate" (`:118`), "recommends; it does not select the testing slate"
+(`:141`), "Ranking advises, never selects… Do not auto-promote the top row" (`:183`).
+`skills/paper-exploration/SKILL.md:41` puts a **Firewall column in the verb table**, with
+`promote` the only row marked "human disposes". `hypothesis-testing:36` and
+`paper-synthesis:24` each explicitly refuse the generate side. `progress` never scores —
+`skills/progress/SKILL.md:191` is an Anti-Goodhart section with an explicit
+do-not-compute list at `:203` and, at `:227`, "If a future request asks for a
+percentage… decline and point here — this is a design invariant, not a missing
+feature." `defend` never supplies the answer (`skills/defend/SKILL.md:59`; the
+`grill-me` inverted-epistemics contrast at `:263` is the sharpest statement of it in the
+repo).
+
+One **disclosed weakening** worth naming, which is not a violation: in `digest`
+extraction mode the agent authors the claim — it reads papers and writes matrix cells
+(`skills/digest/SKILL.md:245-340`) that `render` merges into the author's positioning
+document (`:413`), backed only by a `max(3, 10%)` human sample. The skill confronts this
+head-on rather than hiding it: `:32` "Extraction does **not** certify comprehension";
+`:342` "if the agent also checked the sample, extraction would certify **nothing**";
+`:371` the sample size "is a **convention, not a statistical guarantee**". That is the
+honest handling of an inherently weaker guarantee and is the best-written passage in the
+plugin.
+
+---
+
+### PL-10 — `CHANGELOG.md` is missing two released versions; `CITATION.cff` has drifted
+
+- `CHANGELOG.md` headings are `[Unreleased]` (`:12`), `[0.2.0]` (`:341`), `[0.1.1]`,
+  `[0.1.0]`. **`0.2.1` and `0.2.2` are missing entirely**, despite both tags existing and
+  `pyproject.toml:7` reading `0.2.2`. `publish.yml:34` guards tag↔version but not
+  tag↔changelog, which is how both shipped with no entry. The honest former-name note at
+  `CHANGELOG.md:8` is good practice and should stay.
+- `CITATION.cff:19` reads `version: 0.2.0` against a package at `0.2.2`. ADR-0026 lines
+  46-47 explicitly flag this as manual and required-at-release; it has drifted two
+  patches.
+- `README.md:133` — "To pin a fixed release, add `"ref": "v0.2.0"`". Latest tag is
+  `v0.2.2`.
+
+---
+
+### PL-11 — Skill↔CLI drift, from the plugin's side
+
+Four documented invocations do not run; full analysis and fixes in
+[`api-tech-debt.md`](api-tech-debt.md) API-2. From the plugin's perspective the
+important one is `skills/hypothesis-exploration/SKILL.md:56`, because it is the only
+break inside a `skills/` file and it instructs the author to hand-build a backlog table
+with a column name (`one-line hypothesis`) that `Backlog._require`
+(`exploration/backlog.py:303`) then permanently refuses.
+
+The reason none of this is caught: `tests/test_plugin_content.py` is the only test that
+opens a SKILL.md, it asserts one hard-coded string, and it **deliberately skips fenced
+code blocks** (`tests/test_plugin_content.py:70`) — which is where every invocation
+lives. `.pre-commit-config.yaml:69` scopes the plugin hook to
+`files: ^\.claude-plugin/.*\.json$`, so editing a skill triggers only whitespace and
+codespell.
+
+---
+
+## Packaging and the two-artifact rule — verified clean
+
+Plugin version `0.2.2` (`.claude-plugin/plugin.json:3`); package version `0.2.2`
+(`defendable-science/pyproject.toml:7`). Numerically identical, which is not itself a
+violation but means nothing would visibly break if they *were* being locked.
+
+**The automation respects ADR-0026, verified in the code and not just the comments.**
+`tools/bump_version.py:28` targets only `_ROOT / "defendable-science" / "pyproject.toml"`
+and `:133` writes only that file. No workflow or script touches `plugin.json` —
+confirmed by grep across `.github/`. The intent is documented three times
+(`tools/bump_version.py:15`, `.github/workflows/bump-version.yml:7`, `:69`). Clean.
+
+**Trigger → effect:**
+
+| Workflow | Trigger | Effect |
+|---|---|---|
+| `ci.yml` | push→main, every PR, merge_group | `pre-commit` (all hooks, `--hook-stage manual`); `test` matrix py3.11–3.14 → ruff + mypy + pytest with the 100 % gate, Codecov on 3.13 only; `plugin-validate`; `check` alls-green aggregator (`:77`) |
+| `bump-version.yml` | `workflow_dispatch` only | Runs `tools/bump_version.py`, edits **pyproject only**, opens a `release:` PR via `RELEASE_PAT` |
+| `publish.yml` | `release: published`; `workflow_dispatch` | Guard: release tag must equal pyproject version (`:34`, refuses otherwise); `uv build`; OIDC Trusted Publishing to TestPyPI or PyPI |
+| `docs-publish.yml` | `release: published`; `workflow_dispatch`; PR on paths incl. `skills/**`, `decisions/**`, `docs/**` | PR → strict build + `mint validate` + `mint broken-links`, no push. Release → build, validate, push to the docs repo, then poll the live site and 404-check every nav URL (`:203`) plus lychee internal links |
+| `live-validation.yml` | `workflow_dispatch`; **weekly cron Mon 06:00 UTC** | Installs rclone, runs `DEFENDABLE_SCIENCE_LIVE=1 pytest -m live --no-cov` against real OpenAlex/S2 |
+
+`publish.yml`'s tag↔version guard and `docs-publish.yml`'s live-404 sweep are both
+notably careful.
+
+**CI gaps.** `tools/validate-plugin.sh` runs unconditionally in CI (`ci.yml:68`) but is
+nearly a no-op there: `claude` is not installed in that job, so it always takes the
+structural fallback, which checks only that the two JSON files parse and carry a handful
+of keys. It never opens `skills/`. Nothing validates SKILL.md frontmatter — a malformed
+`name`, a name/directory mismatch, or a missing `description` passes every gate. The
+only real skill-content gate is `docs-publish.yml`'s PR job (`mint validate` +
+`mint broken-links`), whose path filter lists `resources/references/**` but **not**
+`resources/templates/`, `resources/rigor/`, `resources/contracts/` or
+`resources/ensure-tooling.md` — so a PR touching only the bootstrap file skips it
+entirely. And **nothing checks plugin↔package compatibility**, which is exactly how PL-1
+shipped.
+
+---
+
+## Positive patterns to preserve
+
+1. **The ADR set is the best artifact in the repository.** 41 ADRs, a complete index
+   (`decisions/README.md:15`), a `Status`/`Date`/`Deciders` line on every one, and real
+   *rejected alternatives* sections — `decisions/0026:51` explains why locked versions
+   were rejected, `decisions/0038:74` why PDF-text verification was rejected as
+   disproportionate. For a single-maintainer repo with no second reviewer this is the
+   compensating control, and it works.
+
+2. **The exploration→resolution firewall is maintained in prose, not just claimed.** See
+   PL-9. `skills/paper-exploration/SKILL.md:41`'s Firewall column and
+   `skills/progress/SKILL.md:227`'s "decline and point here — this is a design
+   invariant, not a missing feature" are the two mechanisms doing the most work.
+
+3. **Failure honesty is written into the skills, not only the code.**
+   `resources/ensure-tooling.md:50` ("Never fake tooling output"),
+   `skills/digest/SKILL.md:207` (parse defensively rather than assuming JSON on every
+   non-zero exit), `skills/digest/SKILL.md:32`/`:342`/`:371` (extraction certifies less
+   than comprehension, and says so three times).
+
+4. **`ensure-tooling` is linked, never inlined** — 8 of 8 call sites (PL-8). The one
+   piece of duplication that would matter most is the one that was avoided.
+
+5. **Consent and honest-stop are first-class in the bootstrap.**
+   `resources/ensure-tooling.md:45` forbids a silent `curl … | sh` and requires the
+   user's confirmation before mutating their environment. Rare, and correct.
+
+6. **Templates are guarded against renderer drift.** `tests/test_status.py:121`
+   parametrises over all nine shipped `resources/templates/**.md` and asserts each
+   status block byte-matches `scaffold/status.render()`; `:179` pins
+   `templates/README.md`'s field set and order; `:204` pins that no machine-read field
+   ships a placeholder; `tests/test_render.py:147` pins `milestones.yml`. This is the
+   pattern the skill copies (PL-8) and the CLI invocations (PL-11) still need.
+
+7. **The plugin/consumer boundary is stated and mostly held.**
+   `docs/design/00-meta-spec.md:455`'s table (skill-count error aside) draws the line
+   clearly, and `resources/ensure-tooling.md:56` explains the isolation property that
+   makes it work.
+
+---
+
+*Cross-references: [`api-tech-debt.md`](api-tech-debt.md) API-2/3/6/12 for the
+invocation and pin drift; [`coverage.md`](coverage.md) §10 for what
+`tools/validate-plugin.sh` does and does not check; [`be-tech-debt.md`](be-tech-debt.md)
+BE-4/BE-9 for the parsing debt the Pydantic decision addresses.*

--- a/.codebase_audit/project-brief.md
+++ b/.codebase_audit/project-brief.md
@@ -1,0 +1,495 @@
+# Project brief — the business domain
+
+Derived by reading the code, the skills and the ADRs, not by paraphrasing the README.
+Every claim carries a `file:line`.
+
+---
+
+## 1. What the product is
+
+`defendable-science` is a **research-workflow methodology for a PhD-scale research
+program**, shipped as a Claude Code plugin plus a supporting CLI. Its thesis is stated
+in one line in `.claude-plugin/plugin.json:4`:
+
+> "Assistants, not researchers: you drive, and you must be able to defend it."
+
+The domain problem it addresses is not productivity. It is **defensibility**: at a
+viva, a review, or a retraction inquiry, a researcher must be able to say what they
+claimed, on what evidence, why they believed it, and who signed off — for work that an
+AI assistant helped produce. Every mechanism in the repository is downstream of that.
+
+Two artifacts ship independently (`CLAUDE.md:7`, ADR-0026): the **plugin** (markdown
+skills, the primary deliverable) and the **`defendable-science` package** (a Typer CLI
+the skills shell out to, published to PyPI and installed isolated from the consumer's
+ML environment, `resources/ensure-tooling.md:56`).
+
+---
+
+## 2. The methodology: three nested levels, generate → resolve
+
+One object×action shape repeats at three scales (ADR-0005, ADR-0006). At each level a
+*generate* skill proposes and a *resolve* skill disposes.
+
+```
+  thesis            (optional top)              thesis
+     │                                             │
+     ├── paper       paper-exploration  ────→  paper-synthesis
+     │                    (generate)              (resolve)
+     │                                             │
+     └── hypothesis  hypothesis-exploration ──→ hypothesis-testing
+                          (generate)              (resolve)
+```
+
+Nesting is real containment, not analogy: a hypothesis lives inside a paper
+(`Layout.hypothesis_dir`, `scaffold/layout.py:199`), a paper inside the portfolio
+(`Layout.paper_dir`, `:179`), and a thesis is optional and skippable
+(`skills/thesis/SKILL.md:3`, "skip it entirely for a repo that is not a thesis").
+
+### The exploration→resolution firewall
+
+**No skill both proposes a claim and adjudicates it.** This is the load-bearing
+structural rule, and it is maintained in the prose rather than merely asserted.
+`skills/paper-exploration/SKILL.md:41` renders it as a **Firewall column in the verb
+table**, where `promote` is the only row marked "human disposes".
+`skills/hypothesis-exploration/SKILL.md` does rank — the closest thing to adjudication
+in a generate skill — and fences it three times: "advisory inputs to the human's
+ordering, not an automatic gate" (`:118`), "recommends; it does not select the testing
+slate" (`:141`), "Ranking advises, never selects… Do not auto-promote the top row"
+(`:183`). The resolve skills refuse the other direction
+(`skills/hypothesis-testing/SKILL.md:36`, `skills/paper-synthesis/SKILL.md:24`).
+
+The firewall is why the CLI has no command that both scores and selects: `backlog rank`
+writes scores and sets a row `ranked` (`cli.py:2124`, "advises; never selects"), and
+`backlog promote` is a separate, explicitly human act (`cli.py:2289`, "an explicit human
+pick").
+
+### The eleven skills, from their own text
+
+| Skill | Level / role | What it actually does |
+|---|---|---|
+| `hypothesis-exploration` | hypothesis · generate | Runs an origin-agnostic idea pipeline — a raw idea, a citation-seeded lead, a data pattern — into the paper's backlog, ranks advisorily, hands promoted items to `hypothesis-testing`. "Proposes only; never tests or adjudicates a claim." (`SKILL.md:3`) |
+| `hypothesis-testing` | hypothesis · resolve | Drives one promoted hypothesis through `hypothesis → strategy → design/plan → findings` to a **signed** verdict. Does the science (strategy, rigor, verdict); **delegates the engineering** to a bound backend. (`SKILL.md:3`) |
+| `paper-exploration` | paper · generate | Mines finished and in-flight work for candidate application and follow-up papers; grooms the portfolio backlog; wires a promoted paper into the registry. "Proposes candidate papers (never commits to writing one)." (`SKILL.md:3`) |
+| `paper-synthesis` | paper · resolve | Drives one paper through `pitch → positioning → outline/plan → decision → sections` to a human-signed publish/no-go, assembling claims from a **Toulmin-sextet ledger** whose entries cite experiment-backend run-refs. "Drafts proposals; the author authors and decides." (`SKILL.md:3`) |
+| `thesis` | thesis · both, optional | Frames the aims, chooses which portfolio papers compose the thesis, assembles the kappa framing chapter, and clears the **defensibility gate** (per-gap signed acknowledgement, ADR-0021). Refuses to "adjudicate paper quality" (`SKILL.md:33`). |
+| `progress` | cross-cutting · read-only | Reads `status:` frontmatter from every artifact and projects a dashboard: state, coverage, named blockers, uncovered aims. "Never a percentage or productivity score." (`SKILL.md:3`) |
+| `defend` | cross-cutting · guardrail | A Socratic **tutor-examiner**. Runs a probe → teach → re-probe loop before a material decision is recorded, "without grading the substance of novel claims" (`SKILL.md:3`). Verifies the author can articulate a claim; never supplies the answer. |
+| `digest` | cross-cutting · inbound | `defend`'s inbound counterpart: verified comprehension of an **external** paper (depth mode), plus **extraction mode** for survey-scale breadth reading that "certifies something deliberately weaker than comprehension" (`SKILL.md:3`). |
+| `literature` | shared capability | Mines and situates a literature over one citation-graph substrate (OpenAlex + Semantic Scholar): **scout** mode for leads, **position** mode for defending a committed claim against prior work. |
+| `dataset` | shared capability | A thin git-tracked registry, tiered storage, a private rclone mirror, SHA-256 fixity, Croissant interop. |
+| `research-init` | onboarding | Two modes: **init** (scaffold a fresh repo) and **adopt** (backfill an existing one that already has papers, data and results). |
+
+### What is deliberately *not* here
+
+**Engineering is delegated, not implemented** (ADR-0023,
+`resources/contracts/engineering.md`). The plugin never designs, plans or writes
+experiment code; it hands that to a bound backend across a contract. This is why
+`backlog promote --scaffold` at the paper level *requires* `--backend`
+(`cli.py:2167`): "the plugin ships no experiment backend, so a registry row with an
+empty binding is not a usable paper (ADR-0013)".
+
+---
+
+## 3. Actors and the agency / access-control model
+
+There is no authentication and no authorisation in the software sense. The access-control
+model is **who is permitted to decide what**, enforced by refusals in the code and the
+skill prose. Three actors:
+
+| Actor | May decide |
+|---|---|
+| **The human researcher** | Every material claim, every promotion, every verdict, every publish decision, every rights assertion. Named in `signed-off-by`. |
+| **The agent** | Proposals, mechanical transformations, projections, and factual observations. Never a decision. |
+| **The engineering backend** | Runs experiments and returns run-refs. Bound per paper; the plugin ships none. |
+
+### The agency principle
+
+ADR-0003 and `resources/references/agency-principle.md`. The human makes and signs every
+material decision. Enforced at these points:
+
+| Enforcement | Location |
+|---|---|
+| Gaps cannot be waved through without a named human | `defend/record.py:285` — `if outcome in ("overridden", "acknowledged-per-gap") and not signed_off_by: raise RecordError("passing surfaced gaps requires a named --signed-off-by")` |
+| A verdict with no `signed-off-by` is "not yet decided", not decided | `progress/model.py:47`; `check` raises a `gap` at `check/checks.py:1576` |
+| An unsigned refutation blocks nothing | `progress/collect.py:350` — a load-bearing refuted hypothesis is named as a blocker **only** `if … other.signed_off` |
+| Ranking advises, never selects | `cli.py:2124`; `skills/hypothesis-exploration/SKILL.md:183` |
+| Promotion is a separate, explicit act | `cli.py:2289` |
+| The machine never advances a triage disposition | `cli.py:2961` — `digest extract record` writes only `extracted` and `extraction-cells`, "never `disposition`, which is the human's decision, and a machine advancing it would be exactly the agency violation this tool exists to prevent" |
+| Scaffolds seed structure, never prose | `exploration/backlog.py:580` — "seeding prose the author did not write would cut against the agency principle" |
+| A dropped idea keeps its reason and is never deleted | `cli.py:2351` — "file-drawer discipline" |
+
+### The understanding principle
+
+ADR-0004. A decision may not be recorded until the human can articulate it. `defend` is
+the guardrail: it probes, teaches, re-probes, and then `defend record` writes both the
+frontmatter status and an evidentiary record (`defend/record.py:224`). It records
+**observed facts only** — `defend/record.py:9`: "there is no field for a 'correct
+answer', a score, or a pass/fail, and it never writes `verdict` / `decision` /
+`defensible`."
+
+### Trust tiers in literature acquisition
+
+`literature/acquire.py` establishes a checksum on first acquisition rather than
+verifying against a known one, so the metadata gate stands where `dataset` has a hash
+(`acquire.py:3`). Three tiers:
+
+| Tier | Rungs | Rule | Location |
+|---|---|---|---|
+| **identity** | 1–3 (`openalex-best`, `openalex-locations`, `openalex-landing`) | Ungated — the URL came from the work the citekey already resolves to | `acquire.py:1413` |
+| **gated** | 4–5 (`sibling-version`, `arxiv-search`) | Must pass `evaluate_match` on title × author × year; **first-author family name is a hard gate** | `acquire.py:118`, `:276`, `:331` |
+| **trusted** | 6 (`venue-resolver`) | Admitted on the operator's word, recorded as `TRUSTED`, **never** as `accept` | `acquire.py:128`, `:1405`, ADR-0038 |
+
+The `TRUSTED` constant's docstring is the clearest statement of the access model in the
+codebase (`acquire.py:124`): reporting a consumer-configured URL as `accept` "would be a
+verification never performed". And `acquire.py:1396`: "an integrity tool must not
+launder configuration into evidence".
+
+Gated outcomes that are plausible but unproven land in **quarantine** with nothing
+written to the registry (`acquire.py:1043`), awaiting an explicit human
+`literature confirm --sha256`; there is "deliberately no 'promote whatever is in
+quarantine' convenience".
+
+### Human `confirm` steps
+
+| Step | What it authorises | Location |
+|---|---|---|
+| `literature confirm --sha256` | Promote a quarantined candidate after human review | `cli.py:1317` |
+| `literature confirm --file` | Adopt a hand-downloaded PDF; records `rung: manual` and an **empty, non-redistributable** license because "the tool observed nothing about the rights on a file it did not fetch" | `acquire.py:1963`, `:1976` |
+| `digest extract sample --verdict` | A human's finding about a sampled batch. `verified` is **refused outright** if any drawn paper's cells could not be shown, "because the human cannot have verified what they were never shown" | `cli.py:3357` |
+| `dataset ingest` → `_needs_human` | Lists the fields Croissant could not fill (`license`, `tier`, `access`, `datasheet`, `sensitivity`) for the human to confirm on register | `cli.py:1555` |
+
+### Rights as an access decision
+
+`PERMISSIVE_SPDX` (`acquire.py:380`) is "deliberately short and **not configurable**:
+whether a license grants redistribution is a compliance judgement, and a consumer
+overriding it in config would be the plugin quietly sanctioning a republication it
+cannot vouch for". Absent or unrecognised ⇒ `redistributable: false`
+(`acquire.py:397`). `fetch` never copies bytes into the repository; it only reports
+`committable`.
+
+### Key handling (ADR-0029, ADR-0032)
+
+| Rule | Location |
+|---|---|
+| Store lives **outside any repo** by default — `$XDG_CONFIG_HOME/defendable-science/keys.json` | `core/keys.py:129` |
+| Precedence `os.environ` > store > `None` | `core/keys.py:243` |
+| A value never reaches argv — stdin or a hidden prompt only | `cli.py:2448` |
+| A value is never echoed, logged, or returned by the reporting API | `cli.py:2483` (`_key_report` returns presence and source, never a value) |
+| Least privilege: a child process gets only the variables it needs | `core/keys.py:279` (`scoped_env`), `:318` (`rclone_scoped_env`) |
+| Guardrail: warn if the resolved store sits in a non-gitignored work tree | `core/keys.py:406`, surfaced at `cli.py:2403` |
+| Honest about what it is not: "plaintext at rest … *not* encryption" | `core/keys.py:32` |
+| `mailto` goes to OpenAlex only, never to arXiv — sending a user's email to an unrelated host "would be a privacy leak, not a nicety" | `core/http.py:229` |
+
+*(One implementation defect in this area — the store is written world-readable and then
+chmod'd — is BE-6 in [`be-tech-debt.md`](be-tech-debt.md). The model is sound; the write
+is not.)*
+
+---
+
+## 4. Core entities
+
+### `status:` frontmatter — the primary artifact schema
+
+Every staged document carries one. Rendered by `scaffold/status.render()`
+(`scaffold/status.py:112`); the per-template initial forms are declared once at
+`scaffold/status.py:84` (`TEMPLATE_FORMS`) and guarded against drift by
+`tests/test_status.py:121`.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `level` | `hypothesis` \| `paper` \| `thesis` | which schema applies |
+| `id` | str \| null | stable artifact id; keys the artifact across backlog, registry and dashboard |
+| `verdict` | `confirmed` \| `refuted` \| `inconclusive` \| `n/a` \| null | the science's answer |
+| `readiness` | level-specific (`resolved`, `framing`, `defensible`, `publish`, `no-go`, …) | the decision axis |
+| `signed-off-by` | str \| null | **the named human**; null means *not yet decided* |
+| `load-bearing` | bool | whether refuting this invalidates the paper's claim |
+| `covers` | list[str] | thesis aim ids this artifact supports |
+| `blockers` | list[str] | free-text, author-flagged |
+| `last-updated` | ISO date \| null | newest across the artifact |
+| `understanding` | `{status: ok\|gaps, unresolved: [...]}` | written by `defend record` |
+| `extraction` | `{cells, locators, in-sample, batch-check}` | written by `digest extract`; **never** on the same axis as `understanding` |
+
+The `understanding`/`extraction` split is load-bearing: `digest/artifact.py` refuses to
+write `understanding` from an extraction path because "a digest carrying an
+`understanding` block reads to `progress` as 'digested & understood', which would be
+false for a paper nobody has read" (`cli.py:1880`).
+
+**Staged documents and their authority** (`scaffold/layout.py:36`, `:65`):
+
+```
+hypothesis:  hypothesis.md → strategy.md → findings.md*
+paper:       pitch.md → positioning.md → ledger.md → decision.md*
+thesis:      aims.md → kappa.md*
+                                          * = AUTHORITATIVE_DOCUMENTS
+```
+
+The authoritative document owns the adjudication axes; siblings may carry their own
+lighter `understanding` and `last-updated`, which `progress` surfaces but never treats
+as the verdict source (`scaffold/layout.py:48`). Before the authoritative document
+exists, the furthest stage present stands in (`progress/collect.py:176`).
+
+### Backlog row — the one explicit state machine
+
+`exploration/backlog.py:4`:
+
+```
+  park                add
+    │                  │
+    ▼                  ▼
+ parked ──────────► candidate ──rank──► ranked ──promote──► promoted
+    │                  │                   │
+    └──────────────────┴───────drop────────┴────────────► dropped (reason required)
+```
+
+`dropped` is terminal and non-destructive — the row stays with its reason
+(`cli.py:2351`). `promoted` at the paper level additionally scaffolds a paper root and
+appends a `papers.md` registry row (`exploration/backlog.py:558`).
+
+Two column profiles (`exploration/backlog.py:39`, `:51`):
+
+| Level | Columns |
+|---|---|
+| hypothesis | `id, one-line, move/type, provenance, EIG, feas, interest, frame, status, note` |
+| paper | `id, one-line, lens, provenance, feas, interest, status, note` |
+
+`provenance` is required on every row — "no orphan ideas"
+(`exploration/backlog.py:305`).
+
+### Registry entry (`references.json`, CSL-JSON + a namespaced spine)
+
+ADR-0020. The bibliography is valid CSL-JSON so it round-trips through Zotero and
+pandoc; the substrate spine lives under CSL's schema-designated `custom` field,
+namespaced `defendable-science` (`literature/registry.py:24`).
+
+```
+Entry(citekey, title, year, first_author_family, doi, asset, raw)   registry.py:120
+└─ Asset(schema=1, pid, files[], license, redistributable,          registry.py:95
+         access, mirror, acquisition)
+   ├─ AssetFile(path, sha256, size, media_type)                     registry.py:34
+   ├─ License(id, observed, source)  ← *observed*, not asserted     registry.py:51
+   ├─ MirrorRef(remote, key)                                        registry.py:65
+   └─ Acquisition(rung, url, candidate, match, fetched)             registry.py:77
+```
+
+### Triage row (`triage.yml`) — the PRISMA sidecar
+
+`TriageRow(citekey, disposition, raw)` (`literature/registry.py:475`). `disposition` is
+the human's state-machine value; the `raw` dict preserves fields the model does not
+name, including the rationale text. `patch_triage` refuses to rewrite the file if it
+carries comments, non-mapping rows, or any YAML anchor
+(`literature/registry.py:769`, `:778`, `:785`) because "the triage sidecar's `rationale`
+fields *are* the PRISMA audit trail".
+
+### Extraction cell
+
+`Cell(citekey, axis, value, locator, justification)`
+(`digest/extraction.py:205`). A locator is **required** unless `value` is
+`not-addressed`, in which case a justification is required (`extraction.py:386`). Rule 2
+is the anti-gaming rule: every matrix axis must be accounted for, so an agent that finds
+an axis hard cannot simply omit the cell — "a short row looks exactly like a clean row"
+(`extraction.py:454`).
+
+### Dataset entry (`datasets.yml`)
+
+`DatasetEntry` with `FileRef`, `Retrieval`, `Citation`, `Mirror`
+(`dataset/manifest.py`). Three storage tiers (ADR-0010, `TIERS` at `manifest.py:27`):
+
+| Tier | Meaning | Resolution |
+|---|---|---|
+| **A** | committed in-repo | verify in place at its repo path (`retrieval.py:95`) |
+| **B** | public, fetchable | cache → mirror → pooch, SHA-256 at every hop (`retrieval.py:104-128`) |
+| **C** | gated / manual | **never fetches**; prints the recorded instructions (`retrieval.py:131`) |
+
+### Check finding
+
+`Finding(severity, check, file, message, remedy)` (`check/model.py:36`) — `remedy` is a
+required field. Three severities with the exit code keyed to **severity, not count**
+(`check/model.py:3`):
+
+| Severity | Meaning | Exit |
+|---|---|---|
+| `invalid` | violates a shape this package owns | 1 |
+| `unreadable` | could not be read or parsed, so validity is **unknown** | 1 |
+| `gap` | a valid file holding incomplete science | 0 |
+
+`check/model.py:14`: "The exit code is keyed to invalid *files*, never to incomplete
+*science*: a `refuted` hypothesis or a `no-go` paper is successful science and is not a
+finding of any kind."
+
+### Dashboard artifact
+
+`Artifact` (`progress/model.py:29`) — a frozen dataclass of *facts read from
+frontmatter, never judgements*. `progress/model.py:4`: "There is deliberately no
+aggregate, no score and no completion field." `unreadable` and `Milestones.unknown` are
+modelled separately from absence "because 'we do not know' and 'there is nothing' are
+different facts and only one of them is fine" (`progress/model.py:9`).
+
+### Consumer layout
+
+`Layout` (frozen, `scaffold/layout.py:76`) — four recordable roots
+(`research_root`, `literature_dir`, `datasets_manifest`, `thesis_dir`,
+`LAYOUT_KEYS` at `:20`); everything inside a paper is **derived and not configurable**
+(`:177`). Defaults omitted when recorded (ADR-0039, `recorded_layout` at `:336`), and
+every configured value is confined to the repository (`_relative`, `:241`).
+
+---
+
+## 5. Automation — what triggers what
+
+### Skill → CLI invocation chain
+
+Every CLI-invoking skill first executes `resources/ensure-tooling.md` — linked, never
+inlined, from 8 of 9 call sites (`skills/progress/SKILL.md:46` is the omission).
+
+| Skill | Invokes |
+|---|---|
+| `research-init` | `defendable-science init [--thesis] [--dry-run] [--root]`, `check` |
+| `hypothesis-exploration` | `backlog park/add/rank/list/promote/drop --level hypothesis` |
+| `paper-exploration` | the same with `--level paper`, `promote --scaffold --backend` |
+| `literature` | `literature resolve/cites/refs/enrich/neighbors`, `fetch/confirm/verify/mirror` |
+| `dataset` | `dataset validate/ingest/emit/fetch/verify/mirror/audit` |
+| `defend` | `defend record --artifact --target --points`, `digest extract cells` |
+| `digest` | `digest extract axes/record/sample/render` |
+| `progress` | `check`, `progress dashboard` |
+| `thesis`, `hypothesis-testing`, `paper-synthesis` | no direct CLI calls (they drive documents) |
+
+### CLI command → file-write effects
+
+| Command | Writes |
+|---|---|
+| `init` | the whole consumer tree; merges `.gitignore` append-only; **never overwrites** (`cli.py:516`) |
+| `check` | nothing — read-only |
+| `progress dashboard` | `dashboard.md`, wholesale; a hand-edit is correctly discarded (`cli.py:729`) |
+| `backlog park/add/rank/drop` | the backlog table |
+| `backlog promote --scaffold` | + paper tree, `pitch.md`, `backlog.md`, a `papers.md` row |
+| `literature fetch` | blob store, quarantine, `references.json` spine, optionally the mirror |
+| `literature confirm` | blob store, `references.json` spine; unlinks the quarantine sidecar |
+| `defend record` | artifact `status.understanding`, a transcript, an accountability-log entry |
+| `digest extract record` | digest artifact + cells block, a log entry, then `triage.yml` |
+| `digest extract sample --verdict` | `batch-check` on **every** batch member, `in-sample` on drawn ones, log entries |
+| `digest extract render` | `positioning.md`'s matrix, merged |
+| `keys set/unset` | the out-of-repo key store |
+| `dataset fetch/mirror` | blob store, the mirror |
+
+### GitHub Actions
+
+| Workflow | Trigger | Effect |
+|---|---|---|
+| `ci.yml` | push→main, every PR, merge_group | pre-commit (all hooks); test matrix py3.11–3.14 → ruff + mypy + pytest with the 100 % gate; Codecov on 3.13; `plugin-validate`; `check` alls-green aggregator (`:77`) |
+| `bump-version.yml` | `workflow_dispatch` | `tools/bump_version.py` edits **`pyproject.toml` only**; opens a release PR |
+| `publish.yml` | `release: published`, `workflow_dispatch` | guard: release tag must equal the pyproject version (`:34`); `uv build`; OIDC Trusted Publishing (ADR-0027) |
+| `docs-publish.yml` | `release: published`, dispatch, PR on `skills/**`/`decisions/**`/`docs/**` | PR → `mint validate` + `mint broken-links`. Release → push to the docs repo, poll the live site, 404-check every nav URL (`:203`) |
+| `live-validation.yml` | dispatch, **weekly cron Mon 06:00 UTC** | `DEFENDABLE_SCIENCE_LIVE=1 pytest -m live` against real OpenAlex/S2/rclone |
+
+`dependabot.yml` covers GitHub Actions and Python deps (ADR-0036); 7 of the repo's
+commits are dependabot's.
+
+### Pre-commit hooks
+
+`.pre-commit-config.yaml`: trailing-whitespace, end-of-file-fixer, check-yaml,
+check-added-large-files, pyupgrade `--py311-plus`, and five `repo: local` hooks —
+codespell, ruff, mypy, `validate-plugin.sh` (scoped to
+`files: ^\.claude-plugin/.*\.json$`, `:69`), detect-secrets. The local-hook choice is
+deliberate: it keeps each tool's version authored only in `pyproject.toml`'s `lint`
+group rather than on a second Dependabot schedule (`.pre-commit-config.yaml:21`,
+ADR-0036).
+
+---
+
+## 6. Glossary
+
+**Agency principle** — the human makes and signs every material decision; the agent
+proposes. ADR-0003, `resources/references/agency-principle.md`. Enforced at
+`defend/record.py:285` and eight other points (§3).
+
+**Understanding principle** — a decision may not be recorded until the human can
+articulate it. ADR-0004; `defend` is its guardrail.
+
+**Exploration→resolution firewall** — no skill both proposes a claim and adjudicates
+it. `CLAUDE.md:24`; rendered as a table column at
+`skills/paper-exploration/SKILL.md:41`.
+
+**`defend`** — the Socratic tutor-examiner. Probe → teach → re-probe, before a material
+decision is recorded. Never grades the substance of a novel claim
+(`skills/defend/SKILL.md:3`); never supplies the answer (`:59`).
+
+**`digest`** — `defend`'s inbound counterpart: verified comprehension of someone else's
+paper. Two modes — **depth** (full comprehension, an hour or two per paper) and
+**extraction** (breadth, survey-scale, certifying deliberately less). ADR-0034,
+ADR-0040.
+
+**Evidentiary point record** — ADR-0033. What `defend record` writes per probed point:
+`PointRecord(point, source_quote, reader_answer, resolved, location, gap_note)`
+(`defend/record.py:49`). Records what grounds the claim and what the human actually
+said — observed facts, never a grade.
+
+**Accountability log** — the append-only trail under
+`<research_root>/defend-log/`, written by `defend record`, `digest extract record` and
+`digest extract sample`. One trail, one writer (`defend/record.py:320`), never
+overwritten (`:344`).
+
+**Fixity** — SHA-256 as the identity of bytes. `core/fixity.py`; verified at every hop
+of the resolution chain (`dataset/retrieval.py:68`), and a blob that fails is deleted
+rather than left to be re-read (`literature/acquire.py:1221`).
+
+**Content-addressed store** — `<cache_dir>/sha256/<hash>`. Overwriting is safe and
+unconditional because the destination is derived from the bytes
+(`literature/acquire.py:1089`).
+
+**Tiers A / B / C** — dataset storage classes: in-repo, public-fetchable, gated-manual.
+ADR-0010; `dataset/manifest.py:27`.
+
+**Ladder / rung** — the six-step PDF acquisition sequence, best-first and lazy
+(`literature/acquire.py:1358`). Rungs 1–3 identity-derived, 4–5 gated, 6 trusted.
+
+**Match gate** — `evaluate_match` (`literature/acquire.py:276`). Title × author × year;
+first-author family name is a hard gate. Verdicts: `identity`, `trusted`, `accept`,
+`quarantine`, `refuse`.
+
+**Quarantine** — plausible-but-unproven bytes parked with their evidence, **nothing
+written to the registry**, awaiting an explicit human `confirm`
+(`literature/acquire.py:1043`).
+
+**Polite pool** — OpenAlex's faster tier for requests carrying a contact `mailto`.
+`core/http.py:121`; the email is sent to OpenAlex only (`core/http.py:229`).
+
+**Compat pin** — the version range the plugin declares for the package. ADR-0026;
+`resources/ensure-tooling.md:26`. The two artifacts version independently and must
+**never** be locked together. *(The pin currently names an unreleased version — PL-1.)*
+
+**Failure honesty** — `CLAUDE.md:65`: never report a failure as a legitimate
+empty/negative/complete result, and never surface a transient error as a raw traceback.
+Implemented as type distinctions: `MirrorUnreachableError` vs. a `False` return
+(`core/mirror.py:43`), `DownloadError.hard_miss` (`core/download.py:71`),
+`RateLimitError` (`core/http.py:52`).
+
+**Toulmin sextet** — the claim/ground/warrant/backing/qualifier/rebuttal structure of a
+ledger entry. `resources/templates/paper/ledger.md`;
+`skills/paper-synthesis/SKILL.md:90`.
+
+**Kappa** — the framing chapter of a compilation thesis; where the defensibility
+sign-off lives (`scaffold/layout.py:52`, `AUTHORITATIVE_DOCUMENTS["thesis"]`).
+
+**Concept matrix** — the table in `positioning.md` whose columns are the axes a paper's
+delta turns on. The extraction question set (`digest/extraction.py:31`); its row is a
+**projection** of the recorded cells, never authored independently
+(`digest/artifact.py:285`).
+
+**Batch check** — the verdict a human records over an extraction batch after inspecting
+a `max(3, 10%)` sample (ADR-0040). A `failed` verdict lands on **every** member,
+sampled or not, and touches no cell — "silently repairing the caught cell would convert
+that signal into a tidy-looking local fix" (`cli.py:3253`).
+
+**Engineering delegation contract** — ADR-0023,
+`resources/contracts/engineering.md`. Design, planning and code are handed to a bound
+backend; the plugin never implements them.
+
+**Experiment backend** — the per-paper binding recorded in `papers.md` that runs
+experiments and returns run-refs. ADR-0013,
+`resources/contracts/experiment-backend.md`. The plugin ships none, which is why
+`--backend` is required (`cli.py:2167`).
+
+---
+
+*See [`executive-summary.md`](executive-summary.md) for the assessment, and the four
+debt reports for where this design is and is not carried through.*


### PR DESCRIPTION
## What

A deep codebase audit of both shipped artifacts, as seven reports under
`.codebase_audit/`. **Documentation-only — no source, test, config, or doc file
outside `.codebase_audit/` is modified.** `git show --stat` is seven added
markdown files and nothing else.

**Headline rating: 6.5 / 10.** The engineering discipline is genuinely strong
where most projects are weak — a 100% branch-coverage gate that a mutation
spot-check shows is *not* theatre (7/7 non-equivalent mutants killed on
`core/fixity.py`), strict-mypy-clean over 17 kLOC, zero functions above McCabe
10, 41 ADRs with real rejected-alternatives sections, and a failure-honesty
model implemented as type distinctions rather than as a convention. The debt is
concentrated on the **public surfaces**: the CLI/JSON contract the markdown
skills parse, and the boundary between the plugin and the package.

Every finding carries a verified `file:line`; the notable ones were reproduced
against the working tree.

## Top 5 findings

1. **Four documented CLI invocations do not run, and nothing tests the contract**
   — [`api-tech-debt.md`](../blob/docs/codebase-audit-2026-08/.codebase_audit/api-tech-debt.md)
   API-2/API-3. `docs/USER-GUIDE.md:182` uses `--EIG` (the flag is `--eig`);
   `docs/guides/dataset.md:32` and `:139` call `dataset verify` with no required
   positional — the first of those is the block that *defines* the guide's
   "shell blocks are verbatim" convention; and
   `skills/hypothesis-exploration/SKILL.md:56` documents a backlog column
   (`one-line hypothesis`) that `Backlog._require` permanently refuses, in a
   section telling the author to hand-build that table.
   `tests/test_plugin_content.py` is the only test that opens a SKILL.md, it
   asserts one hard-coded string, and it deliberately skips fenced code blocks —
   where every invocation lives.

2. **The shipped bootstrap names a package version that has never been released**
   — [`plugin-tech-debt.md`](../blob/docs/codebase-audit-2026-08/.codebase_audit/plugin-tech-debt.md)
   PL-1/PL-2. `resources/ensure-tooling.md:26` pins `>=0.3.0,<0.4.0`; the package
   is `0.2.2` and the newest tag is `v0.2.2`. The pin is also never passed to any
   install command (`:28`, `:30`, `:32` are bare), and there is no upgrade path —
   a mismatch falls through to a bare `uv tool install`, a no-op against an
   existing older install, so a stale CLI is kept **silently**. ADR-0026:35
   promises the bootstrap "installs/**upgrades**".

3. **Six unvalidated JSON boundaries — four tracebacks and one silently wrong
   value** — [`be-tech-debt.md`](../blob/docs/codebase-audit-2026-08/.codebase_audit/be-tech-debt.md)
   BE-4, tracked in #169. All reproduced independently. The worst is not a crash:
   a bare string in an S2 `contexts` field is indexed to its first character and
   emitted as the citation context (`literature/graph.py:349` → `'t'`), with no
   `degraded` marker. Four of the six are in `literature/graph.py`; the *same*
   upstream record is guarded correctly by `acquire.py:549`, so the rule exists
   and was applied to one of two readers.

4. **The claim lands before the evidence, and writes are non-atomic** —
   [`data-tech-debt.md`](../blob/docs/codebase-audit-2026-08/.codebase_audit/data-tech-debt.md)
   DATA-1 / BE-2 / BE-3. `defend/record.py:288` patches the artifact's
   `status.understanding` and *then* writes the accountability-log entry, so a
   failed log write leaves an artifact claiming verified understanding with no
   evidence behind it — and `progress`/`check` read the frontmatter, not the log.
   Same shape at `digest/artifact.py:548`. Separately, only **3 of 18 write
   sites** use the temp-then-rename idiom that `0489114` just hardened; the 15
   that do not include the key store, every backlog table, and `positioning.md`'s
   full rewrite, whose docstring promises "Nothing is ever deleted".

5. **Externally-derived identifiers reach the filesystem unchecked** — BE-1.
   Reproduced: a `--cells` entry whose citekey is `../../../../../../tmp/…`
   caused `digest extract record` to write a markdown file **outside the work
   tree**, creating intermediate directories on the way. `Layout.digest`
   (`scaffold/layout.py:144`) and four siblings interpolate an untrusted
   identifier with no containment check, while the same repository enforces
   exactly that rule in three other places (`acquire.py:1019`, `layout.py:241`,
   `cli.py:359`) — an inconsistency, not an oversight.

Runner-up worth flagging: **no schema version on any artifact and no migration
path** (DATA-4), with each artifact's shape defined in four places and only one
of six pairings guarded by a test. A field whose semantics change is read
silently as if it meant the new thing — and `CHANGELOG.md` records that a
sign-off rule already changed this way once.

## Template adaptation

The audit template was written for a web-app/ORM stack. It was mapped onto this
repo's CLI + git-native-artifact reality rather than applied literally:

| Original category | Mapped to |
|---|---|
| REST API design | The `defendable-science <group> <cmd>` tree **and the JSON each command emits**, since markdown skills parse it |
| HTTP status codes | Exit-code discipline (0/1/2/3), tabulated per command |
| Missing pagination | Unbounded result sets and missing `--limit`/`--offset` |
| Rate limiting | Outbound politeness — polite pool, User-Agent, 429/5xx backoff, per-host pacing |
| Auth bypasses | API-key handling: leakage into JSON/logs/cache, file permissions, absent-key behaviour |
| Missing error response models | Machine-readable failure vs. bare stderr prose |
| Database / ORM | Files in a git repo: markdown + YAML frontmatter, CSL-JSON, Croissant, an HTTP cache, a key store, a registry |
| Missing indexes | Full directory walks and linear scans per invocation; O(n) growth as a portfolio grows |
| ORM misuse (over-fetching) | Reading and re-parsing whole documents when only frontmatter is needed |
| Missing DB constraints | No single authoritative artifact schema — writer / template / reader / validator drift |
| **Alembic migrations** | **Recorded as N/A explicitly**, then audited as artifact schema evolution in already-initialised consumer repos — a real and unaddressed gap |
| Transaction boundaries | Atomicity of multi-file writes and the rollback story |
| Connection pool misuse | HTTP session reuse + on-disk cache TTL, key collisions, negative caching, concurrency |
| Missing soft-delete | Whether recorded evidence is append-only and tamper-evident |
| SQL injection | `yaml.load` vs `safe_load`, path traversal from DOIs/citekeys/titles, zip-slip, rclone argv injection |
| N+1 queries | Redundant per-item HTTP round-trips and repeated filesystem walks |
| Sync-in-async | Blocking-I/O discipline: timeouts, retry/backoff, subprocess handling, partial-write races |
| Async test coverage | Cross-process concurrency and crash-recovery coverage |
| Coverage percentages | **Reframed**: the gate makes them 100% by construction, so the report audits assertion *quality* instead |
| *(absent from the template)* | **Added `plugin-tech-debt.md`** — the markdown deliverable is the primary artifact and was invisible to every tool in CI |

## Note on the Pydantic recommendations

Recommendations to adopt Pydantic v2 appear in three reports and are **scoped to
the external-input parsing boundary only** (API responses, Croissant, CSL-JSON,
user YAML, config), per the maintainer's decision tracked in #169. Stdlib
`dataclasses` remain the norm for internal value objects and no recommendation
proposes changing that; several sites are explicitly called out as *better left
as stdlib*, including `progress/collect.py:64`, whose tolerance is deliberate
and documented.

Two premises were verified rather than assumed: the CLI is installed **isolated**
from the consumer's environment (`resources/ensure-tooling.md:56`), so the
"Rust-binary conflicts" half of `CLAUDE.md:64` does not apply; and `pyyaml`
already ships a compiled C extension (`_yaml`, 3.1 MB installed — larger than
`rich`), so the "light wheel" half is already breached.

Because nothing has landed on `main`, the reports document `CLAUDE.md:64` and
its **fourteen** in-repo restatements exactly as they stand — including the
governance finding that survives the decision either way:
`decisions/0031-config-driven-cache-dir.md:32` cites "(ADR rejecting it stands)",
a **dangling reference to an ADR that does not exist**. The prohibition lives
only in contributor guidance and is cited secondhand by three ADRs.

## Checks

- `./tools/validate-plugin.sh` — ✔ passed
- `codespell` on the changed files — clean
- Package checks not run: no package file changed.

<!-- No `Closes #NN`: this audit closes no existing issue. #169 is referenced as
     the tracking issue for the Pydantic/ADR reconciliation, not resolved here. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
