### PR TITLE
test(literature): pin both halves of the malformed-body reason string (closes #178)

### DIFF
--- a/defendable-science/tests/test_literature.py
+++ b/defendable-science/tests/test_literature.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 import pytest
@@ -1226,6 +1227,8 @@ def test_resolve_malformed_200_body_is_transport_error_not_a_miss() -> None:
     rec = graph.resolve("W1", client=client)
     assert rec["resolved"] is False
     assert rec["transport_error"] is True
+    pattern = rf"{re.escape('https://api.openalex.org/works/W1')}: <root>: Input should be a valid dictionary"
+    assert re.search(pattern, rec["reason"])
 
 
 # --- S2 leg fix wave: converted halfway, whole-branch review (#169) ---------
@@ -1305,6 +1308,8 @@ def test_resolve_s2_crossref_malformed_body_is_transport_error_not_a_miss() -> N
     rec = graph.resolve("CorpusId:7", client=client)
     assert rec["resolved"] is False
     assert rec["transport_error"] is True
+    pattern = rf"{re.escape(f'{_S2}/paper/CorpusId:7')}: <root>: Input should be a valid dictionary"
+    assert re.search(pattern, rec["reason"])
 
 
 # --- final-review fix wave: dropped null guards (default_factory covers a


### PR DESCRIPTION
## What

Pins the full validation-failure message — both the failing URL and the
reason text — on the two `resolve()` transport-error regression tests
(OpenAlex and S2 crossref legs), closing a gap where a regression that
emptied or truncated `rec["reason"]` could have stayed green.

## Details

- `test_resolve_malformed_200_body_is_transport_error_not_a_miss` and
  `test_resolve_s2_crossref_malformed_body_is_transport_error_not_a_miss`
  previously asserted only the `transport_error` discriminator.
- Added `re.search` assertions against `rec["reason"]` following the same
  idiom already used in `tests/test_keys.py`.
- Verified each assertion is load-bearing: temporarily dropped the URL
  from `_explain`'s output in `core/models.py`, confirmed both tests fail,
  then reverted — no production code change ships in this PR.
- `uv run pytest -q` (100% statement+branch coverage gate), `uv run mypy`,
  `uv run ruff check`, and `uv run ruff format --check` all pass.

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
