### PR TITLE
fix(literature,dataset): stop two silent-wrong-value boundaries

### DIFF
--- a/defendable-science/defendable_science/dataset/manifest.py
+++ b/defendable-science/defendable_science/dataset/manifest.py
@@ -268,8 +268,17 @@ def _decode_retrieval(raw: Any, where: str) -> Retrieval:
     """Decode a ``retrieval`` block."""
     if not isinstance(raw, dict):
         raise ManifestError(f"{where}: 'retrieval' must be a mapping")
+    kind_raw = raw.get("kind")
     return Retrieval(
-        kind=_str_or_error(raw.get("kind", ""), where, "retrieval.kind"),
+        # An explicit `kind: null` must resolve the same as an absent key —
+        # both mean "unset", and _decode_entry already treats a null
+        # `retrieval:` block itself as absent. Routing null through
+        # `_str_or_error` directly would abort the whole load() for a field
+        # that has a defined default, instead of the one clean validate()
+        # error the missing-key case produces.
+        kind=_str_or_error(
+            "" if kind_raw is None else kind_raw, where, "retrieval.kind"
+        ),
         url=_opt_str(raw.get("url")),
     )
 

--- a/defendable-science/defendable_science/dataset/manifest.py
+++ b/defendable-science/defendable_science/dataset/manifest.py
@@ -221,15 +221,44 @@ def _int_or_error(value: Any, where: str, fieldname: str) -> int | None:
         ) from exc
 
 
+def _str_or_error(value: Any, where: str, fieldname: str) -> str:
+    """Coerce a required field to ``str``, raising :class:`ManifestError` on shape.
+
+    Accepts a real ``str`` unchanged, and coerces a bare ``int``/``float`` (a
+    human writing ``id: 2024`` in YAML is realistic and unambiguous). A
+    ``list`` or ``dict`` is never silently stringified — the old
+    ``str(value)`` behavior turned a mistyped ``path: [a, b]`` into the
+    plausible-looking but wrong string ``"['a', 'b']"``, which then failed
+    far downstream instead of here. ``bool`` is rejected too: it is a
+    subclass of ``int`` but ``str(True)`` is not a value anyone meant to
+    write in this field.
+
+    :param value: The raw value to coerce.
+    :param where: Location prefix for the error message.
+    :param fieldname: The field name to name in the error message.
+    :returns: The coerced string.
+    :raises ManifestError: If `value` is not a string or scalar number.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return str(value)
+    raise ManifestError(
+        f"{where}: '{fieldname}' must be a string, got {type(value).__name__}: {value!r}"
+    )
+
+
 def _decode_file_ref(raw: Any, where: str) -> FileRef:
     """Decode one ``files[]`` element, raising :class:`ManifestError` on shape."""
     if not isinstance(raw, dict):
         raise ManifestError(f"{where}: each file must be a mapping")
     try:
-        path = str(raw["path"])
-        sha256 = str(raw["sha256"])
+        path_raw = raw["path"]
+        sha256_raw = raw["sha256"]
     except KeyError as exc:
         raise ManifestError(f"{where}: file missing required key {exc}") from exc
+    path = _str_or_error(path_raw, where, "path")
+    sha256 = _str_or_error(sha256_raw, where, "sha256")
     return FileRef(
         path=path, sha256=sha256, size=_int_or_error(raw.get("size"), where, "size")
     )
@@ -240,7 +269,7 @@ def _decode_retrieval(raw: Any, where: str) -> Retrieval:
     if not isinstance(raw, dict):
         raise ManifestError(f"{where}: 'retrieval' must be a mapping")
     return Retrieval(
-        kind=str(raw.get("kind", "")),
+        kind=_str_or_error(raw.get("kind", ""), where, "retrieval.kind"),
         url=_opt_str(raw.get("url")),
     )
 
@@ -268,7 +297,7 @@ def _decode_entry(raw: Any, index: int) -> DatasetEntry:
         raise ManifestError(f"{where}: entry must be a mapping")
     if "id" not in raw:
         raise ManifestError(f"{where}: entry missing required key 'id'")
-    entry_id = str(raw["id"])
+    entry_id = _str_or_error(raw["id"], where, "id")
     where = f"entry '{entry_id}'"
 
     retrieval = None

--- a/defendable-science/defendable_science/literature/acquire.py
+++ b/defendable-science/defendable_science/literature/acquire.py
@@ -141,6 +141,15 @@ QUARANTINE_YEAR_WINDOW = 5
 _PUNCT = re.compile(r"[^\w\s]", flags=re.UNICODE)
 _SPACE = re.compile(r"\s+")
 
+#: OpenAlex's ``filter`` grammar reserves ``,`` (AND) and ``|`` (OR) between
+#: terms. A human-authored title containing either would silently splice a
+#: second filter clause into the query instead of erroring, so both are
+#: replaced with a space before interpolation. ``title.search`` is full-text,
+#: so dropping these characters narrows nothing that matters, and the
+#: three-way match gate re-checks the title against the real record
+#: afterwards (ADR-0037) — a query-time approximation is safe here.
+_FILTER_RESERVED = re.compile(r"[,|]")
+
 
 @dataclass
 class Candidate:
@@ -726,9 +735,10 @@ def sibling_candidates(
     if entry.title is None:
         return []
     anchor = _short_id(work.get("id"))
+    search = _FILTER_RESERVED.sub(" ", entry.title)
     page = client.get_json(
         f"{OPENALEX}/works",
-        {"filter": f"title.search:{entry.title}", "per-page": str(SEARCH_LIMIT)},
+        {"filter": f"title.search:{search}", "per-page": str(SEARCH_LIMIT)},
     )
     if not isinstance(page, dict):
         return []

--- a/defendable-science/defendable_science/literature/acquire.py
+++ b/defendable-science/defendable_science/literature/acquire.py
@@ -150,6 +150,14 @@ _SPACE = re.compile(r"\s+")
 #: afterwards (ADR-0037) — a query-time approximation is safe here.
 _FILTER_RESERVED = re.compile(r"[,|]")
 
+#: OpenAlex additionally reserves a *leading* ``!`` on a filter value as
+#: negation — ``title.search:!Kung`` means "does not contain Kung", not
+#: "contains !Kung". Only the leading position is reserved (a mid-title
+#: ``!``, e.g. "Kung! Fu", is just full-text content), so only a leading run
+#: of ``!`` is stripped rather than every ``!`` in the title — narrower than
+#: the comma/pipe case, where the character is reserved everywhere.
+_LEADING_BANG = re.compile(r"^!+\s*")
+
 
 @dataclass
 class Candidate:
@@ -735,7 +743,13 @@ def sibling_candidates(
     if entry.title is None:
         return []
     anchor = _short_id(work.get("id"))
-    search = _FILTER_RESERVED.sub(" ", entry.title)
+    search = _FILTER_RESERVED.sub(" ", entry.title).lstrip()
+    search = _LEADING_BANG.sub("", search).strip()
+    if not search:
+        # A title made entirely of reserved characters (",", "|", "!") would
+        # otherwise collapse to an empty or all-whitespace search, sending an
+        # unbounded `title.search:` query instead of a targeted one.
+        return []
     page = client.get_json(
         f"{OPENALEX}/works",
         {"filter": f"title.search:{search}", "per-page": str(SEARCH_LIMIT)},

--- a/defendable-science/defendable_science/literature/acquire.py
+++ b/defendable-science/defendable_science/literature/acquire.py
@@ -153,10 +153,16 @@ _FILTER_RESERVED = re.compile(r"[,|]")
 #: OpenAlex additionally reserves a *leading* ``!`` on a filter value as
 #: negation — ``title.search:!Kung`` means "does not contain Kung", not
 #: "contains !Kung". Only the leading position is reserved (a mid-title
-#: ``!``, e.g. "Kung! Fu", is just full-text content), so only a leading run
-#: of ``!`` is stripped rather than every ``!`` in the title — narrower than
-#: the comma/pipe case, where the character is reserved everywhere.
-_LEADING_BANG = re.compile(r"^!+\s*")
+#: ``!``, e.g. "Kung! Fu", is just full-text content), so only the leading
+#: run is stripped rather than every ``!`` in the title — narrower than the
+#: comma/pipe case, where the character is reserved everywhere.
+#:
+#: The class spans whitespace as well as ``!`` because :data:`_FILTER_RESERVED`
+#: runs *first* and substitutes a space for every ',' and '|'. That can
+#: manufacture a gap inside what was a single leading run — "!,!Kung" becomes
+#: "! !Kung" — and a pattern anchored to one unbroken run would leave the
+#: second ``!`` in place, inverting the query after all.
+_LEADING_BANG = re.compile(r"^[!\s]+")
 
 
 @dataclass
@@ -743,8 +749,7 @@ def sibling_candidates(
     if entry.title is None:
         return []
     anchor = _short_id(work.get("id"))
-    search = _FILTER_RESERVED.sub(" ", entry.title).lstrip()
-    search = _LEADING_BANG.sub("", search).strip()
+    search = _LEADING_BANG.sub("", _FILTER_RESERVED.sub(" ", entry.title)).strip()
     if not search:
         # A title made entirely of reserved characters (",", "|", "!") would
         # otherwise collapse to an empty or all-whitespace search, sending an

--- a/defendable-science/tests/test_acquire.py
+++ b/defendable-science/tests/test_acquire.py
@@ -710,6 +710,13 @@ def test_rung_4_comma_in_title_does_not_split_the_filter_query() -> None:
     An unescaped comma in the title would silently turn one
     ``title.search:`` clause into two ANDed clauses instead of raising, so
     the request actually sent must carry exactly one ``title.search:`` term.
+
+    The load-bearing check is the absence of ',' anywhere in the filter
+    value: counting terms with the ``title.search:`` prefix (as the first
+    assertion below does) is *not* discriminating on its own — with the sub
+    reverted, ``"title.search:Deep Learning, Revisited".split(",")`` still
+    yields exactly one element that starts with that prefix, so that
+    assertion alone would pass even with the bug present.
     """
     client = FakeClient({"/works": {"results": []}})
     entry = _entry(title="Deep Learning, Revisited")
@@ -720,7 +727,7 @@ def test_rung_4_comma_in_title_does_not_split_the_filter_query() -> None:
     search_terms = params["filter"].split(",")
     title_search_terms = [t for t in search_terms if t.startswith("title.search:")]
     assert len(title_search_terms) == 1
-    assert "," not in params["filter"].split("title.search:", 1)[1]
+    assert "," not in params["filter"]
 
 
 def test_rung_4_pipe_in_title_does_not_split_the_filter_query() -> None:
@@ -733,6 +740,37 @@ def test_rung_4_pipe_in_title_does_not_split_the_filter_query() -> None:
     assert params is not None
     assert params["filter"].count("title.search:") == 1
     assert "|" not in params["filter"]
+
+
+def test_rung_4_leading_bang_in_title_does_not_invert_the_search() -> None:
+    """OpenAlex reserves a leading '!' on a filter value for negation.
+
+    An unescaped leading '!' would silently turn "does this title" into
+    "does NOT contain this title", returning an empty rung instead of
+    erroring or matching. The request actually sent must not carry that '!'.
+    """
+    client = FakeClient({"/works": {"results": []}})
+    entry = _entry(title="!Kung-Fu Panda")
+    a.sibling_candidates(entry, _work("sill1997"), client=client)
+    assert len(client.calls) == 1
+    _url, params = client.calls[0]
+    assert params is not None
+    assert params["filter"] == "title.search:Kung-Fu Panda"
+
+
+def test_rung_4_all_reserved_character_title_short_circuits_without_a_request() -> None:
+    """A title made only of reserved characters must not send an unbounded query.
+
+    Stripping ',', '|', and a leading '!' from a title like "!,|" leaves
+    nothing to search on; sending `title.search:` with no value would be an
+    unbounded query rather than a targeted one, so the rung must return no
+    candidates without calling the client at all.
+    """
+    client = FakeClient({"/works": {"results": []}})
+    entry = _entry(title="!,|")
+    result = a.sibling_candidates(entry, _work("sill1997"), client=client)
+    assert result == []
+    assert client.calls == []
 
 
 def test_rung_5_builds_candidates_from_the_arxiv_atom_feed() -> None:

--- a/defendable-science/tests/test_acquire.py
+++ b/defendable-science/tests/test_acquire.py
@@ -701,6 +701,40 @@ def test_rung_4_proposes_a_subtitle_extended_sibling_and_the_gate_decides() -> N
         assert record.verdict == a.QUARANTINE  # author+year decide, not the filter
 
 
+# --- #173: a title with a filter-reserved character must not split the query -
+
+
+def test_rung_4_comma_in_title_does_not_split_the_filter_query() -> None:
+    """OpenAlex's ``filter`` grammar reserves ',' for AND between terms.
+
+    An unescaped comma in the title would silently turn one
+    ``title.search:`` clause into two ANDed clauses instead of raising, so
+    the request actually sent must carry exactly one ``title.search:`` term.
+    """
+    client = FakeClient({"/works": {"results": []}})
+    entry = _entry(title="Deep Learning, Revisited")
+    a.sibling_candidates(entry, _work("sill1997"), client=client)
+    assert len(client.calls) == 1
+    _url, params = client.calls[0]
+    assert params is not None
+    search_terms = params["filter"].split(",")
+    title_search_terms = [t for t in search_terms if t.startswith("title.search:")]
+    assert len(title_search_terms) == 1
+    assert "," not in params["filter"].split("title.search:", 1)[1]
+
+
+def test_rung_4_pipe_in_title_does_not_split_the_filter_query() -> None:
+    """OpenAlex's ``filter`` grammar reserves '|' for OR within a term."""
+    client = FakeClient({"/works": {"results": []}})
+    entry = _entry(title="A|B testing")
+    a.sibling_candidates(entry, _work("sill1997"), client=client)
+    assert len(client.calls) == 1
+    _url, params = client.calls[0]
+    assert params is not None
+    assert params["filter"].count("title.search:") == 1
+    assert "|" not in params["filter"]
+
+
 def test_rung_5_builds_candidates_from_the_arxiv_atom_feed() -> None:
     feed = (
         '<?xml version="1.0"?>'

--- a/defendable-science/tests/test_acquire.py
+++ b/defendable-science/tests/test_acquire.py
@@ -758,6 +758,24 @@ def test_rung_4_leading_bang_in_title_does_not_invert_the_search() -> None:
     assert params["filter"] == "title.search:Kung-Fu Panda"
 
 
+def test_rung_4_bang_run_split_by_a_reserved_character_is_still_stripped() -> None:
+    """Substituting ',' / '|' first can *manufacture* a second leading '!'.
+
+    ``_FILTER_RESERVED`` turns ',' and '|' into spaces before the leading-'!'
+    strip runs, so "!,!Kung Fu" becomes "! !Kung Fu" — two bang-runs
+    separated by a space. A pattern matching only a single run leaves the
+    second '!' in place, the query inverts after all, and rung 4 returns an
+    empty result indistinguishable from a genuine miss.
+    """
+    client = FakeClient({"/works": {"results": []}})
+    entry = _entry(title="!,!Kung Fu")
+    a.sibling_candidates(entry, _work("sill1997"), client=client)
+    assert len(client.calls) == 1
+    _url, params = client.calls[0]
+    assert params is not None
+    assert params["filter"] == "title.search:Kung Fu"
+
+
 def test_rung_4_all_reserved_character_title_short_circuits_without_a_request() -> None:
     """A title made only of reserved characters must not send an unbounded query.
 

--- a/defendable-science/tests/test_manifest.py
+++ b/defendable-science/tests/test_manifest.py
@@ -350,6 +350,24 @@ def test_decode_retrieval_kind_list_raises_naming_entry_and_field(
         m.load(_write(tmp_path, text))
 
 
+def test_decode_retrieval_null_kind_matches_the_absent_key_case(
+    tmp_path: Path,
+) -> None:
+    """An explicit ``kind: null`` must not abort load() the way a wrong type does.
+
+    It means the same thing as an absent key — `_decode_entry` already treats
+    a null `retrieval:` block itself as absent — so both must load cleanly
+    and produce the identical single validate() error, not a `ManifestError`
+    that discards the rest of the report.
+    """
+    null_text = "datasets:\n  - id: x\n    retrieval: {kind: null, url: http://a}\n"
+    absent_text = "datasets:\n  - id: x\n    retrieval: {url: http://a}\n"
+    null_report = m.validate(m.load(_write(tmp_path, null_text)))
+    absent_report = m.validate(m.load(_write(tmp_path, absent_text)))
+    assert null_report.errors == absent_report.errors
+    assert any("retrieval.kind" in e for e in null_report.errors)
+
+
 def test_decode_entry_id_list_raises_naming_the_field(tmp_path: Path) -> None:
     text = "datasets:\n  - id: [a, b]\n"
     with pytest.raises(
@@ -370,6 +388,29 @@ def test_decode_entry_id_accepts_a_bare_integer(tmp_path: Path) -> None:
     text = f"datasets:\n  - id: 2024\n    files:\n      - path: p\n        sha256: {_HEX}\n"
     manifest = m.load(_write(tmp_path, text))
     assert manifest.datasets[0].id == "2024"
+
+
+def test_decode_entry_id_accepts_a_bare_float(tmp_path: Path) -> None:
+    """``_str_or_error`` deliberately accepts a bare float, coercing it to str."""
+    text = (
+        f"datasets:\n  - id: 1.5\n    files:\n      - path: p\n        sha256: {_HEX}\n"
+    )
+    manifest = m.load(_write(tmp_path, text))
+    assert manifest.datasets[0].id == "1.5"
+
+
+def test_decode_entry_id_bool_raises_naming_the_field(tmp_path: Path) -> None:
+    """``bool`` is an ``int`` subclass but ``_str_or_error`` rejects it anyway.
+
+    Pins the ``not isinstance(value, bool)`` guard: a YAML ``true``/``false``
+    scalar must raise ``ManifestError`` naming the field and its type, not
+    silently coerce to the string ``"True"``/``"False"``.
+    """
+    text = "datasets:\n  - id: true\n"
+    with pytest.raises(
+        m.ManifestError, match=r"datasets\[0\]: 'id' must be a string, got bool"
+    ):
+        m.load(_write(tmp_path, text))
 
 
 def test_validate_conditional_and_shape_errors() -> None:

--- a/defendable-science/tests/test_manifest.py
+++ b/defendable-science/tests/test_manifest.py
@@ -315,6 +315,63 @@ def test_decode_citation_not_mapping(tmp_path: Path) -> None:
         m.load(_write(tmp_path, text))
 
 
+# --- #173: a wrong-typed present key must never silently stringify ----------
+
+
+def test_decode_file_path_list_raises_naming_entry_and_field(tmp_path: Path) -> None:
+    """The old symptom (a list silently becoming the string "['a', 'b']") is gone.
+
+    An error is raised instead, naming the entry, the field, and the type.
+    """
+    text = f"datasets:\n  - id: x\n    files:\n      - path: [a, b]\n        sha256: {_HEX}\n"
+    with pytest.raises(
+        m.ManifestError,
+        match=r"entry 'x': files\[0\]: 'path' must be a string, got list",
+    ):
+        m.load(_write(tmp_path, text))
+
+
+def test_decode_file_sha256_mapping_raises_naming_entry_and_field(
+    tmp_path: Path,
+) -> None:
+    text = "datasets:\n  - id: x\n    files:\n      - path: p\n        sha256: {a: 1}\n"
+    with pytest.raises(m.ManifestError, match=r"'sha256' must be a string, got dict"):
+        m.load(_write(tmp_path, text))
+
+
+def test_decode_retrieval_kind_list_raises_naming_entry_and_field(
+    tmp_path: Path,
+) -> None:
+    text = "datasets:\n  - id: x\n    retrieval:\n      kind: [http]\n"
+    with pytest.raises(
+        m.ManifestError,
+        match=r"entry 'x': 'retrieval\.kind' must be a string, got list",
+    ):
+        m.load(_write(tmp_path, text))
+
+
+def test_decode_entry_id_list_raises_naming_the_field(tmp_path: Path) -> None:
+    text = "datasets:\n  - id: [a, b]\n"
+    with pytest.raises(
+        m.ManifestError, match=r"datasets\[0\]: 'id' must be a string, got list"
+    ):
+        m.load(_write(tmp_path, text))
+
+
+def test_decode_entry_id_mapping_raises_naming_the_field(tmp_path: Path) -> None:
+    text = "datasets:\n  - id: {a: 1}\n"
+    with pytest.raises(
+        m.ManifestError, match=r"datasets\[0\]: 'id' must be a string, got dict"
+    ):
+        m.load(_write(tmp_path, text))
+
+
+def test_decode_entry_id_accepts_a_bare_integer(tmp_path: Path) -> None:
+    text = f"datasets:\n  - id: 2024\n    files:\n      - path: p\n        sha256: {_HEX}\n"
+    manifest = m.load(_write(tmp_path, text))
+    assert manifest.datasets[0].id == "2024"
+
+
 def test_validate_conditional_and_shape_errors() -> None:
     entry = m.DatasetEntry(
         id="e",


### PR DESCRIPTION
## What

Fixes two silent-wrong-value boundaries found by the codebase audit (#172,
BE-4/BE-9) that fell outside #169's JSON-parsing-boundary work: an unescaped
title corrupting an OpenAlex filter query, and `str()` coercion in the
manifest decoder silently stringifying lists/mappings.

## Details

- **Site A** (`literature/acquire.py`, `sibling_candidates`): OpenAlex's
  `filter` grammar reserves `,` (AND) and `|` (OR). A registry title
  containing either (e.g. "Deep Learning, Revisited") silently spliced a
  second filter clause into the rung-4 sibling search instead of erroring —
  the entry then landed on the `manual[]` worklist as if the search
  genuinely found nothing. Fixed with a `_FILTER_RESERVED` regex that
  replaces both characters with a space before interpolation (chosen over
  URL-encoding: the characters are meaningful to OpenAlex's filter grammar,
  not to HTTP). `title.search` is full-text, so this narrows nothing that
  matters, and the three-way match gate still re-verifies the real record
  afterwards (ADR-0037).
  - Audited every other `filter:`-interpolation site in `acquire.py`
    (`grep -n filter`) — the sibling-search call is the only one that builds
    an OpenAlex `filter` expression from human-authored text; no other site
    needed the fix.
- **Site B** (`dataset/manifest.py`): `_decode_file_ref`, `_decode_retrieval`,
  and `_decode_entry` used `str(...)` on a *present* key of the wrong type.
  A `KeyError` on a missing key was handled, but `path: [a, b]` in YAML
  silently became the string `"['a', 'b']"`, failing confusingly and far
  away in `dataset/retrieval.py`'s `Path(ref.path)`. Added `_str_or_error`
  (mirroring `_int_or_error`'s style/messages) and used it for `path`,
  `sha256`, `retrieval.kind`, and `id`. It accepts a real `str` or a bare
  `int`/`float` (coercing — `id: 2024` is a realistic thing to write in
  YAML) but raises `ManifestError` naming the entry, field, and offending
  type for a `list`/`dict`.
- Deliberately unchanged: `literature/graph.py` (owned by #169, already
  merged) and `dataset/retrieval.py` (downstream consumer — the fix is at
  the decode boundary only).

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
