### PR TITLE
fix(core): guard identifier-taking paths against traversal (closes #182)

### DIFF
--- a/defendable-science/defendable_science/check/checks.py
+++ b/defendable-science/defendable_science/check/checks.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any
 from defendable_science.check.model import Finding, Report
 from defendable_science.core.config import load_config_text
 from defendable_science.core.gitignore import literal_covers
+from defendable_science.core.paths import require_path_segment
 from defendable_science.dataset import manifest as mf
 from defendable_science.digest import artifact as artifact_mod
 from defendable_science.digest import extraction as extraction_mod
@@ -583,8 +584,9 @@ def _check_registered_paper(layout: Layout, probe: Probe, row: Row) -> list[Find
     :param row: One ``papers.md`` row.
     :returns: The findings for this row. An unbound backend is a ``gap`` —
         incomplete science in a valid file — while a root that is missing or
-        outside the repository, and a backlog the registry implies but the repo
-        does not have, are ``invalid``.
+        outside the repository, a paper-id that is a path rather than a slug,
+        and a backlog the registry implies but the repo does not have, are
+        ``invalid``.
     """
     registry = str(layout.rel(layout.papers_registry))
     paper_id = row.get("paper-id", "").strip()
@@ -600,6 +602,24 @@ def _check_registered_paper(layout: Layout, probe: Probe, row: Row) -> list[Find
                     "keys the paper across its backlog, the dashboard and `progress`"
                 ),
                 remedy="give the row a stable paper-id, or delete the row",
+            )
+        ]
+    try:
+        require_path_segment(paper_id, what="paper-id", error=ValueError)
+    except ValueError:
+        # `layout.paper_dir(paper_id)` below would raise `LayoutError` on
+        # exactly this input, uncaught — the integrity tool must report the
+        # integrity problem, not crash on it (defendable-science#182).
+        return [
+            Finding(
+                severity="invalid",
+                check=TABLES_CHECK,
+                file=registry,
+                message=f"registered paper-id {paper_id!r} is a path, not a slug",
+                remedy=(
+                    "paper-id must be a single directory name, not a path — "
+                    "e.g. `depth-collapse`, not `docs/depth-collapse`"
+                ),
             )
         ]
     if not root:

--- a/defendable-science/defendable_science/cli.py
+++ b/defendable-science/defendable_science/cli.py
@@ -2615,14 +2615,19 @@ def _positioning_context(
     :param paper: The paper id, or ``None`` to infer it from the cwd.
     :param positioning: An explicit positioning path, which always wins.
     :returns: The config mapping, the resolved layout, and the document path.
-    :raises typer.Exit: Code 1 on an invalid ``layout:`` block; code 2 when
-        ``--paper`` is omitted and the cwd is outside every paper.
+    :raises typer.Exit: Code 1 on an invalid ``layout:`` block, or a ``--paper``
+        that is not a single path segment; code 2 when ``--paper`` is omitted
+        and the cwd is outside every paper.
     """
     config, layout = _layout_or_exit()
     if positioning is not None:
         return config, layout, Path(positioning)
     paper_id = paper or _paper_dir_or_exit(layout, "--paper").name
-    return config, layout, layout.positioning(paper_id)
+    try:
+        return config, layout, layout.positioning(paper_id)
+    except LayoutError as exc:
+        typer.echo(f"invalid --paper: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
 
 
 def _locator_patterns(lit: dict[str, Any] | None) -> list[re.Pattern[str]]:
@@ -2744,16 +2749,18 @@ def extract_cells(
     the same convention `extract sample --citekey` already uses.
 
     :param citekey: The digested paper's citekey (`Layout.digest`'s key).
-    :raises typer.Exit: Code 0 with the cells as JSON; code 1 if the paper has
-        not been extracted, or its cells block is absent or malformed.
+    :raises typer.Exit: Code 0 with the cells as JSON; code 1 if `citekey` is
+        not a single path segment, the paper has not been extracted, or its
+        cells block is absent or malformed.
     """
     _config, layout = _layout_or_exit()
-    artifact = layout.digest(citekey)
+    artifact: Path | None = None
     cells: list[dict[str, Any]] | None = None
     error: str | None = None
     try:
+        artifact = layout.digest(citekey)
         cells = [dataclasses.asdict(c) for c in artifact_mod.read_cells(artifact)]
-    except extraction_mod.ExtractionError as exc:
+    except (LayoutError, extraction_mod.ExtractionError) as exc:
         typer.echo(f"digest extract cells failed: {exc}", err=True)
         error = str(exc)
     typer.echo(
@@ -2761,7 +2768,7 @@ def extract_cells(
             {
                 "ok": error is None,
                 "citekey": citekey,
-                "artifact": str(artifact),
+                "artifact": str(artifact) if artifact is not None else None,
                 "cells": cells,
                 "error": error,
             },
@@ -2948,8 +2955,12 @@ def extract_record(
     errors: list[dict[str, str]] = []
     triage_not_updated: list[dict[str, str]] = []
     for citekey, paper_cells in sorted(accepted.items()):
-        artifact = layout.digest(citekey)
+        # A display-only path, computed without the guard: if `layout.digest`
+        # below rejects `citekey`, this is never opened or written — it only
+        # names, in the error report, where the write would have gone.
+        artifact = layout.digests_dir / f"{citekey}.md"
         try:
+            artifact = layout.digest(citekey)
             # `init` does not scaffold literature/digests/ — the first recorded
             # paper creates it.
             artifact.parent.mkdir(parents=True, exist_ok=True)
@@ -2961,7 +2972,7 @@ def extract_record(
                 log_dir=log_root,
                 date=date,
             )
-        except (extraction_mod.ExtractionError, OSError) as exc:
+        except (LayoutError, extraction_mod.ExtractionError, OSError) as exc:
             # The sweep continues and the report is still emitted. Aborting here
             # would leave the author knowing only that *something* failed, while
             # some papers had already landed — and re-running the whole batch to
@@ -3100,12 +3111,16 @@ def depth_cells_record(
     recorded: list[dict[str, Any]] = []
     errors: list[dict[str, str]] = []
     for citekey, paper_cells in sorted(accepted.items()):
-        artifact = layout.digest(citekey)
+        # A display-only path, computed without the guard: if `layout.digest`
+        # below rejects `citekey`, this is never opened or written — it only
+        # names, in the error report, where the write would have gone.
+        artifact = layout.digests_dir / f"{citekey}.md"
         try:
+            artifact = layout.digest(citekey)
             log_entry = artifact_mod.write_depth_cells(
                 artifact, paper_cells, log_dir=log_root, date=date
             )
-        except (extraction_mod.ExtractionError, OSError) as exc:
+        except (LayoutError, extraction_mod.ExtractionError, OSError) as exc:
             # The sweep continues, same posture as `extract record`: a batch
             # of several depth-read papers must not be strangled by one bad
             # artifact, and re-running to find out which one would append a
@@ -3249,10 +3264,14 @@ def _read_sampled_cells(
     drawn_cells: dict[str, list[extraction_mod.Cell]] = {}
     sampled: list[dict[str, Any]] = []
     for key in sample:
-        target = layout.digest(key)
+        # A display-only path, computed without the guard: if `layout.digest`
+        # below rejects `key`, this is never opened — it only names, in the
+        # error report, where the read would have gone.
+        target = layout.digests_dir / f"{key}.md"
         try:
+            target = layout.digest(key)
             drawn_cells[key] = artifact_mod.read_cells(target)
-        except (extraction_mod.ExtractionError, OSError) as exc:
+        except (LayoutError, extraction_mod.ExtractionError, OSError) as exc:
             _note_error(errors, key, target, str(exc))
             continue
         sampled.append(
@@ -3299,8 +3318,12 @@ def _apply_verdict(
     updated: list[str] = []
     log_entries: list[str] = []
     for key in members:
-        target = layout.digest(key)
+        # A display-only path, computed without the guard: if `layout.digest`
+        # below rejects `key`, this is never opened or written — it only
+        # names, in the error report, where the write would have gone.
+        target = layout.digests_dir / f"{key}.md"
         try:
+            target = layout.digest(key)
             artifact_mod.set_batch_check(target, verdict, date=date)
             updated.append(key)
             if key in drawn_cells:
@@ -3318,7 +3341,7 @@ def _apply_verdict(
                         )
                     )
                 )
-        except (extraction_mod.ExtractionError, OSError) as exc:
+        except (LayoutError, extraction_mod.ExtractionError, OSError) as exc:
             _note_error(errors, key, target, str(exc))
     return updated, log_entries
 
@@ -3587,10 +3610,14 @@ def _cells_to_render(
     """
     rows: dict[str, dict[str, str]] = {}
     for citekey in batch:
-        target = layout.digest(citekey)
+        # A display-only path, computed without the guard: if `layout.digest`
+        # below rejects `citekey`, this is never opened — it only names, in
+        # the error report, where the read would have gone.
+        target = layout.digests_dir / f"{citekey}.md"
         try:
+            target = layout.digest(citekey)
             cells = artifact_mod.read_cells(target)
-        except (extraction_mod.ExtractionError, OSError) as exc:
+        except (LayoutError, extraction_mod.ExtractionError, OSError) as exc:
             typer.echo(f"digest extract render failed for {citekey}: {exc}", err=True)
             errors.append(
                 {"citekey": citekey, "artifact": str(target), "reason": str(exc)}

--- a/defendable-science/defendable_science/core/paths.py
+++ b/defendable-science/defendable_science/core/paths.py
@@ -1,0 +1,41 @@
+"""Guard for externally-derived identifiers joined onto a filesystem path.
+
+A citekey, paper id, or accountability-log stem is a single path *segment* —
+never a sub-path — but each arrives from outside the process (a CLI option, a
+CSL-JSON field, backlog data) with nothing checked. Joining one unvalidated
+onto a path lets ``..`` or an absolute-looking value escape the directory it
+was meant to stay inside (defendable-science#182). This is deliberately
+stricter than :func:`~defendable_science.scaffold.layout._relative`, which
+resolves and checks containment for a *configured path* that may legitimately
+have subdirectories — an identifier never should.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_UNSAFE = frozenset({"", ".", ".."})
+
+
+def require_path_segment(
+    value: str, *, what: str, error: Callable[[str], Exception]
+) -> str:
+    """Reject `value` unless it is safe as a single filesystem path segment.
+
+    :param value: The externally-derived identifier (citekey, paper id, log stem).
+    :param what: What is being validated, for the error message (e.g. ``"citekey"``).
+    :param error: The calling module's own error type (e.g. ``LayoutError``,
+        ``RecordError``) — never a bare ``ValueError`` leaking past the caller's
+        module boundary.
+    :returns: `value` unchanged.
+    :raises Exception: `error`, naming `what` and the offending value, if `value`
+        is empty, ``.``/``..``, or contains a path separator — anything that
+        would make it address more than one path segment and let it escape the
+        directory it is joined into.
+    """
+    if value in _UNSAFE or "/" in value or "\\" in value:
+        raise error(f"{what} is not a valid path segment: {value!r}")
+    return value

--- a/defendable-science/defendable_science/core/paths.py
+++ b/defendable-science/defendable_science/core/paths.py
@@ -32,10 +32,11 @@ def require_path_segment(
         module boundary.
     :returns: `value` unchanged.
     :raises Exception: `error`, naming `what` and the offending value, if `value`
-        is empty, ``.``/``..``, or contains a path separator — anything that
-        would make it address more than one path segment and let it escape the
-        directory it is joined into.
+        is empty, ``.``/``..``, contains a path separator, or contains a control
+        character (e.g. an embedded NUL) - anything that would either address
+        more than one path segment or reach the OS call as a raw, uncaught
+        error instead of this function's own signal.
     """
-    if value in _UNSAFE or "/" in value or "\\" in value:
+    if value in _UNSAFE or "/" in value or "\\" in value or any(c < " " for c in value):
         raise error(f"{what} is not a valid path segment: {value!r}")
     return value

--- a/defendable-science/defendable_science/core/paths.py
+++ b/defendable-science/defendable_science/core/paths.py
@@ -8,10 +8,18 @@ was meant to stay inside (defendable-science#182). This is deliberately
 stricter than :func:`~defendable_science.scaffold.layout._relative`, which
 resolves and checks containment for a *configured path* that may legitimately
 have subdirectories — an identifier never should.
+
+The backslash check makes Windows nominally in scope, so a Windows *drive*
+(``"C:PWNED"``, drive-relative — no separator at all, so escapes the other
+checks) is rejected too, via :mod:`ntpath` rather than :mod:`os.path`: the
+latter is a no-op for drive detection on the POSIX hosts this test suite
+actually runs on, which would make the check silently do nothing everywhere
+it is exercised.
 """
 
 from __future__ import annotations
 
+import ntpath
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -32,11 +40,18 @@ def require_path_segment(
         module boundary.
     :returns: `value` unchanged.
     :raises Exception: `error`, naming `what` and the offending value, if `value`
-        is empty, ``.``/``..``, contains a path separator, or contains a control
-        character (e.g. an embedded NUL) - anything that would either address
-        more than one path segment or reach the OS call as a raw, uncaught
-        error instead of this function's own signal.
+        is empty, ``.``/``..``, contains a path separator, contains a control
+        character (e.g. an embedded NUL), or is a Windows drive-relative value
+        (``"C:PWNED"``) — anything that would either address more than one
+        path segment or reach the OS call as a raw, uncaught error instead of
+        this function's own signal.
     """
-    if value in _UNSAFE or "/" in value or "\\" in value or any(c < " " for c in value):
+    if (
+        value in _UNSAFE
+        or "/" in value
+        or "\\" in value
+        or any(c < " " for c in value)
+        or ntpath.splitdrive(value)[0]
+    ):
         raise error(f"{what} is not a valid path segment: {value!r}")
     return value

--- a/defendable-science/defendable_science/defend/record.py
+++ b/defendable-science/defendable_science/defend/record.py
@@ -339,10 +339,13 @@ def append_log_entry(log_dir: Path, date: str, stem: str, body: str) -> Path:
         naming scheme changes.
     :param body: The rendered YAML to write.
     :returns: The path written.
-    :raises RecordError: If `stem` is not a single path segment — see
-        :func:`~defendable_science.core.paths.require_path_segment`
-        (defendable-science#182).
+    :raises RecordError: If `date` or `stem` is not a single path segment —
+        see :func:`~defendable_science.core.paths.require_path_segment`
+        (defendable-science#182). No current caller passes an untrusted
+        `date` (both are machine-generated), but this is public API and the
+        guard covers the whole filename it builds, not half of it.
     """
+    date = require_path_segment(date, what="date", error=RecordError)
     stem = require_path_segment(stem, what="stem", error=RecordError)
     log_dir.mkdir(parents=True, exist_ok=True)
     target = log_dir / f"{date}-{stem}.yml"

--- a/defendable-science/defendable_science/defend/record.py
+++ b/defendable-science/defendable_science/defend/record.py
@@ -26,6 +26,7 @@ from defendable_science.core.frontmatter import (
     set_field,
     split_frontmatter,
 )
+from defendable_science.core.paths import require_path_segment
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -338,7 +339,11 @@ def append_log_entry(log_dir: Path, date: str, stem: str, body: str) -> Path:
         naming scheme changes.
     :param body: The rendered YAML to write.
     :returns: The path written.
+    :raises RecordError: If `stem` is not a single path segment — see
+        :func:`~defendable_science.core.paths.require_path_segment`
+        (defendable-science#182).
     """
+    stem = require_path_segment(stem, what="stem", error=RecordError)
     log_dir.mkdir(parents=True, exist_ok=True)
     target = log_dir / f"{date}-{stem}.yml"
     n = 2

--- a/defendable-science/defendable_science/exploration/backlog.py
+++ b/defendable-science/defendable_science/exploration/backlog.py
@@ -19,6 +19,7 @@ from datetime import date as date_cls
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+from defendable_science.core.paths import require_path_segment
 from defendable_science.scaffold import status
 
 if TYPE_CHECKING:
@@ -476,8 +477,11 @@ def scaffold_hypothesis(
     :param provenance: The verbatim provenance carried from the backlog row.
     :param today: ISO date for ``last-updated`` (defaults to today).
     :returns: The path to the written ``hypothesis.md``.
-    :raises BacklogError: If the target file already exists.
+    :raises BacklogError: If `slug` is not a single path segment (a ``--slug``
+        crafted to escape the hypotheses directory — defendable-science#182),
+        or if the target file already exists.
     """
+    slug = require_path_segment(slug, what="slug", error=BacklogError)
     folder = Path(paper_root) / "hypotheses" / slug
     target = folder / "hypothesis.md"
     if target.exists():

--- a/defendable-science/defendable_science/exploration/backlog.py
+++ b/defendable-science/defendable_science/exploration/backlog.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Literal
 
 from defendable_science.core.paths import require_path_segment
 from defendable_science.scaffold import status
+from defendable_science.scaffold.layout import LayoutError
 
 if TYPE_CHECKING:
     from defendable_science.scaffold.layout import Layout
@@ -597,9 +598,14 @@ def scaffold_paper(
     :param provenance: The verbatim provenance carried from the backlog row.
     :param today: ISO date for ``last-updated`` (defaults to today).
     :returns: The paper root directory.
-    :raises BacklogError: If the paper root already exists.
+    :raises BacklogError: If `paper_id` is not a single path segment (a
+        ``row["id"]`` crafted to escape the research root -- defendable-science#182),
+        or if the paper root already exists.
     """
-    root = layout.paper_dir(paper_id)
+    try:
+        root = layout.paper_dir(paper_id)
+    except LayoutError as exc:
+        raise BacklogError(str(exc)) from exc
     if root.exists():
         raise BacklogError(f"{root} already exists — refusing to overwrite")
     layout.hypotheses_dir(paper_id).mkdir(parents=True)

--- a/defendable-science/defendable_science/scaffold/layout.py
+++ b/defendable-science/defendable_science/scaffold/layout.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from defendable_science.core.paths import require_path_segment
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
@@ -142,7 +144,13 @@ class Layout:
         return self.literature_dir / "digests"
 
     def digest(self, citekey: str) -> Path:
-        """Return the digest artifact of `citekey`."""
+        """Return the digest artifact of `citekey`.
+
+        :raises LayoutError: If `citekey` is not a single path segment — see
+            :func:`~defendable_science.core.paths.require_path_segment`
+            (defendable-science#182).
+        """
+        citekey = require_path_segment(citekey, what="citekey", error=LayoutError)
         return self.digests_dir / f"{citekey}.md"
 
     # --- config ---
@@ -177,7 +185,14 @@ class Layout:
     # --- per-paper (derived, never configurable) ---
 
     def paper_dir(self, paper_id: str) -> Path:
-        """Return the root directory of `paper_id`."""
+        """Return the root directory of `paper_id`.
+
+        :raises LayoutError: If `paper_id` is not a single path segment — see
+            :func:`~defendable_science.core.paths.require_path_segment`
+            (defendable-science#182). Every other per-paper path derives from
+            this one, so guarding it here covers them all.
+        """
+        paper_id = require_path_segment(paper_id, what="paper_id", error=LayoutError)
         return self.research_root / paper_id
 
     def backlog(self, paper_id: str) -> Path:
@@ -197,7 +212,12 @@ class Layout:
         return self.paper_docs_dir(paper_id) / "positioning.md"
 
     def hypothesis_dir(self, paper_id: str, slug: str) -> Path:
-        """Return one hypothesis folder of `paper_id`."""
+        """Return one hypothesis folder of `paper_id`.
+
+        :raises LayoutError: If `paper_id` or `slug` is not a single path
+            segment (defendable-science#182).
+        """
+        slug = require_path_segment(slug, what="slug", error=LayoutError)
         return self.hypotheses_dir(paper_id) / slug
 
     def rel(self, path: Path) -> Path:

--- a/defendable-science/tests/test_backlog.py
+++ b/defendable-science/tests/test_backlog.py
@@ -141,6 +141,19 @@ def test_scaffold_hypothesis_rejects_a_traversal_slug(tmp_path: Path) -> None:
         )
 
 
+def test_scaffold_paper_rejects_a_traversal_paper_id(tmp_path: Path) -> None:
+    """`paper_id` reaching `layout.paper_dir` uncaught used to escape as `LayoutError`.
+
+    (defendable-science#182, review round 3) It must surface as `BacklogError`
+    instead, the type `backlog promote`'s CLI handler actually catches
+    (`cli.py:2339`).
+    """
+    layout = Layout.default(tmp_path)
+    layout.research_root.mkdir(parents=True)
+    with pytest.raises(b.BacklogError, match="paper_id"):
+        b.scaffold_paper(layout, "../../../../tmp/PWNED", "x", backend="y")
+
+
 def test_scaffold_paper_creates_root_and_registers(tmp_path: Path) -> None:
     layout = Layout.default(tmp_path)
     layout.research_root.mkdir(parents=True)

--- a/defendable-science/tests/test_backlog.py
+++ b/defendable-science/tests/test_backlog.py
@@ -125,6 +125,22 @@ def test_scaffold_hypothesis_writes_frontmatter(tmp_path: Path) -> None:
         )
 
 
+def test_scaffold_hypothesis_rejects_a_traversal_slug(tmp_path: Path) -> None:
+    """`slug` is a single path segment (defendable-science#182, review round 2).
+
+    `Layout.hypothesis_dir` guards this same join, but has no live caller —
+    `scaffold_hypothesis` (reached from `backlog promote --scaffold`) joins
+    `slug` itself and must carry its own guard.
+    """
+    with pytest.raises(b.BacklogError, match="slug"):
+        b.scaffold_hypothesis(
+            tmp_path / "paperA",
+            "../../../../../../tmp/dsaudit/PWNED",
+            "x",
+            "own",
+        )
+
+
 def test_scaffold_paper_creates_root_and_registers(tmp_path: Path) -> None:
     layout = Layout.default(tmp_path)
     layout.research_root.mkdir(parents=True)

--- a/defendable-science/tests/test_check.py
+++ b/defendable-science/tests/test_check.py
@@ -797,6 +797,21 @@ def test_tables_check_flags_a_registry_that_holds_no_table() -> None:
     assert "paper-id" in findings[0].remedy
 
 
+def test_tables_check_flags_a_paper_id_that_is_a_path_instead_of_a_slug() -> None:
+    """A path typed into the paper-id column is exactly what this check exists to catch.
+
+    (defendable-science#182, review round 3) It must report an `invalid`
+    Finding, not raise `LayoutError` out of the check itself.
+    """
+    files = _scaffolded()
+    files[LAYOUT.papers_registry] = _registry("| docs/dc | | bench |\n")
+
+    findings = c.check_tables(LAYOUT, FakeProbe(files))
+
+    assert [f.severity for f in findings] == ["invalid"]
+    assert "docs/dc" in findings[0].message
+
+
 def test_tables_check_surfaces_the_parsers_own_error_for_a_malformed_table() -> None:
     files = _scaffolded()
     files[LAYOUT.papers_registry] = (

--- a/defendable-science/tests/test_digest_artifact.py
+++ b/defendable-science/tests/test_digest_artifact.py
@@ -557,6 +557,19 @@ def test_append_log_entry_creates_the_directory_and_returns_its_path(
     assert written.read_text(encoding="utf-8") == "body: 1\n"
 
 
+def test_append_log_entry_rejects_a_traversal_stem(tmp_path: Path) -> None:
+    """`stem` is a single path segment, not a sub-path (defendable-science#182)."""
+    from defendable_science.defend.record import RecordError, append_log_entry
+
+    with pytest.raises(RecordError, match="stem"):
+        append_log_entry(
+            tmp_path / "log",
+            DATE,
+            "../../../../../../tmp/dsaudit/PWNED",
+            "body: 1\n",
+        )
+
+
 def test_the_block_is_appended_after_trailing_blank_lines_not_among_them(
     tmp_path: Path,
 ) -> None:

--- a/defendable-science/tests/test_digest_artifact.py
+++ b/defendable-science/tests/test_digest_artifact.py
@@ -570,6 +570,25 @@ def test_append_log_entry_rejects_a_traversal_stem(tmp_path: Path) -> None:
         )
 
 
+def test_append_log_entry_rejects_a_traversal_date(tmp_path: Path) -> None:
+    """`date` is interpolated into the same filename as `stem`.
+
+    It gets the same guard even though no current caller passes an untrusted
+    value (defendable-science#182, review round 3) -- a future `--date`
+    option (the pattern already exists elsewhere) must not reopen this at a
+    boundary that looks guarded.
+    """
+    from defendable_science.defend.record import RecordError, append_log_entry
+
+    with pytest.raises(RecordError, match="date"):
+        append_log_entry(
+            tmp_path / "log",
+            "../../../../../../tmp/dsaudit/PWNED",
+            "stem",
+            "body: 1\n",
+        )
+
+
 def test_the_block_is_appended_after_trailing_blank_lines_not_among_them(
     tmp_path: Path,
 ) -> None:

--- a/defendable-science/tests/test_digest_cli.py
+++ b/defendable-science/tests/test_digest_cli.py
@@ -165,6 +165,31 @@ def test_axes_outside_a_paper_exits_2_naming_the_option(
     assert "--paper" in result.stderr
 
 
+def test_axes_a_traversal_paper_option_exits_1_not_a_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--paper ../x` used to reach `Layout.positioning` uncaught.
+
+    It goes through `_positioning_context`, which every `extract`/
+    `depth cells` command resolves through (defendable-science#182, review
+    round 3).
+
+    `CliRunner`'s default `catch_exceptions=True` swallows *any* exception
+    into `exit_code == 1` with nothing written to stdout/stderr, so checking
+    for the string "Traceback" there proves nothing either way -- the real
+    discriminator is `type(result.exception)`: a deliberate `typer.Exit`
+    always surfaces as `SystemExit`, while an unhandled domain exception
+    surfaces as itself.
+    """
+    root = _repo(tmp_path)
+    monkeypatch.chdir(root)
+    result = runner.invoke(
+        app, ["digest", "extract", "axes", "--paper", "../../../../tmp/PWNED"]
+    )
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
 def test_axes_positioning_option_overrides_the_layout(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -339,6 +364,28 @@ def test_cells_missing_citekey_option_exits_2(
     monkeypatch.chdir(_repo(tmp_path))
     result = runner.invoke(app, ["digest", "extract", "cells"])
     assert result.exit_code == 2
+
+
+def test_cells_a_traversal_citekey_is_reported_not_raised(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--citekey ../x` used to raise `LayoutError` before the JSON report existed.
+
+    (defendable-science#182, review round 3) The command's whole contract is
+    a JSON report plus exit 1, never a traceback.
+    """
+    monkeypatch.chdir(_repo(tmp_path))
+    result = runner.invoke(
+        app,
+        ["digest", "extract", "cells", "--citekey", "../../../../tmp/PWNED"],
+    )
+    assert result.exit_code == 1
+    assert "Traceback" not in (result.stdout + result.stderr)
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert payload["cells"] is None
+    assert payload["artifact"] is None
+    assert payload["error"]
 
 
 # --- record: the happy path ------------------------------------------------------
@@ -692,6 +739,43 @@ def test_record_reports_what_landed_when_one_paper_fails_to_write(
     # The good paper really did land, exactly as the report says.
     assert layout.digest("sill1997monotonic").is_file()
     assert len(list((root / "log").iterdir())) == 1
+
+
+def test_record_reports_a_traversal_citekey_and_still_records_the_rest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One citekey that is not a single path segment must not abort the sweep.
+
+    `layout.digest(citekey)` used to sit outside the per-citekey `try`
+    (defendable-science#182, review round 3), so the `LayoutError` it now
+    raises for a bad citekey escaped uncaught -- aborting mid-batch, which is
+    precisely the outcome the surrounding comment says must never happen.
+    """
+    root = _repo(tmp_path)
+    layout = Layout.default(root.resolve())
+    cells = [
+        *GOOD_CELLS,
+        {
+            "citekey": "../../../../tmp/PWNED",
+            "axis": "guarantee type",
+            "value": "v",
+            "locator": "§1",
+        },
+        {
+            "citekey": "../../../../tmp/PWNED",
+            "axis": "partial monotonicity",
+            "value": "w",
+            "locator": "§2",
+        },
+    ]
+    result = _record(root, cells, monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert [r["citekey"] for r in payload["recorded"]] == ["sill1997monotonic"]
+    assert [e["citekey"] for e in payload["errors"]] == ["../../../../tmp/PWNED"]
+    assert layout.digest("sill1997monotonic").is_file()
 
 
 # --- record: the triage writeback --------------------------------------------------

--- a/defendable-science/tests/test_digest_depth_cells_cli.py
+++ b/defendable-science/tests/test_digest_depth_cells_cli.py
@@ -260,6 +260,38 @@ def test_record_refuses_a_missing_depth_digest(
     assert payload["errors"][0]["citekey"] == CITEKEY
 
 
+def test_record_reports_a_traversal_citekey_and_still_records_the_rest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same shape and same fix as `test_digest_cli.py`'s sibling for `extract record`.
+
+    (defendable-science#182, review round 3) The sweep posture this file's
+    own module docstring promises must survive a citekey that is not a
+    single path segment.
+    """
+    root = _repo(tmp_path)
+    _seed_depth_digest(root)
+    bad_key = "../../../../tmp/PWNED"
+    cells = [
+        *GOOD_CELLS,
+        {"citekey": bad_key, "axis": "guarantee type", "value": "v", "locator": "§1"},
+        {
+            "citekey": bad_key,
+            "axis": "partial monotonicity",
+            "value": "not-addressed",
+            "justification": "n/a",
+        },
+    ]
+    result = _record(root, cells, monkeypatch=monkeypatch)
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert [r["citekey"] for r in payload["recorded"]] == [CITEKEY]
+    assert [e["citekey"] for e in payload["errors"]] == [bad_key]
+    assert Layout.default(root.resolve()).digest(CITEKEY).is_file()
+
+
 def test_record_refuses_an_artifact_with_no_understanding_block(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/defendable-science/tests/test_digest_render.py
+++ b/defendable-science/tests/test_digest_render.py
@@ -620,6 +620,29 @@ def test_render_reports_an_unreadable_artifact_and_still_lands_the_rest(
     assert "bad2021" not in text  # no row invented for a paper we could not read
 
 
+def test_render_reports_a_traversal_citekey_and_still_lands_the_rest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same shape and fix as the unreadable-artifact test above.
+
+    (defendable-science#182, review round 3) `layout.digest(citekey)` used
+    to sit outside `_cells_to_render`'s per-citekey `try`, so a citekey that
+    is not a single path segment escaped uncaught instead of landing in
+    `errors`.
+    """
+    root = _repo(tmp_path)
+    _extract(root, "good2020", {"guarantee type": "one", "partial monotonicity": "no"})
+    bad_key = "../../../../tmp/PWNED"
+    result = _run(root, monkeypatch, "--citekey", "good2020", "--citekey", bad_key)
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    payload = json.loads(result.stdout)
+    assert payload["rendered"] == ["good2020"]
+    assert [e["citekey"] for e in payload["errors"]] == [bad_key]
+    text = _positioning(root).read_text(encoding="utf-8")
+    assert "| good2020 |" in text
+
+
 def test_render_refuses_a_placeholder_matrix_without_writing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/defendable-science/tests/test_layout.py
+++ b/defendable-science/tests/test_layout.py
@@ -63,6 +63,58 @@ def test_positioning_is_a_staged_paper_document() -> None:
     out = lay.Layout.default(Path("/repo"))
 
     assert lay.STAGED_DOCUMENTS[out.positioning("p1").name] == "paper"
+
+
+# --- gap 5: identifier-taking paths reject a traversal attempt (#182) -------
+
+_TRAVERSAL = "../../../../../../tmp/dsaudit/PWNED"
+
+
+def test_digest_rejects_a_traversal_citekey() -> None:
+    """A citekey is a single path segment, not a sub-path.
+
+    Reproduces #182: `Layout.digest(_TRAVERSAL).resolve()` used to land at
+    `/tmp/dsaudit/PWNED.md`, outside `repo_root` entirely.
+    """
+    out = lay.Layout.default(Path("/repo"))
+    with pytest.raises(lay.LayoutError, match="citekey"):
+        out.digest(_TRAVERSAL)
+
+
+def test_paper_dir_rejects_a_traversal_paper_id() -> None:
+    """`paper_dir` is the shared root of the four derived per-paper methods.
+
+    Guarding it here covers backlog/hypotheses_dir/paper_docs_dir/positioning
+    too, since they all call through it.
+    """
+    out = lay.Layout.default(Path("/repo"))
+    with pytest.raises(lay.LayoutError, match="paper_id"):
+        out.paper_dir(_TRAVERSAL)
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["backlog", "hypotheses_dir", "paper_docs_dir", "positioning"],
+)
+def test_paper_dir_derived_methods_reject_a_traversal_paper_id(method: str) -> None:
+    out = lay.Layout.default(Path("/repo"))
+    with pytest.raises(lay.LayoutError, match="paper_id"):
+        getattr(out, method)(_TRAVERSAL)
+
+
+def test_hypothesis_dir_rejects_a_traversal_paper_id_or_slug() -> None:
+    out = lay.Layout.default(Path("/repo"))
+    with pytest.raises(lay.LayoutError, match="paper_id"):
+        out.hypothesis_dir(_TRAVERSAL, "a-real-slug")
+    with pytest.raises(lay.LayoutError, match="slug"):
+        out.hypothesis_dir("depth-collapse", _TRAVERSAL)
+
+
+def test_paper_id_containing_a_plain_slash_is_rejected_too() -> None:
+    """Not just `..` — any embedded separator would address a sub-path."""
+    out = lay.Layout.default(Path("/repo"))
+    with pytest.raises(lay.LayoutError, match="paper_id"):
+        out.paper_dir("depth-collapse/../../etc")
     assert out.positioning("p1").parent == out.paper_docs_dir("p1")
 
 

--- a/defendable-science/tests/test_layout.py
+++ b/defendable-science/tests/test_layout.py
@@ -63,6 +63,7 @@ def test_positioning_is_a_staged_paper_document() -> None:
     out = lay.Layout.default(Path("/repo"))
 
     assert lay.STAGED_DOCUMENTS[out.positioning("p1").name] == "paper"
+    assert out.positioning("p1").parent == out.paper_docs_dir("p1")
 
 
 # --- gap 5: identifier-taking paths reject a traversal attempt (#182) -------
@@ -115,7 +116,6 @@ def test_paper_id_containing_a_plain_slash_is_rejected_too() -> None:
     out = lay.Layout.default(Path("/repo"))
     with pytest.raises(lay.LayoutError, match="paper_id"):
         out.paper_dir("depth-collapse/../../etc")
-    assert out.positioning("p1").parent == out.paper_docs_dir("p1")
 
 
 def test_rel_renders_a_path_for_display_and_tolerates_an_outside_path() -> None:

--- a/defendable-science/tests/test_paths.py
+++ b/defendable-science/tests/test_paths.py
@@ -28,6 +28,10 @@ def test_accepts_an_ordinary_identifier(value: str) -> None:
         "/etc/passwd",
         "foo\\bar",
         "..\\..\\PWNED",
+        "a\x00b",
+        "a\nb",
+        "a\tb",
+        "\x1f",
     ],
 )
 def test_rejects_anything_that_is_not_a_single_path_segment(value: str) -> None:

--- a/defendable-science/tests/test_paths.py
+++ b/defendable-science/tests/test_paths.py
@@ -1,0 +1,45 @@
+"""Tests for `core.paths.require_path_segment` (defendable-science, gap 5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from defendable_science.core import paths
+
+
+class _BoomError(Exception):
+    """A stand-in for a module's own domain error."""
+
+
+@pytest.mark.parametrize("value", ["W1", "sill1997monotonic", "hyp-01", "a.b_c-1"])
+def test_accepts_an_ordinary_identifier(value: str) -> None:
+    assert paths.require_path_segment(value, what="citekey", error=_BoomError) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        ".",
+        "..",
+        "../etc/passwd",
+        "../../../../../../tmp/dsaudit/PWNED",
+        "foo/bar",
+        "/etc/passwd",
+        "foo\\bar",
+        "..\\..\\PWNED",
+    ],
+)
+def test_rejects_anything_that_is_not_a_single_path_segment(value: str) -> None:
+    with pytest.raises(_BoomError, match=r"citekey"):
+        paths.require_path_segment(value, what="citekey", error=_BoomError)
+
+
+def test_error_message_names_the_offending_value() -> None:
+    with pytest.raises(_BoomError, match=r"'\.\.'"):
+        paths.require_path_segment("..", what="paper_id", error=_BoomError)
+
+
+def test_error_uses_the_caller_supplied_label() -> None:
+    with pytest.raises(_BoomError, match=r"slug"):
+        paths.require_path_segment("a/b", what="slug", error=_BoomError)

--- a/defendable-science/tests/test_paths.py
+++ b/defendable-science/tests/test_paths.py
@@ -32,6 +32,9 @@ def test_accepts_an_ordinary_identifier(value: str) -> None:
         "a\nb",
         "a\tb",
         "\x1f",
+        "C:PWNED",
+        "C:",
+        "c:PWNED",
     ],
 )
 def test_rejects_anything_that_is_not_a_single_path_segment(value: str) -> None:

--- a/defendable-science/tests/test_sampling.py
+++ b/defendable-science/tests/test_sampling.py
@@ -535,6 +535,41 @@ def test_a_sampled_paper_whose_cells_could_not_be_read_is_not_marked_checked(
     assert _block(root, "b2")["extraction"]["in-sample"] is True
 
 
+def test_apply_reports_a_traversal_citekey_and_still_checks_the_rest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One citekey that is not a single path segment must not abort the batch.
+
+    `layout.digest(key)` used to sit outside the per-citekey `try` in both
+    `_read_sampled_cells` and `_apply_verdict` (defendable-science#182,
+    review round 3); a two-member batch is drawn whole
+    (`select_sample`'s size floor), so this exercises both in one run.
+    """
+    root = _repo(tmp_path, ["good1"])
+    bad_key = "../../../../tmp/PWNED"
+    result = _run(
+        root,
+        "--citekey",
+        "good1",
+        "--citekey",
+        bad_key,
+        "--verdict",
+        "failed",
+        monkeypatch=monkeypatch,
+    )
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    # The bad key fails identically in both `_read_sampled_cells` and
+    # `_apply_verdict`; `_note_error`'s dedup must collapse the two into one
+    # entry ("reporting it twice would suggest two problems").
+    assert [e["citekey"] for e in payload["errors"]] == [bad_key]
+    # A `failed` verdict lands on the run regardless — that is what "failed"
+    # means (mirrors test_a_sampled_paper_whose_cells_could_not_be_read...).
+    assert _block(root, "good1")["extraction"]["batch-check"] == "failed"
+
+
 def test_an_unknown_verdict_is_refused(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## What

Closes gap 5 of the codebase audit: an externally-derived identifier (`--citekey`, a
backlog/registry `paper_id`) reached the filesystem unchecked, letting a traversal
attempt write outside the repository entirely.

## Details

**Reproduced against `main` before the fix:**

```python
Layout.digest("../../../../../../tmp/dsaudit/PWNED").resolve()
# -> /tmp/dsaudit/PWNED.md — escapes repo_root entirely
```

**Not a missing capability — an inconsistency.** `literature/acquire.py`'s `_safe_name`
already sanitizes a citekey before it touches the acquisition cache. The rule was applied to
one reader and not the sibling reader (`Layout`) that needed it just as much — the same shape
as the JSON-boundary fix in #169/#179.

**New shared guard, `core/paths.py`.** `require_path_segment(value, *, what, error)` rejects
anything that isn't a single filesystem path segment (empty, `.`/`..`, or containing a
separator), raising the caller's own error type — mirrors the `core/models.py` pattern this
repo already established for the JSON parsing boundary (`error=SomeErrorType`), so no bare
exception leaks across a module.

**Reject, not coerce — a deliberate choice, not a default.** `_safe_name` coerces (replaces
bad characters, always succeeds); `_relative` (the existing `config.yml` path check) rejects.
Went with reject: `Layout` is a lower-level, more widely used boundary than the acquisition
cache, and silently coercing a bad identifier could quietly redirect a paper's artifacts into
the wrong directory with no error — worse than a loud failure, for a tool whose whole point is
a trustworthy record.

**Applied at:**
- `Layout.digest` (citekey)
- `Layout.paper_dir` (paper_id) — the shared root of `backlog`/`hypotheses_dir`/
  `paper_docs_dir`/`positioning`, so this one guard covers all four
- `Layout.hypothesis_dir` (slug, in addition to paper_id via `paper_dir`)
- `defend/record.py`'s `append_log_entry` (stem) — the other site the audit named

**Left alone, deliberately:** `acquire.py`'s `_safe_name` keeps its existing coercion for the
acquisition cache — a separate, already-working boundary, not part of this fix.

Every regression test reproduces the exact traversal string from the issue and confirms it
fails against pre-fix code before the guard was added.

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
